### PR TITLE
fix(#15): remove orphaned taffy nodes to plug layout memory leak

### DIFF
--- a/crates/phantom-app/Cargo.toml
+++ b/crates/phantom-app/Cargo.toml
@@ -52,6 +52,7 @@ phantom-profile = []
 [dev-dependencies]
 png = "0.17"
 tempfile = "3"
+phantom-ui = { path = "../phantom-ui", features = ["test-utils"] }
 
 [lints]
 workspace = true

--- a/crates/phantom-app/src/agent_pane.rs
+++ b/crates/phantom-app/src/agent_pane.rs
@@ -539,7 +539,6 @@ impl AgentPane {
             registry,
             event_log: self.event_log.clone(),
             pending_spawn,
-            source_event_id: None,
         })
     }
 

--- a/crates/phantom-app/src/agent_pane.rs
+++ b/crates/phantom-app/src/agent_pane.rs
@@ -539,6 +539,7 @@ impl AgentPane {
             registry,
             event_log: self.event_log.clone(),
             pending_spawn,
+            source_event_id: None,
         })
     }
 

--- a/crates/phantom-app/src/coordinator.rs
+++ b/crates/phantom-app/src/coordinator.rs
@@ -1499,7 +1499,11 @@ mod tests {
     ///          (chrome nodes only: root, tab_bar, content, status_bar = 4).
     /// Act:     register an adapter (creates 1 pane node) then immediately
     ///          remove it (must free that pane node) — repeat 1 000 times.
-    /// Assert:  after every removal the total node count equals the baseline.
+    /// Assert:  after every removal the total node count equals the baseline,
+    ///          measured via `total_node_count()` (full Taffy tree) rather
+    ///          than `pane_count()` (direct children of content only) so that
+    ///          orphaned grandchild nodes from nested-split scenarios are also
+    ///          caught.
     #[test]
     fn taffy_node_count_stable_across_spawn_close_cycles() {
         let mut coord = AppCoordinator::new_test(EventBus::new());
@@ -1508,6 +1512,8 @@ mod tests {
         let content = scene.add_node(scene.root(), NodeKind::ContentArea);
 
         // Baseline: chrome nodes only (root + tab_bar + content + status_bar).
+        // Using total_node_count() rather than pane_count() so that orphaned
+        // grandchild nodes from nested splits are captured in the assertion.
         let baseline = layout.total_node_count();
 
         for cycle in 0..1_000 {
@@ -1530,5 +1536,87 @@ mod tests {
                 "cycle {cycle}: Taffy node count leaked — expected {baseline}, got {after}",
             );
         }
+    }
+
+    /// Nested splits at the coordinator level must not leak grandchild nodes.
+    ///
+    /// Arrange:
+    ///   1. Register adapter A → layout pane P_A.
+    ///   2. Register adapter B → layout pane P_B.
+    ///   3. Split P_A horizontally to create two leaves (P_A_L, P_A_R).
+    ///      Remap adapter A to P_A_L; wire a third adapter C to P_A_R.
+    ///   4. Split P_A_L vertically → (P_A_T, P_A_B). Remap A to P_A_T,
+    ///      wire a fourth adapter D to P_A_B.
+    ///
+    /// Tree (content children): [P_A(container→[P_A_L(container→[P_A_T, P_A_B]), P_A_R]), P_B]
+    ///   Total leaves: A(P_A_T), D(P_A_B), C(P_A_R), B(P_B) = 4 adapters
+    ///
+    /// Act: remove all four adapters via `remove_adapter`.
+    ///
+    /// Assert: `total_node_count()` returns to the chrome-only baseline.
+    ///   `pane_count()` would return 0 (content has no direct children) but
+    ///   would miss the two orphaned container nodes P_A and P_A_L. Using
+    ///   `total_node_count()` catches those leaks.
+    #[test]
+    fn taffy_node_count_stable_after_nested_split_spawn_close() {
+        let mut coord = AppCoordinator::new_test(EventBus::new());
+        let mut layout = LayoutEngine::new().unwrap();
+        let mut scene = SceneTree::new();
+        let content_node = scene.add_node(scene.root(), NodeKind::ContentArea);
+
+        // Chrome-only baseline.
+        let chrome_baseline = layout.total_node_count();
+
+        // Register adapter A (gets pane P_A) and adapter B (gets pane P_B).
+        let id_a = register_mock(&mut coord, &mut layout, &mut scene, content_node, "A");
+        let id_b = register_mock(&mut coord, &mut layout, &mut scene, content_node, "B");
+
+        let p_a = coord.pane_id_for(id_a).unwrap();
+
+        // Split P_A horizontally: P_A becomes a container, P_A_L and P_A_R are leaves.
+        let (p_a_l, p_a_r) = layout.split_horizontal(p_a).unwrap();
+
+        // Remap adapter A from P_A (now a container) to P_A_L.
+        coord.remap_pane(id_a, p_a, p_a_l);
+
+        // Register adapter C at P_A_R directly (pane already exists in layout).
+        let scene_node_c = scene.add_node(content_node, NodeKind::Pane);
+        let id_c = coord.register_adapter_at_pane(
+            Box::new(MockAdapter::new("C")),
+            p_a_r,
+            scene_node_c,
+            Cadence::unlimited(),
+        );
+
+        // Split P_A_L vertically: P_A_L becomes a container, P_A_T and P_A_B are leaves.
+        let (p_a_t, p_a_b) = layout.split_vertical(p_a_l).unwrap();
+
+        // Remap adapter A from P_A_L to P_A_T.
+        coord.remap_pane(id_a, p_a_l, p_a_t);
+
+        // Register adapter D at P_A_B directly.
+        let scene_node_d = scene.add_node(content_node, NodeKind::Pane);
+        let id_d = coord.register_adapter_at_pane(
+            Box::new(MockAdapter::new("D")),
+            p_a_b,
+            scene_node_d,
+            Cadence::unlimited(),
+        );
+
+        layout.resize(800.0, 600.0).unwrap();
+
+        // Remove all four adapters. Each `remove_adapter` call invokes
+        // `layout.remove_pane` which must prune now-empty container ancestors.
+        coord.remove_adapter(id_a, &mut layout, &mut scene); // removes P_A_T
+        coord.remove_adapter(id_d, &mut layout, &mut scene); // removes P_A_B → P_A_L container pruned
+        coord.remove_adapter(id_c, &mut layout, &mut scene); // removes P_A_R → P_A container pruned
+        coord.remove_adapter(id_b, &mut layout, &mut scene); // removes P_B
+
+        let after = layout.total_node_count();
+        assert_eq!(
+            after,
+            chrome_baseline,
+            "nested-split coordinator scenario leaked nodes: expected {chrome_baseline}, got {after}",
+        );
     }
 }

--- a/crates/phantom-ui/Cargo.toml
+++ b/crates/phantom-ui/Cargo.toml
@@ -11,5 +11,10 @@ taffy.workspace = true
 log.workspace = true
 anyhow.workspace = true
 
+[features]
+## Exposes test-only helpers (e.g. `LayoutEngine::total_node_count`) for
+## integration tests in downstream crates.  Never enable in production builds.
+test-utils = []
+
 [lints]
 workspace = true

--- a/crates/phantom-ui/src/layout.rs
+++ b/crates/phantom-ui/src/layout.rs
@@ -187,7 +187,7 @@ impl LayoutEngine {
 
         // Prune empty non-chrome ancestors (split containers left behind
         // when both halves of a split have been closed).
-        self.prune_empty_containers(parent_before);
+        self.prune_empty_containers(parent_before)?;
 
         Ok(())
     }
@@ -245,6 +245,7 @@ impl LayoutEngine {
     /// This includes the fixed chrome nodes (root, tab bar, content area,
     /// status bar) as well as all live pane nodes. Use this to assert that
     /// spawn-close cycles do not permanently grow the tree.
+    #[cfg(any(test, feature = "test-utils"))]
     pub fn total_node_count(&self) -> usize {
         self.tree.total_node_count()
     }
@@ -318,7 +319,7 @@ impl LayoutEngine {
     ///
     /// Chrome nodes (root, tab_bar, content, status_bar) are never pruned —
     /// they must remain even when empty to preserve the chrome structure.
-    fn prune_empty_containers(&mut self, start: Option<NodeId>) {
+    fn prune_empty_containers(&mut self, start: Option<NodeId>) -> Result<()> {
         let chrome = [self.root, self.tab_bar, self.content, self.status_bar];
         let mut cursor = start;
         while let Some(node) = cursor {
@@ -332,12 +333,12 @@ impl LayoutEngine {
             }
             // Record the grandparent before removing so we can continue upward.
             let grandparent = self.tree.parent(node);
-            if let Err(e) = self.tree.remove(node) {
-                log::warn!("prune_empty_containers: failed to remove orphaned container: {e}");
-                break;
-            }
+            self.tree
+                .remove(node)
+                .map_err(|e| anyhow::anyhow!("prune_empty_containers: failed to remove orphaned container: {e}"))?;
             cursor = grandparent;
         }
+        Ok(())
     }
 
     /// Compute the absolute pixel rectangle for a node by walking up the
@@ -550,5 +551,65 @@ mod tests {
                 "cycle {cycle}: node count grew from {baseline} to {after}",
             );
         }
+    }
+
+    /// Nested splits (split a leaf that is itself a split child) must not leak
+    /// intermediate container nodes when all three leaves are closed.
+    ///
+    /// Arrange:
+    ///   1. `add_pane` → 1 leaf (A)
+    ///   2. `split_horizontal(A)` → container A promoted, leaves L and R
+    ///   3. `split_vertical(L)` → L promoted to container, leaves T and B
+    ///   Result: 3 leaves (T, B, R) and 2 container nodes (A, L)
+    ///
+    /// Act: close all three leaves (T, B, R).
+    ///
+    /// Assert: `total_node_count()` returns to the chrome-only baseline.
+    ///   `prune_empty_containers` must walk the full ancestor chain — after
+    ///   removing T the inner container (L) becomes empty and must be pruned,
+    ///   which then makes the outer container (A) empty so it too must be
+    ///   pruned. A single-level walk would miss the second prune step.
+    #[test]
+    fn taffy_node_count_stable_after_nested_split_then_close_all() {
+        let mut engine = LayoutEngine::new().unwrap();
+        engine.resize(WINDOW_W, WINDOW_H).unwrap();
+
+        // Baseline: chrome nodes only (root + tab_bar + content + status_bar = 4).
+        let chrome_baseline = engine.total_node_count();
+
+        // Step 1: single leaf A added to the content area.
+        let a = engine.add_pane().unwrap();
+
+        // Step 2: split A horizontally → A becomes a row container, L and R are leaves.
+        let (l, r) = engine.split_horizontal(a).unwrap();
+
+        // Step 3: split L vertically → L becomes a column container, T and B are leaves.
+        // Tree is now: content → [A(container) → [L(container) → [T, B], R]]
+        let (t, b) = engine.split_vertical(l).unwrap();
+
+        engine.resize(WINDOW_W, WINDOW_H).unwrap();
+
+        // All three leaves must have positive area.
+        assert!(engine.get_pane_rect(t).unwrap().height > 0.0, "T must have positive height");
+        assert!(engine.get_pane_rect(b).unwrap().height > 0.0, "B must have positive height");
+        assert!(engine.get_pane_rect(r).unwrap().width > 0.0, "R must have positive width");
+
+        // Close T: L still has B, nothing pruned yet.
+        engine.remove_pane(t).unwrap();
+
+        // Close B: L is now empty → L is pruned; A still has R, not pruned.
+        engine.remove_pane(b).unwrap();
+
+        // Close R: A is now empty → A is pruned; content is a chrome node, stop.
+        engine.remove_pane(r).unwrap();
+
+        engine.resize(WINDOW_W, WINDOW_H).unwrap();
+
+        let after = engine.total_node_count();
+        assert_eq!(
+            after,
+            chrome_baseline,
+            "nested split leaked container nodes: expected {chrome_baseline} nodes, got {after}",
+        );
     }
 }

--- a/crates/phantom-ui/src/layout.rs
+++ b/crates/phantom-ui/src/layout.rs
@@ -167,10 +167,28 @@ impl LayoutEngine {
 
     /// Remove a terminal pane from the layout tree.
     ///
-    /// If the pane is a split container (i.e. it has children from a prior split),
-    /// the entire sub-tree is removed.
+    /// If the pane is a split container (i.e. it has children from a prior
+    /// split), the entire sub-tree is removed.
+    ///
+    /// After removing the target node this method also prunes any ancestor
+    /// split-container nodes that are now empty. A split container is created
+    /// by [`split_horizontal`](Self::split_horizontal) or
+    /// [`split_vertical`](Self::split_vertical): the original pane node is
+    /// promoted to a flex container and two child leaves are added. If both
+    /// children are subsequently removed the container itself becomes an
+    /// orphaned node that would otherwise remain in the Taffy tree forever.
+    /// This pruning step prevents that leak.
     pub fn remove_pane(&mut self, id: PaneId) -> Result<()> {
+        // Record the parent *before* removing the subtree so we can walk
+        // upward afterward and prune any now-empty container ancestors.
+        let parent_before = self.tree.parent(id.0);
+
         self.remove_subtree(id.0)?;
+
+        // Prune empty non-chrome ancestors (split containers left behind
+        // when both halves of a split have been closed).
+        self.prune_empty_containers(parent_before);
+
         Ok(())
     }
 
@@ -220,6 +238,15 @@ impl LayoutEngine {
     /// Return the number of direct children of the content area.
     pub fn pane_count(&self) -> usize {
         self.tree.child_count(self.content)
+    }
+
+    /// Return the total number of nodes in the underlying Taffy tree.
+    ///
+    /// This includes the fixed chrome nodes (root, tab bar, content area,
+    /// status bar) as well as all live pane nodes. Use this to assert that
+    /// spawn-close cycles do not permanently grow the tree.
+    pub fn total_node_count(&self) -> usize {
+        self.tree.total_node_count()
     }
 
     /// Return the root `NodeId` (useful for debugging / printing).
@@ -278,6 +305,39 @@ impl LayoutEngine {
         }
         self.tree.remove(node).map_err(|e| anyhow::anyhow!("failed to remove node: {e}"))?;
         Ok(())
+    }
+
+    /// Walk up the ancestor chain from `start` and remove any non-chrome
+    /// containers that have become empty after a child was removed.
+    ///
+    /// A split operation promotes an existing pane node to a flex container
+    /// and adds two leaf children. If both children are later removed the
+    /// container node would otherwise be orphaned in the Taffy tree. This
+    /// method prunes those empty containers bottom-up so the tree stays
+    /// compact across many split-close cycles.
+    ///
+    /// Chrome nodes (root, tab_bar, content, status_bar) are never pruned —
+    /// they must remain even when empty to preserve the chrome structure.
+    fn prune_empty_containers(&mut self, start: Option<NodeId>) {
+        let chrome = [self.root, self.tab_bar, self.content, self.status_bar];
+        let mut cursor = start;
+        while let Some(node) = cursor {
+            // Never prune fixed chrome nodes.
+            if chrome.contains(&node) {
+                break;
+            }
+            // Only prune if the node is now truly empty.
+            if self.tree.child_count(node) > 0 {
+                break;
+            }
+            // Record the grandparent before removing so we can continue upward.
+            let grandparent = self.tree.parent(node);
+            if let Err(e) = self.tree.remove(node) {
+                log::warn!("prune_empty_containers: failed to remove orphaned container: {e}");
+                break;
+            }
+            cursor = grandparent;
+        }
     }
 
     /// Compute the absolute pixel rectangle for a node by walking up the
@@ -417,5 +477,78 @@ mod tests {
 
         assert!(r2.width > r1.width, "pane should be wider after resize");
         assert!(r2.height > r1.height, "pane should be taller after resize");
+    }
+
+    // ── Layout memory-leak regression (Issue #15) ──────────────────────────
+    //
+    // When `split_horizontal/vertical` promotes a pane node to a flex
+    // container and adds two child leaves, removing both children must also
+    // remove the now-empty container node. Otherwise every split+close cycle
+    // permanently grows the Taffy tree by one orphaned container node.
+
+    /// Splitting a pane and then closing both halves must leave the node
+    /// count at the chrome-only baseline (no orphaned container node).
+    ///
+    /// Arrange: record the chrome-only baseline, add a pane, split it.
+    /// Act:     remove both split children (left then right).
+    /// Assert:  total node count returns to the chrome-only baseline
+    ///          (the original pane node is the split container and must
+    ///           also be pruned when it becomes empty, so we end up with
+    ///           just the 4 chrome nodes again).
+    #[test]
+    fn taffy_node_count_stable_after_split_then_close_both_halves() {
+        let mut engine = LayoutEngine::new().unwrap();
+        engine.resize(WINDOW_W, WINDOW_H).unwrap();
+
+        // Baseline: chrome nodes only (root + tab_bar + content + status_bar = 4).
+        let chrome_baseline = engine.total_node_count();
+
+        let pane = engine.add_pane().unwrap();
+        engine.resize(WINDOW_W, WINDOW_H).unwrap();
+
+        // Split promotes `pane` to a container and creates 2 leaf children.
+        let (left, right) = engine.split_horizontal(pane).unwrap();
+        engine.resize(WINDOW_W, WINDOW_H).unwrap();
+
+        // Close the right half — the container still has one child.
+        engine.remove_pane(right).unwrap();
+
+        // Close the left half — container is now empty and the pruner must
+        // also remove it, returning us to the chrome-only baseline.
+        engine.remove_pane(left).unwrap();
+        engine.resize(WINDOW_W, WINDOW_H).unwrap();
+
+        let after = engine.total_node_count();
+        assert_eq!(
+            after,
+            chrome_baseline,
+            "orphaned split container leaked: expected {chrome_baseline} nodes, got {after}",
+        );
+    }
+
+    /// 1 000 split-then-close cycles must not grow the Taffy tree.
+    #[test]
+    fn taffy_node_count_stable_across_1000_split_close_cycles() {
+        let mut engine = LayoutEngine::new().unwrap();
+        let _pane = engine.add_pane().unwrap();
+        engine.resize(WINDOW_W, WINDOW_H).unwrap();
+
+        // Baseline: chrome (4) + 1 pane = 5.
+        let baseline = engine.total_node_count();
+
+        for cycle in 0..1_000 {
+            // Each add_pane + split + close-both-halves must be net-zero.
+            let p = engine.add_pane().unwrap();
+            let (l, r) = engine.split_horizontal(p).unwrap();
+            engine.remove_pane(r).unwrap();
+            engine.remove_pane(l).unwrap();
+
+            let after = engine.total_node_count();
+            assert_eq!(
+                after,
+                baseline,
+                "cycle {cycle}: node count grew from {baseline} to {after}",
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **Root cause**: `split_horizontal`/`split_vertical` promotes a pane node to a flex container and adds two leaf children. When both leaves were subsequently removed via `remove_pane`, the now-empty container node was never freed — leaking one Taffy node per split+close cycle.
- **Fix**: `remove_pane` now captures the parent before `remove_subtree`, then calls the new `prune_empty_containers` helper which walks up the ancestor chain and removes any non-chrome containers that have become empty. Chrome nodes (`root`, `tab_bar`, `content`, `status_bar`) are explicitly guarded.
- **Bonus fix**: added missing `source_event_id: None` in `agent_pane::build_dispatch_context` that prevented `phantom-app` from compiling against the updated `dispatch::DispatchContext` struct.

## Regression tests (TDD — written before the fix)

| Test | Crate | What it proves |
|------|-------|----------------|
| `layout::taffy_node_count_stable_after_split_then_close_both_halves` | `phantom-ui` | Single split+close cycle returns to chrome-only baseline |
| `layout::taffy_node_count_stable_across_1000_split_close_cycles` | `phantom-ui` | 1000 cycles stay flat (was: +1 node/cycle leak) |
| `coordinator::taffy_node_count_stable_across_spawn_close_cycles` | `phantom-app` | 1000 register/remove cycles don't grow the tree |

All 260 unit tests + 21 integration tests pass after the fix.

## Test plan

- [x] `cargo test -p phantom-ui` — 74 tests, all pass
- [x] `cargo test -p phantom-app` — 260 unit tests + 21 integration tests, all pass
- [x] Manual verify: `layout::total_node_count` returns to baseline after split+close

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)