### PR TITLE
feat(#22): MessageBlock widget

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,38 +55,54 @@ tokio = { version = "1", features = ["full"] }
 
 ## Architecture Overview
 
-Phantom is structured as a Rust workspace with 18 specialized crates:
+Phantom is structured as a Rust workspace with **23 active crates** (4 additional crates exist on disk and compile independently but are not yet wired into the workspace — see "Future / not yet in workspace" below).
+
+Legend: ✅ complete/active · 🔧 skeletal/stubbed · 🚧 Phase 2+ (open issues noted)
 
 ### Core System
-- **phantom**: Main binary and application orchestrator
-- **phantom-supervisor**: Erlang/OTP-inspired process monitor with heartbeat
-- **phantom-app**: Application lifecycle and coordination
+- **phantom** ✅ — Main binary: winit event loop, GPU init, panic recovery, supervisor socket handshake
+- **phantom-supervisor** ✅ — Erlang/OTP-style process monitor: heartbeat watch, auto-restart with back-off ([#53](https://github.com/jdmiranda/phantom/issues/53))
+- **phantom-app** ✅ — Application lifecycle: pane management, boot sequence, agent coordination, inspector UI ([#97](https://github.com/jdmiranda/phantom/issues/97), [#44](https://github.com/jdmiranda/phantom/issues/44))
+- **phantom-protocol** ✅ — Unix-socket IPC wire protocol between supervisor and app (heartbeat, events, commands)
 
 ### Rendering Stack
-- **phantom-renderer**: GPU pipeline (wgpu), text atlas, CRT shaders
-- **phantom-ui**: Themes, layout (taffy), widgets, keybinds
-- **phantom-scene**: Retained scene graph with dirty tracking
+- **phantom-renderer** ✅ — wgpu GPU pipeline: text atlas, quad batcher, CRT post-fx, screenshot, video ([#82](https://github.com/jdmiranda/phantom/issues/82), [#83](https://github.com/jdmiranda/phantom/issues/83), [#84](https://github.com/jdmiranda/phantom/issues/84))
+- **phantom-ui** ✅ — Design tokens, themes, Taffy layout, widget primitives, keybinds ([#20](https://github.com/jdmiranda/phantom/issues/20)–[#27](https://github.com/jdmiranda/phantom/issues/27), [#29](https://github.com/jdmiranda/phantom/issues/29)–[#31](https://github.com/jdmiranda/phantom/issues/31))
+- **phantom-scene** ✅ — Retained scene graph with dirty-bit tracking, clock/cadence, frame delta clamp
 
 ### Terminal Emulation
-- **phantom-terminal**: PTY management, alacritty_terminal wrapper
-- **phantom-semantic**: Command output parsing and understanding
+- **phantom-terminal** ✅ — PTY process management, alacritty_terminal VT100 wrapper, input/output routing, Kitty protocol
+- **phantom-semantic** 🔧 — Command classification and output parsing (git, cargo, etc.); stub integration pending ([#74](https://github.com/jdmiranda/phantom/issues/74), [#94](https://github.com/jdmiranda/phantom/issues/94))
 
 ### AI & Intelligence
-- **phantom-agents**: AI agent runtime, tools, Claude API integration
-- **phantom-brain**: Ambient OODA loop, utility AI scoring
-- **phantom-nlp**: Natural language command interpretation
-- **phantom-context**: Project/git/environment awareness
-- **phantom-memory**: Persistent per-project knowledge storage
+- **phantom-agents** ✅ — Agent lifecycle, tool execution, Claude API chat, role system (Defender/Inspector), permission model, taint levels ([#60](https://github.com/jdmiranda/phantom/issues/60), [#87](https://github.com/jdmiranda/phantom/issues/87), [#93](https://github.com/jdmiranda/phantom/issues/93)–[#96](https://github.com/jdmiranda/phantom/issues/96), [#103](https://github.com/jdmiranda/phantom/issues/103)–[#105](https://github.com/jdmiranda/phantom/issues/105))
+- **phantom-brain** ✅ — Ambient OODA loop on a dedicated thread: event scoring, utility AI, action dispatch, autonomous reconciler ([#32](https://github.com/jdmiranda/phantom/issues/32), [#36](https://github.com/jdmiranda/phantom/issues/36)–[#40](https://github.com/jdmiranda/phantom/issues/40), [#45](https://github.com/jdmiranda/phantom/issues/45)–[#47](https://github.com/jdmiranda/phantom/issues/47), [#61](https://github.com/jdmiranda/phantom/issues/61), [#98](https://github.com/jdmiranda/phantom/issues/98)–[#99](https://github.com/jdmiranda/phantom/issues/99))
+- **phantom-nlp** 🔧 — Natural-language command interpreter; LLM call routing is a stub ([#55](https://github.com/jdmiranda/phantom/issues/55))
+- **phantom-context** ✅ — Project/git/environment detection and context assembly for agent prompts
+- **phantom-memory** 🔧 — Per-project knowledge store with event log and memory blocks; schema and event log pending ([#28](https://github.com/jdmiranda/phantom/issues/28), [#33](https://github.com/jdmiranda/phantom/issues/33), [#62](https://github.com/jdmiranda/phantom/issues/62), [#78](https://github.com/jdmiranda/phantom/issues/78))
 
 ### Persistence & History
-- **phantom-history**: Structured command history (JSONL)
-- **phantom-session**: Session save/restore
+- **phantom-history** 🔧 — Structured JSONL command history store; read/write and agent output capture pending ([#75](https://github.com/jdmiranda/phantom/issues/75))
+- **phantom-session** 🔧 — Session save/restore; agent and goal/task state restore pending ([#76](https://github.com/jdmiranda/phantom/issues/76), [#77](https://github.com/jdmiranda/phantom/issues/77))
 
 ### Extensibility
-- **phantom-plugins**: WASM plugin host and marketplace
-- **phantom-mcp**: Model Context Protocol server/client
-- **phantom-protocol**: Supervisor IPC communication
-- **phantom-adapter**: WASM app adapter framework
+- **phantom-plugins** 🔧 — Plugin lifecycle (manifest, host, registry, marketplace); WASM host is a mock, real wasmtime pending ([#48](https://github.com/jdmiranda/phantom/issues/48))
+- **phantom-mcp** 🔧 — Model Context Protocol server (exposes Phantom to external AI) and client (consumes external tools); client impl and registry pending ([#52](https://github.com/jdmiranda/phantom/issues/52), [#54](https://github.com/jdmiranda/phantom/issues/54))
+- **phantom-adapter** ✅ — `AppAdapter` trait, app registry, pub/sub event bus, spatial layout negotiation; the "everything is an app" abstraction layer ([#17](https://github.com/jdmiranda/phantom/issues/17))
+
+### Capture Pipeline (Phase 2.G)
+- **phantom-vision** 🔧 — Perceptual-hash dedup (dHash + SAD gate) for frame deduplication; GPT-4V analysis pipeline pending ([#70](https://github.com/jdmiranda/phantom/issues/70), [#71](https://github.com/jdmiranda/phantom/issues/71), [#79](https://github.com/jdmiranda/phantom/issues/79))
+- **phantom-bundles** 🔧 — Schema-only types for capture bundles (frames, audio, transcript); serialization and capture pipeline integration pending ([#80](https://github.com/jdmiranda/phantom/issues/80), [#81](https://github.com/jdmiranda/phantom/issues/81), [#91](https://github.com/jdmiranda/phantom/issues/91))
+- **phantom-bundle-store** 🔧 — Unified persistence: SQLite/FTS5 metadata + LanceDB vectors + XChaCha20 encrypted blobs; recovery path tests pending ([#10](https://github.com/jdmiranda/phantom/issues/10), [#88](https://github.com/jdmiranda/phantom/issues/88))
+- **phantom-embeddings** 🔧 — Multi-modal embedding trait + OpenAI backend + mock; persistent storage and vector query pending ([#72](https://github.com/jdmiranda/phantom/issues/72), [#73](https://github.com/jdmiranda/phantom/issues/73))
+
+### Future / Not yet in workspace
+These crates have `Cargo.toml` and compile independently but are not yet members of the workspace `Cargo.toml`:
+
+- **phantom-audio** 🔧 — Audio capture backend abstraction (CoreAudio/ScreenCaptureKit traits + mock); real backends pending ([#9](https://github.com/jdmiranda/phantom/issues/9))
+- **phantom-recall** 🔧 — Intent-anchored retrieval API: query rewriting, score fusion, ANN routing; backend wiring pending ([#72](https://github.com/jdmiranda/phantom/issues/72))
+- **phantom-stt** 🔧 — Speech-to-text backend abstraction (Whisper/Deepgram traits + mock); streaming Whisper and OpenAI integration pending ([#56](https://github.com/jdmiranda/phantom/issues/56), [#68](https://github.com/jdmiranda/phantom/issues/68))
+- **phantom-voice** 🔧 — Text-to-speech backend abstraction (ElevenLabs/Piper/system TTS traits + mock); real TTS pending ([#69](https://github.com/jdmiranda/phantom/issues/69))
 
 ## Key Architectural Decisions
 

--- a/crates/phantom-ui/src/widgets/divider.rs
+++ b/crates/phantom-ui/src/widgets/divider.rs
@@ -1,0 +1,333 @@
+//! Sec.26 — Thin separator line widget (horizontal and vertical).
+//!
+//! A [`Divider`] draws a single hairline quad between two adjacent UI regions.
+//! Its color is sourced from [`crate::tokens::Tokens`]: `chrome_divider` maps
+//! to the phosphor-green grid line color — no raw RGBA constants live here.
+//!
+//! # Examples
+//!
+//! ```
+//! use phantom_ui::widgets::divider::{Divider, Orientation};
+//! use phantom_ui::layout::Rect;
+//! use phantom_ui::widgets::Widget;
+//!
+//! let sep = Divider::horizontal();
+//! let rect = Rect { x: 0.0, y: 100.0, width: 1920.0, height: 1.0 };
+//! // One background quad in chrome_divider color.
+//! assert_eq!(sep.render_quads(&rect).len(), 1);
+//! assert!(sep.render_text(&rect).is_empty());
+//! ```
+
+use crate::layout::Rect;
+use crate::render_ctx::RenderCtx;
+use crate::tokens::Tokens;
+use crate::widgets::{TextSegment, Widget};
+use phantom_renderer::quads::QuadInstance;
+
+// -----------------------------------------------------------------------
+// Orientation
+// -----------------------------------------------------------------------
+
+/// Axis along which the divider line runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Orientation {
+    /// A full-width horizontal line; height equals `thickness`.
+    Horizontal,
+    /// A full-height vertical line; width equals `thickness`.
+    Vertical,
+}
+
+// -----------------------------------------------------------------------
+// Divider
+// -----------------------------------------------------------------------
+
+/// A hairline separator widget — horizontal or vertical.
+///
+/// The widget fills its entire [`Rect`] with a single `chrome_divider`-colored
+/// quad. The caller is responsible for passing a rect whose minor dimension
+/// (height for horizontal, width for vertical) equals the desired visual
+/// thickness — the widget does not enforce this to stay flexible for DPI
+/// scaling and fractional pixel budgets.
+///
+/// Colors are sourced from [`Tokens::phosphor`], so theme changes propagate
+/// without touching widget code.
+#[derive(Debug, Clone)]
+pub struct Divider {
+    /// Axis along which the line is drawn.
+    pub orientation: Orientation,
+    /// Thickness of the line in pixels.
+    ///
+    /// For a [`Orientation::Horizontal`] divider this is the height;
+    /// for [`Orientation::Vertical`] it is the width.
+    pub thickness: f32,
+    /// Render context for token resolution (spacing, DPI metrics).
+    ctx: RenderCtx,
+}
+
+impl Divider {
+    /// Create a 1 px horizontal divider using the fallback render context.
+    pub fn horizontal() -> Self {
+        Self::new(Orientation::Horizontal, RenderCtx::fallback())
+    }
+
+    /// Create a 1 px vertical divider using the fallback render context.
+    pub fn vertical() -> Self {
+        Self::new(Orientation::Vertical, RenderCtx::fallback())
+    }
+
+    /// Create a divider with an explicit orientation and render context.
+    ///
+    /// `thickness` defaults to `tokens.hair()` (1 px). Call
+    /// [`Self::with_thickness`] to override after construction.
+    pub fn new(orientation: Orientation, ctx: RenderCtx) -> Self {
+        let thickness = Tokens::phosphor(ctx).hair();
+        Self { orientation, thickness, ctx }
+    }
+
+    /// Override the divider thickness in pixels.
+    #[must_use]
+    pub fn with_thickness(mut self, thickness: f32) -> Self {
+        self.thickness = thickness;
+        self
+    }
+
+    /// Update the live render context.
+    pub fn set_render_ctx(&mut self, ctx: RenderCtx) {
+        self.ctx = ctx;
+    }
+
+    /// The preferred minor-axis size (height for horizontal, width for
+    /// vertical) that the caller should reserve in the layout budget.
+    pub fn preferred_size(&self) -> f32 {
+        self.thickness
+    }
+
+    /// Resolve the divider color from the token table.
+    fn divider_color(&self) -> [f32; 4] {
+        Tokens::phosphor(self.ctx).colors.chrome_divider
+    }
+}
+
+impl Default for Divider {
+    fn default() -> Self {
+        Self::horizontal()
+    }
+}
+
+impl Widget for Divider {
+    /// Emit a single quad that fills the provided rect.
+    ///
+    /// The rect's minor dimension (height for horizontal, width for vertical)
+    /// should match [`Self::thickness`] — the widget renders whatever space it
+    /// is given.
+    fn render_quads(&self, rect: &Rect) -> Vec<QuadInstance> {
+        vec![QuadInstance {
+            pos: [rect.x, rect.y],
+            size: [rect.width, rect.height],
+            color: self.divider_color(),
+            border_radius: 0.0,
+        }]
+    }
+
+    /// Dividers carry no text; always returns an empty [`Vec`].
+    fn render_text(&self, _rect: &Rect) -> Vec<TextSegment> {
+        Vec::new()
+    }
+}
+
+// -----------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::render_ctx::RenderCtx;
+    use crate::tokens::Tokens;
+
+    fn h_rect() -> Rect {
+        Rect { x: 0.0, y: 100.0, width: 1920.0, height: 1.0 }
+    }
+
+    fn v_rect() -> Rect {
+        Rect { x: 400.0, y: 0.0, width: 1.0, height: 600.0 }
+    }
+
+    // ── Construction ────────────────────────────────────────────────────────
+
+    #[test]
+    fn horizontal_constructor_sets_orientation_and_hair_thickness() {
+        let d = Divider::horizontal();
+        assert_eq!(d.orientation, Orientation::Horizontal);
+        // hair() == 1.0 per Tokens spec.
+        let expected_thickness = Tokens::phosphor(RenderCtx::fallback()).hair();
+        assert_eq!(d.thickness, expected_thickness);
+    }
+
+    #[test]
+    fn vertical_constructor_sets_orientation_and_hair_thickness() {
+        let d = Divider::vertical();
+        assert_eq!(d.orientation, Orientation::Vertical);
+        let expected_thickness = Tokens::phosphor(RenderCtx::fallback()).hair();
+        assert_eq!(d.thickness, expected_thickness);
+    }
+
+    #[test]
+    fn with_thickness_overrides_default() {
+        let d = Divider::horizontal().with_thickness(2.0);
+        assert_eq!(d.thickness, 2.0);
+    }
+
+    #[test]
+    fn preferred_size_matches_thickness() {
+        let d = Divider::vertical().with_thickness(3.0);
+        assert_eq!(d.preferred_size(), 3.0);
+    }
+
+    #[test]
+    fn default_is_horizontal() {
+        let d = Divider::default();
+        assert_eq!(d.orientation, Orientation::Horizontal);
+    }
+
+    // ── Rendering — quad count and structure ─────────────────────────────────
+
+    #[test]
+    fn horizontal_renders_exactly_one_quad() {
+        let d = Divider::horizontal();
+        let quads = d.render_quads(&h_rect());
+        assert_eq!(quads.len(), 1, "horizontal divider must emit exactly one quad");
+    }
+
+    #[test]
+    fn vertical_renders_exactly_one_quad() {
+        let d = Divider::vertical();
+        let quads = d.render_quads(&v_rect());
+        assert_eq!(quads.len(), 1, "vertical divider must emit exactly one quad");
+    }
+
+    #[test]
+    fn horizontal_quad_fills_full_rect() {
+        let d = Divider::horizontal();
+        let rect = h_rect();
+        let quads = d.render_quads(&rect);
+        let q = &quads[0];
+        assert_eq!(q.pos[0], rect.x);
+        assert_eq!(q.pos[1], rect.y);
+        assert_eq!(q.size[0], rect.width);
+        assert_eq!(q.size[1], rect.height);
+    }
+
+    #[test]
+    fn vertical_quad_fills_full_rect() {
+        let d = Divider::vertical();
+        let rect = v_rect();
+        let quads = d.render_quads(&rect);
+        let q = &quads[0];
+        assert_eq!(q.pos[0], rect.x);
+        assert_eq!(q.pos[1], rect.y);
+        assert_eq!(q.size[0], rect.width);
+        assert_eq!(q.size[1], rect.height);
+    }
+
+    // ── Token color compliance ────────────────────────────────────────────────
+
+    #[test]
+    fn horizontal_color_matches_chrome_divider_token() {
+        let ctx = RenderCtx::fallback();
+        let tokens = Tokens::phosphor(ctx);
+        let d = Divider::horizontal();
+        let quads = d.render_quads(&h_rect());
+        assert_eq!(
+            quads[0].color,
+            tokens.colors.chrome_divider,
+            "divider color must come from tokens.colors.chrome_divider — no hardcoded RGBA",
+        );
+    }
+
+    #[test]
+    fn vertical_color_matches_chrome_divider_token() {
+        let ctx = RenderCtx::fallback();
+        let tokens = Tokens::phosphor(ctx);
+        let d = Divider::vertical();
+        let quads = d.render_quads(&v_rect());
+        assert_eq!(
+            quads[0].color,
+            tokens.colors.chrome_divider,
+            "divider color must come from tokens.colors.chrome_divider — no hardcoded RGBA",
+        );
+    }
+
+    #[test]
+    fn no_hardcoded_colors_in_quads() {
+        // The quad's color must equal the live token value, not a constant.
+        // If someone ever hard-codes [0.18, 0.38, 0.24, 0.60] this test would
+        // still pass, but changing the token would break it — that's the point.
+        let ctx = RenderCtx::fallback();
+        let expected = Tokens::phosphor(ctx).colors.chrome_divider;
+        for orientation in [Orientation::Horizontal, Orientation::Vertical] {
+            let d = Divider::new(orientation, ctx);
+            let rect = match orientation {
+                Orientation::Horizontal => h_rect(),
+                Orientation::Vertical => v_rect(),
+            };
+            let quads = d.render_quads(&rect);
+            assert_eq!(quads[0].color, expected, "color must equal live token for {orientation:?}");
+        }
+    }
+
+    // ── Text is always empty ──────────────────────────────────────────────────
+
+    #[test]
+    fn horizontal_emits_no_text() {
+        let d = Divider::horizontal();
+        assert!(d.render_text(&h_rect()).is_empty(), "dividers carry no text");
+    }
+
+    #[test]
+    fn vertical_emits_no_text() {
+        let d = Divider::vertical();
+        assert!(d.render_text(&v_rect()).is_empty(), "dividers carry no text");
+    }
+
+    // ── Widget trait object safety ─────────────────────────────────────────────
+
+    #[test]
+    fn divider_is_object_safe() {
+        let d = Divider::horizontal();
+        let widget: &dyn Widget = &d;
+        assert_eq!(widget.render_quads(&h_rect()).len(), 1);
+        assert!(widget.render_text(&h_rect()).is_empty());
+    }
+
+    // ── Sizing semantics ──────────────────────────────────────────────────────
+
+    #[test]
+    fn horizontal_preferred_size_is_height_of_divider() {
+        // For a horizontal divider, preferred_size() should match thickness
+        // (the height dimension), not the width.
+        let d = Divider::horizontal();
+        assert_eq!(d.preferred_size(), d.thickness);
+    }
+
+    #[test]
+    fn vertical_preferred_size_is_width_of_divider() {
+        // For a vertical divider, preferred_size() should match thickness
+        // (the width dimension).
+        let d = Divider::vertical();
+        assert_eq!(d.preferred_size(), d.thickness);
+    }
+
+    #[test]
+    fn render_ctx_update_propagates_to_token_color() {
+        // After updating the ctx the divider_color should still resolve from
+        // Tokens::phosphor using the new context. We verify no panic and that
+        // the color remains the token value.
+        let mut d = Divider::horizontal();
+        let new_ctx = RenderCtx::new((10.0, 20.0), 2.0);
+        d.set_render_ctx(new_ctx);
+        let expected = Tokens::phosphor(new_ctx).colors.chrome_divider;
+        let quads = d.render_quads(&h_rect());
+        assert_eq!(quads[0].color, expected);
+    }
+}

--- a/crates/phantom-ui/src/widgets/message_block.rs
+++ b/crates/phantom-ui/src/widgets/message_block.rs
@@ -31,9 +31,9 @@ use phantom_renderer::quads::QuadInstance;
 // -----------------------------------------------------------------------
 
 /// Width of the avatar glyph column in pixels.
-pub const AVATAR_W: f32 = 16.0;
+pub(crate) const AVATAR_W: f32 = 16.0;
 /// Horizontal gap between the avatar column and the body text column.
-pub const AVATAR_GAP: f32 = 8.0;
+pub(crate) const AVATAR_GAP: f32 = 8.0;
 
 // -----------------------------------------------------------------------
 // MessageRole
@@ -131,7 +131,8 @@ pub struct MessageBlock {
     pub body: String,
     /// Wall-clock timestamp (milliseconds since epoch). Currently unused
     /// in rendering but stored for future timestamp overlays.
-    pub timestamp_ms: u64,
+    #[allow(dead_code)]
+    pub(crate) timestamp_ms: u64,
     /// Render context for cell metrics. Defaults to `RenderCtx::fallback()`.
     ctx: RenderCtx,
 }
@@ -191,10 +192,14 @@ impl MessageBlock {
                 break;
             }
             // Find the last space within `cols` chars to word-wrap cleanly.
-            let slice: String = chars[..cols].iter().collect();
-            let break_at = slice
-                .rfind(' ')
-                .filter(|&p| p > 0)
+            // Use char-index arithmetic throughout — `rfind` on a `&str`
+            // returns a *byte* offset, which is wrong for multibyte text.
+            let break_at = chars[..cols]
+                .iter()
+                .enumerate()
+                .rfind(|&(_, c)| *c == ' ')
+                .map(|(i, _)| i)
+                .filter(|&i| i > 0)
                 .unwrap_or(cols); // hard-break if no space found
 
             lines.push(chars[..break_at].iter().collect());
@@ -657,5 +662,66 @@ mod tests {
         ] {
             assert!(!role.label().is_empty(), "label for {role:?} must not be empty");
         }
+    }
+
+    // ----------------------------------------------------------------
+    // Multibyte / Unicode regression tests
+    // ----------------------------------------------------------------
+
+    /// Wrapping a body that contains multibyte characters (emoji, accented
+    /// letters, CJK) must not panic and must produce correct line boundaries.
+    ///
+    /// With cell_w=8, rect=800 → body col = (800 - 16 - 8) / 8 = 97 cols.
+    /// Each emoji is one *char* but 4 UTF-8 bytes.  Using a byte offset from
+    /// `rfind` as a char index would either panic (out-of-bounds) or slice at
+    /// a non-char boundary — this test catches both failure modes.
+    #[test]
+    fn wrap_is_correct_for_multibyte_body() {
+        // 50 emoji chars + space + 50 more emoji → 101 chars total.
+        // The space is at char index 50, well inside the 97-col limit,
+        // so the wrap should break there and NOT at a mid-emoji byte offset.
+        let left: String = "🦀".repeat(50); // 50 chars, 200 bytes
+        let right: String = "🦀".repeat(50); // 50 chars, 200 bytes
+        let body = format!("{left} {right}"); // 101 chars, 401 bytes
+
+        let mut block = MessageBlock::new(MessageRole::Agent, body.clone(), 0);
+        block.set_render_ctx(fallback_ctx());
+
+        // Must not panic:
+        let lines = block.wrapped_lines(800.0);
+
+        // The space lives at char index 50 (≤ 97), so we expect a soft wrap
+        // there, giving us exactly 2 lines.
+        assert_eq!(lines.len(), 2, "emoji body should wrap into 2 lines: {lines:?}");
+
+        // First line must be exactly the 50 crab emoji.
+        assert_eq!(lines[0], left, "first line should be the 50-emoji prefix");
+
+        // Second line must be the remaining 50 emoji (space consumed by wrap).
+        assert_eq!(lines[1], right, "second line should be the 50-emoji suffix");
+
+        // Sanity-check that the output round-trips back to the original body
+        // (minus the joining space which is consumed).
+        let reconstructed = lines.join(" ");
+        assert_eq!(reconstructed, body, "reconstructed body must match original");
+    }
+
+    /// Accented / Latin-extended characters (2-byte UTF-8) wrap correctly.
+    #[test]
+    fn wrap_is_correct_for_accented_chars() {
+        // 'é' is U+00E9, 2 bytes in UTF-8 but 1 char.
+        // 48 × 'é' + space + 48 × 'é' = 97 chars exactly at the break point.
+        let left: String = "é".repeat(48);
+        let right: String = "é".repeat(48);
+        let body = format!("{left} {right}extra"); // space at index 48 → within 97 cols
+
+        let mut block = MessageBlock::new(MessageRole::User, body, 0);
+        block.set_render_ctx(fallback_ctx());
+
+        // Must not panic:
+        let lines = block.wrapped_lines(800.0);
+
+        assert!(lines.len() >= 2, "accented body should wrap: {lines:?}");
+        assert_eq!(lines[0], left, "first line should be 48 accented chars");
     }
 }

--- a/crates/phantom-ui/src/widgets/message_block.rs
+++ b/crates/phantom-ui/src/widgets/message_block.rs
@@ -1,0 +1,661 @@
+//! Issue #22 — Chat-style `MessageBlock` widget for agent panes.
+//!
+//! Each block renders one message turn: a 16×16 role-glyph (initial letter)
+//! on the left, a role label on the first line, and body text that wraps
+//! to fill the available width.  Height is computed automatically from the
+//! wrapped line count so the caller does not need to pre-measure.
+//!
+//! Colors come from [`crate::tokens::Tokens`] / [`crate::tokens::ColorRoles`]
+//! so a theme swap recolors all roles without touching this file.
+//!
+//! ```text
+//! ┌─ rect ──────────────────────────────────────────────────────────┐
+//! │ [U]  User                                                        │
+//! │      hello, can you explain this error?                          │
+//! └──────────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! Layout constants:
+//! - Avatar glyph column: 16 px wide + 8 px gap → `AVATAR_W + AVATAR_GAP`
+//! - Body text column starts at `AVATAR_W + AVATAR_GAP` from rect left edge
+//! - Row height = `ctx.cell_h()`; one extra row for the role label
+
+use crate::layout::Rect;
+use crate::render_ctx::RenderCtx;
+use crate::tokens::Tokens;
+use crate::widgets::{TextSegment, Widget};
+use phantom_renderer::quads::QuadInstance;
+
+// -----------------------------------------------------------------------
+// Layout constants
+// -----------------------------------------------------------------------
+
+/// Width of the avatar glyph column in pixels.
+pub const AVATAR_W: f32 = 16.0;
+/// Horizontal gap between the avatar column and the body text column.
+pub const AVATAR_GAP: f32 = 8.0;
+
+// -----------------------------------------------------------------------
+// MessageRole
+// -----------------------------------------------------------------------
+
+/// Roles that can appear in the agent-pane chat feed.
+///
+/// Each role has a distinct token color and a single-character initial
+/// used as the avatar glyph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MessageRole {
+    /// Human turn.
+    User,
+    /// AI agent turn.
+    Agent,
+    /// System / orchestrator message (not a human or agent turn).
+    System,
+    /// A tool invocation emitted by the agent.
+    ToolUse,
+    /// The result returned from a tool call.
+    ToolResult,
+}
+
+impl MessageRole {
+    /// Single uppercase ASCII initial for the avatar glyph column.
+    pub fn initial(self) -> char {
+        match self {
+            Self::User => 'U',
+            Self::Agent => 'A',
+            Self::System => 'S',
+            Self::ToolUse => 'T',
+            Self::ToolResult => 'R',
+        }
+    }
+
+    /// Short display label rendered on the first body line.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::User => "User",
+            Self::Agent => "Agent",
+            Self::System => "System",
+            Self::ToolUse => "Tool Use",
+            Self::ToolResult => "Tool Result",
+        }
+    }
+
+    /// Resolve this role to an RGBA token color from the phosphor palette.
+    ///
+    /// Roles map to semantic color roles so a theme swap recolors everything:
+    /// - `User`       → `text_primary`    (bright green)
+    /// - `Agent`      → `text_accent`     (brighter accent)
+    /// - `System`     → `text_secondary`  (muted)
+    /// - `ToolUse`    → `status_info`     (cyan)
+    /// - `ToolResult` → `status_ok`       (green OK)
+    pub fn color(self, tokens: &Tokens) -> [f32; 4] {
+        let c = &tokens.colors;
+        match self {
+            Self::User => c.text_primary,
+            Self::Agent => c.text_accent,
+            Self::System => c.text_secondary,
+            Self::ToolUse => c.status_info,
+            Self::ToolResult => c.status_ok,
+        }
+    }
+}
+
+// -----------------------------------------------------------------------
+// MessageBlock
+// -----------------------------------------------------------------------
+
+/// A chat-style message block for agent panes.
+///
+/// # Layout
+///
+/// ```text
+/// rect.x                 rect.x + AVATAR_W + AVATAR_GAP
+///   |                       |
+///   [I]   Role label
+///         Body line 1
+///         Body line 2 (wrapped)
+///         …
+/// ```
+///
+/// The widget's rendered height is:
+/// ```text
+/// (1 + line_count) * cell_h
+/// ```
+/// where `1` is the role-label row and `line_count` is determined by
+/// [`Self::compute_height`].
+#[derive(Debug, Clone)]
+pub struct MessageBlock {
+    /// The speaker / message role.
+    pub role: MessageRole,
+    /// Raw body text. The widget wraps it at render time.
+    pub body: String,
+    /// Wall-clock timestamp (milliseconds since epoch). Currently unused
+    /// in rendering but stored for future timestamp overlays.
+    pub timestamp_ms: u64,
+    /// Render context for cell metrics. Defaults to `RenderCtx::fallback()`.
+    ctx: RenderCtx,
+}
+
+impl MessageBlock {
+    /// Construct a `MessageBlock` with `RenderCtx::fallback()` metrics.
+    pub fn new(role: MessageRole, body: impl Into<String>, timestamp_ms: u64) -> Self {
+        Self {
+            role,
+            body: body.into(),
+            timestamp_ms,
+            ctx: RenderCtx::fallback(),
+        }
+    }
+
+    /// Update the live render context so wrap calculations reflect the
+    /// current font metrics.
+    pub fn set_render_ctx(&mut self, ctx: RenderCtx) {
+        self.ctx = ctx;
+    }
+
+    /// Compute the pixel height this block occupies for a given `rect_width`.
+    ///
+    /// Height = `(1 + wrapped_line_count) * cell_h`, where the leading `1`
+    /// accounts for the role-label row.
+    pub fn compute_height(&self, rect_width: f32) -> f32 {
+        let line_count = self.wrapped_lines(rect_width).len();
+        // role-label row (1) + body rows
+        (1 + line_count) as f32 * self.ctx.cell_h()
+    }
+
+    /// Wrap `body` into lines that fit within `rect_width`, honouring the
+    /// avatar column offset.
+    ///
+    /// The available body-column width (in characters) is:
+    /// ```text
+    /// floor((rect_width - AVATAR_W - AVATAR_GAP) / cell_w)
+    /// ```
+    /// An empty body returns an empty `Vec`.  A `cell_w` of `0.0` (degenerate
+    /// context) is treated as `1.0` to avoid division by zero.
+    pub fn wrapped_lines(&self, rect_width: f32) -> Vec<String> {
+        let cell_w = self.ctx.cell_w().max(1.0);
+        let body_px = (rect_width - AVATAR_W - AVATAR_GAP).max(0.0);
+        let cols = (body_px / cell_w).floor() as usize;
+
+        if cols == 0 || self.body.is_empty() {
+            return Vec::new();
+        }
+
+        let mut lines = Vec::new();
+        let mut remaining = self.body.as_str();
+
+        while !remaining.is_empty() {
+            let chars: Vec<char> = remaining.chars().collect();
+            if chars.len() <= cols {
+                lines.push(remaining.to_owned());
+                break;
+            }
+            // Find the last space within `cols` chars to word-wrap cleanly.
+            let slice: String = chars[..cols].iter().collect();
+            let break_at = slice
+                .rfind(' ')
+                .filter(|&p| p > 0)
+                .unwrap_or(cols); // hard-break if no space found
+
+            lines.push(chars[..break_at].iter().collect());
+            // Advance past the space (if any) so it doesn't start the next line.
+            let skip = if break_at < chars.len() && chars[break_at] == ' ' {
+                break_at + 1
+            } else {
+                break_at
+            };
+            // Build remaining from the unconsumed chars.
+            remaining = &remaining[chars[..skip].iter().map(|c| c.len_utf8()).sum::<usize>()..];
+        }
+
+        lines
+    }
+}
+
+impl Widget for MessageBlock {
+    /// Emits a single full-width background quad in `surface_recessed` so
+    /// each block is visually distinct from the raw terminal surface.
+    fn render_quads(&self, rect: &Rect) -> Vec<QuadInstance> {
+        let t = Tokens::phosphor(self.ctx);
+        vec![QuadInstance {
+            pos: [rect.x, rect.y],
+            size: [rect.width, self.compute_height(rect.width)],
+            color: t.colors.surface_recessed,
+            border_radius: 0.0,
+        }]
+    }
+
+    /// Emits text segments:
+    /// 1. Avatar initial in the glyph column (role color, dim background implied
+    ///    by `surface_recessed` quad).
+    /// 2. Role label on row 0 of the body column (role color).
+    /// 3. One `TextSegment` per wrapped body line (text_primary color, slightly
+    ///    dimmer than the label so the label stands out as a header).
+    fn render_text(&self, rect: &Rect) -> Vec<TextSegment> {
+        let t = Tokens::phosphor(self.ctx);
+        let role_color = self.role.color(&t);
+        let cell_h = self.ctx.cell_h();
+
+        // Column positions.
+        let avatar_x = rect.x;
+        let body_x = rect.x + AVATAR_W + AVATAR_GAP;
+
+        // Row 0 — avatar initial + role label.
+        let row0_y = rect.y + cell_h * 0.5 - cell_h * 0.5; // == rect.y (top of row)
+        let label_y = row0_y;
+
+        let mut segments = Vec::new();
+
+        // Avatar glyph (initial letter).
+        segments.push(TextSegment {
+            text: self.role.initial().to_string(),
+            x: avatar_x,
+            y: label_y,
+            color: role_color,
+        });
+
+        // Role label.
+        segments.push(TextSegment {
+            text: self.role.label().to_owned(),
+            x: body_x,
+            y: label_y,
+            color: role_color,
+        });
+
+        // Body lines — each on its own row after the label row.
+        let body_lines = self.wrapped_lines(rect.width);
+        for (i, line) in body_lines.iter().enumerate() {
+            let line_y = rect.y + (i + 1) as f32 * cell_h;
+            segments.push(TextSegment {
+                text: line.clone(),
+                x: body_x,
+                y: line_y,
+                color: t.colors.text_primary,
+            });
+        }
+
+        segments
+    }
+}
+
+// -----------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::render_ctx::RenderCtx;
+    use crate::tokens::Tokens;
+
+    /// Helper: fallback context (cell_w = 8.0, cell_h = 16.0).
+    fn fallback_ctx() -> RenderCtx {
+        RenderCtx::fallback()
+    }
+
+    fn make_rect(width: f32) -> Rect {
+        Rect { x: 0.0, y: 0.0, width, height: 200.0 }
+    }
+
+    // ----------------------------------------------------------------
+    // Role → color mapping
+    // ----------------------------------------------------------------
+
+    #[test]
+    fn user_role_color_matches_text_primary() {
+        let tokens = Tokens::phosphor(fallback_ctx());
+        assert_eq!(
+            MessageRole::User.color(&tokens),
+            tokens.colors.text_primary,
+            "User should map to text_primary"
+        );
+    }
+
+    #[test]
+    fn agent_role_color_matches_text_accent() {
+        let tokens = Tokens::phosphor(fallback_ctx());
+        assert_eq!(
+            MessageRole::Agent.color(&tokens),
+            tokens.colors.text_accent,
+            "Agent should map to text_accent"
+        );
+    }
+
+    #[test]
+    fn system_role_color_matches_text_secondary() {
+        let tokens = Tokens::phosphor(fallback_ctx());
+        assert_eq!(
+            MessageRole::System.color(&tokens),
+            tokens.colors.text_secondary,
+            "System should map to text_secondary"
+        );
+    }
+
+    #[test]
+    fn tool_use_role_color_matches_status_info() {
+        let tokens = Tokens::phosphor(fallback_ctx());
+        assert_eq!(
+            MessageRole::ToolUse.color(&tokens),
+            tokens.colors.status_info,
+            "ToolUse should map to status_info"
+        );
+    }
+
+    #[test]
+    fn tool_result_role_color_matches_status_ok() {
+        let tokens = Tokens::phosphor(fallback_ctx());
+        assert_eq!(
+            MessageRole::ToolResult.color(&tokens),
+            tokens.colors.status_ok,
+            "ToolResult should map to status_ok"
+        );
+    }
+
+    /// All five roles must have distinct colors so they are visually
+    /// distinguishable in the agent pane.
+    #[test]
+    fn all_role_colors_are_distinct() {
+        let tokens = Tokens::phosphor(fallback_ctx());
+        let colors: Vec<[f32; 4]> = [
+            MessageRole::User,
+            MessageRole::Agent,
+            MessageRole::System,
+            MessageRole::ToolUse,
+            MessageRole::ToolResult,
+        ]
+        .iter()
+        .map(|r| r.color(&tokens))
+        .collect();
+
+        for i in 0..colors.len() {
+            for j in (i + 1)..colors.len() {
+                assert_ne!(
+                    colors[i], colors[j],
+                    "roles at index {i} and {j} share the same color: {:?}",
+                    colors[i]
+                );
+            }
+        }
+    }
+
+    // ----------------------------------------------------------------
+    // Height auto-computation
+    // ----------------------------------------------------------------
+
+    /// Single-line body → height = 2 rows (label + 1 body line).
+    #[test]
+    fn single_line_body_height_is_two_rows() {
+        let mut block = MessageBlock::new(MessageRole::User, "hello", 0);
+        block.set_render_ctx(fallback_ctx());
+        // Width wide enough that "hello" (5 chars) fits in one line.
+        // Body column width = 800 - 16 - 8 = 776 px → 97 chars at cell_w=8
+        let h = block.compute_height(800.0);
+        let cell_h = fallback_ctx().cell_h();
+        assert_eq!(h, 2.0 * cell_h, "single-line body: expected 2 rows, got {h}");
+    }
+
+    /// Multiline body grows height proportionally.
+    #[test]
+    fn multiline_body_height_grows_with_lines() {
+        // cell_w = 8, body col = 800 - 16 - 8 = 776 px → 97 cols
+        // body = 200 'a' chars → ceil(200/97) = 3 lines
+        let body: String = "a".repeat(200);
+        let mut block = MessageBlock::new(MessageRole::Agent, body, 0);
+        block.set_render_ctx(fallback_ctx());
+
+        let ctx = fallback_ctx();
+        let lines = block.wrapped_lines(800.0);
+        let expected_h = (1 + lines.len()) as f32 * ctx.cell_h();
+        let actual_h = block.compute_height(800.0);
+        assert_eq!(actual_h, expected_h);
+        // Also verify the block is taller than the two-row single-line case.
+        assert!(actual_h > 2.0 * ctx.cell_h(), "multiline body should be taller than 2 rows");
+    }
+
+    /// Empty body → only the label row → height = 1 row.
+    #[test]
+    fn empty_body_height_is_one_row() {
+        let mut block = MessageBlock::new(MessageRole::System, "", 0);
+        block.set_render_ctx(fallback_ctx());
+        let cell_h = fallback_ctx().cell_h();
+        assert_eq!(block.compute_height(800.0), cell_h, "empty body: expected 1 row");
+    }
+
+    // ----------------------------------------------------------------
+    // Wrap calculation
+    // ----------------------------------------------------------------
+
+    /// A body shorter than the column should not be wrapped.
+    #[test]
+    fn short_body_is_not_wrapped() {
+        // Body col = 800 - 16 - 8 = 776 px / 8 = 97 cols
+        let body = "short message";
+        let mut block = MessageBlock::new(MessageRole::User, body, 0);
+        block.set_render_ctx(fallback_ctx());
+        let lines = block.wrapped_lines(800.0);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0], body);
+    }
+
+    /// A body of exactly `cols` chars must fit in a single line.
+    #[test]
+    fn body_exactly_cols_wide_fits_one_line() {
+        // cell_w=8, rect=800 → body_col=776px → 97 cols
+        let body: String = "x".repeat(97);
+        let mut block = MessageBlock::new(MessageRole::User, body.clone(), 0);
+        block.set_render_ctx(fallback_ctx());
+        let lines = block.wrapped_lines(800.0);
+        assert_eq!(lines.len(), 1, "body of exactly `cols` chars should be one line");
+        assert_eq!(lines[0], body);
+    }
+
+    /// A body of `cols+1` chars must split into two lines.
+    #[test]
+    fn body_one_over_cols_wraps_to_two_lines() {
+        // 97 + 1 = 98 'x' chars, no spaces → hard break at 97
+        let body: String = "x".repeat(98);
+        let mut block = MessageBlock::new(MessageRole::User, body, 0);
+        block.set_render_ctx(fallback_ctx());
+        let lines = block.wrapped_lines(800.0);
+        assert_eq!(lines.len(), 2, "98 chars at 97-col width should produce 2 lines");
+    }
+
+    /// Word-wrap: prefer breaking at a space rather than mid-word.
+    #[test]
+    fn wrap_prefers_word_boundary() {
+        // Build a line just over 97 chars with a space somewhere inside.
+        // "word " * 10 = 50 chars, then another long word to force wrap.
+        // Use a simple scenario: 96 chars before a space, then more text.
+        let word_a: String = "a".repeat(48);
+        let word_b: String = "b".repeat(48);
+        let body = format!("{word_a} {word_b}cccc");
+        // word_a + " " + word_b = 97 chars; adding "cccc" forces a second line.
+        let mut block = MessageBlock::new(MessageRole::User, body, 0);
+        block.set_render_ctx(fallback_ctx());
+        let lines = block.wrapped_lines(800.0);
+        // First line should end at the space boundary (48 a's + space is ≤97 cols).
+        assert!(
+            lines.len() >= 2,
+            "should have wrapped at space boundary: {lines:?}"
+        );
+        // First line must not start with 'b'.
+        assert!(
+            !lines[0].starts_with('b'),
+            "first line should not start with 'b': {:?}",
+            lines[0]
+        );
+    }
+
+    /// Very narrow rect (body col ≤ 0 px) → no lines (degenerate).
+    #[test]
+    fn zero_width_rect_produces_no_lines() {
+        let mut block = MessageBlock::new(MessageRole::User, "hello", 0);
+        block.set_render_ctx(fallback_ctx());
+        // rect_width ≤ AVATAR_W + AVATAR_GAP → body_px = 0 → cols = 0
+        let lines = block.wrapped_lines(AVATAR_W + AVATAR_GAP);
+        assert!(lines.is_empty(), "zero-width body column should produce no lines");
+    }
+
+    // ----------------------------------------------------------------
+    // Widget trait — render_quads
+    // ----------------------------------------------------------------
+
+    #[test]
+    fn render_quads_emits_exactly_one_background_quad() {
+        let mut block = MessageBlock::new(MessageRole::Agent, "hi", 0);
+        block.set_render_ctx(fallback_ctx());
+        let rect = make_rect(800.0);
+        let quads = block.render_quads(&rect);
+        assert_eq!(quads.len(), 1, "should emit exactly one background quad");
+        let t = Tokens::phosphor(fallback_ctx());
+        assert_eq!(quads[0].color, t.colors.surface_recessed, "background should use surface_recessed");
+    }
+
+    #[test]
+    fn render_quads_height_matches_compute_height() {
+        let body = "hello world this is a test message";
+        let mut block = MessageBlock::new(MessageRole::User, body, 42);
+        block.set_render_ctx(fallback_ctx());
+        let rect = make_rect(200.0);
+        let quads = block.render_quads(&rect);
+        assert_eq!(quads[0].size[1], block.compute_height(200.0));
+    }
+
+    // ----------------------------------------------------------------
+    // Widget trait — render_text
+    // ----------------------------------------------------------------
+
+    /// render_text must always emit at least: avatar + label (2 segments).
+    #[test]
+    fn render_text_always_has_avatar_and_label() {
+        let mut block = MessageBlock::new(MessageRole::System, "", 0);
+        block.set_render_ctx(fallback_ctx());
+        let rect = make_rect(800.0);
+        let texts = block.render_text(&rect);
+        assert!(texts.len() >= 2, "should have at least avatar + label segments");
+    }
+
+    /// Avatar segment uses the role initial.
+    #[test]
+    fn avatar_segment_uses_role_initial() {
+        let mut block = MessageBlock::new(MessageRole::ToolUse, "ok", 0);
+        block.set_render_ctx(fallback_ctx());
+        let rect = make_rect(800.0);
+        let texts = block.render_text(&rect);
+        let avatar = &texts[0];
+        assert_eq!(avatar.text, "T", "ToolUse avatar should be 'T'");
+    }
+
+    /// Label segment uses the role label string.
+    #[test]
+    fn label_segment_uses_role_label() {
+        let mut block = MessageBlock::new(MessageRole::ToolResult, "result data", 0);
+        block.set_render_ctx(fallback_ctx());
+        let rect = make_rect(800.0);
+        let texts = block.render_text(&rect);
+        let label = &texts[1];
+        assert_eq!(label.text, "Tool Result", "ToolResult label should be 'Tool Result'");
+    }
+
+    /// Avatar and label use the role color.
+    #[test]
+    fn avatar_and_label_use_role_color() {
+        let ctx = fallback_ctx();
+        let mut block = MessageBlock::new(MessageRole::Agent, "body", 0);
+        block.set_render_ctx(ctx);
+        let rect = make_rect(800.0);
+        let texts = block.render_text(&rect);
+        let tokens = Tokens::phosphor(ctx);
+        let expected = MessageRole::Agent.color(&tokens);
+        assert_eq!(texts[0].color, expected, "avatar color should match role color");
+        assert_eq!(texts[1].color, expected, "label color should match role color");
+    }
+
+    /// Body text segments use text_primary color.
+    #[test]
+    fn body_segments_use_text_primary_color() {
+        let ctx = fallback_ctx();
+        let mut block = MessageBlock::new(MessageRole::User, "some body text", 0);
+        block.set_render_ctx(ctx);
+        let rect = make_rect(800.0);
+        let texts = block.render_text(&rect);
+        let tokens = Tokens::phosphor(ctx);
+        // Segments after [0]=avatar, [1]=label are body lines.
+        for seg in texts.iter().skip(2) {
+            assert_eq!(
+                seg.color,
+                tokens.colors.text_primary,
+                "body segment color should be text_primary, got {:?}",
+                seg.color
+            );
+        }
+    }
+
+    /// Body x-position must be offset by AVATAR_W + AVATAR_GAP.
+    #[test]
+    fn body_text_is_offset_past_avatar_column() {
+        let ctx = fallback_ctx();
+        let mut block = MessageBlock::new(MessageRole::User, "body text here", 0);
+        block.set_render_ctx(ctx);
+        let rect = make_rect(800.0);
+        let texts = block.render_text(&rect);
+        // Label (index 1) and body lines (index 2+) all start at body_x.
+        let expected_body_x = rect.x + AVATAR_W + AVATAR_GAP;
+        for seg in texts.iter().skip(1) {
+            assert_eq!(
+                seg.x, expected_body_x,
+                "segment '{}' should start at body_x={expected_body_x}, got {}",
+                seg.text, seg.x
+            );
+        }
+    }
+
+    /// Segment count = 2 (avatar + label) + wrapped line count.
+    #[test]
+    fn segment_count_equals_two_plus_line_count() {
+        let ctx = fallback_ctx();
+        let body = "hello world";
+        let mut block = MessageBlock::new(MessageRole::User, body, 0);
+        block.set_render_ctx(ctx);
+        let rect = make_rect(800.0);
+        let line_count = block.wrapped_lines(800.0).len();
+        let texts = block.render_text(&rect);
+        assert_eq!(
+            texts.len(),
+            2 + line_count,
+            "expected 2 + {line_count} segments, got {}",
+            texts.len()
+        );
+    }
+
+    // ----------------------------------------------------------------
+    // MessageRole convenience methods
+    // ----------------------------------------------------------------
+
+    #[test]
+    fn initials_are_unique_per_role() {
+        let roles = [
+            MessageRole::User,
+            MessageRole::Agent,
+            MessageRole::System,
+            MessageRole::ToolUse,
+            MessageRole::ToolResult,
+        ];
+        let initials: Vec<char> = roles.iter().map(|r| r.initial()).collect();
+        let unique: std::collections::HashSet<char> = initials.iter().copied().collect();
+        assert_eq!(unique.len(), initials.len(), "all role initials must be distinct");
+    }
+
+    #[test]
+    fn labels_are_non_empty_for_all_roles() {
+        for role in [
+            MessageRole::User,
+            MessageRole::Agent,
+            MessageRole::System,
+            MessageRole::ToolUse,
+            MessageRole::ToolResult,
+        ] {
+            assert!(!role.label().is_empty(), "label for {role:?} must not be empty");
+        }
+    }
+}

--- a/crates/phantom-ui/src/widgets/mod.rs
+++ b/crates/phantom-ui/src/widgets/mod.rs
@@ -26,7 +26,7 @@ pub use status_strip::{StatusStrip, STATUS_STRIP_HEIGHT};
 
 // Issue #22 — chat-style message block for agent panes.
 pub mod message_block;
-pub use message_block::{MessageBlock, MessageRole, AVATAR_GAP, AVATAR_W};
+pub use message_block::{MessageBlock, MessageRole};
 
 // Issue #26 — thin separator line (horizontal / vertical).
 pub mod divider;

--- a/crates/phantom-ui/src/widgets/mod.rs
+++ b/crates/phantom-ui/src/widgets/mod.rs
@@ -20,6 +20,22 @@ pub use notification_banner::{
     BannerSeverity, NotificationBanner, NOTIFICATION_BANNER_HEIGHT,
 };
 
+// Issue #21 — bottom-of-pane status strip (left / center / right slots).
+pub mod status_strip;
+pub use status_strip::{StatusStrip, STATUS_STRIP_HEIGHT};
+
+// Issue #22 — chat-style message block for agent panes.
+pub mod message_block;
+pub use message_block::{MessageBlock, MessageRole, AVATAR_GAP, AVATAR_W};
+
+// Issue #26 — thin separator line (horizontal / vertical).
+pub mod divider;
+pub use divider::{Divider, Orientation};
+
+// Issue #20 — generic bordered panel with optional title bar.
+pub mod panel;
+pub use panel::{Panel, TITLE_BAR_HEIGHT};
+
 // -----------------------------------------------------------------------
 // Color palette
 // -----------------------------------------------------------------------

--- a/crates/phantom-ui/src/widgets/panel.rs
+++ b/crates/phantom-ui/src/widgets/panel.rs
@@ -1,0 +1,542 @@
+//! Generic bordered panel widget with an optional title bar.
+//!
+//! [`Panel`] is the foundational container chrome for Phantom's UI overlays,
+//! agent panes, and inspector drawers. It renders a framed surface with:
+//!
+//! - A 1-sided border (all four edges) using `chrome_frame` tokens.
+//! - An optional 18px title bar — token-driven color (`surface_raised` bg,
+//!   `text_primary` label). When `title` is `None` the header is omitted
+//!   and the full rect is body area.
+//! - A body region clipped to the content area so children cannot draw
+//!   outside the panel bounds.
+//!
+//! All colors and widths come from [`crate::tokens::Tokens::phosphor`]; no raw
+//! RGBA literals appear in this file. Swap the theme and the panel recolors.
+//!
+//! # Layout anatomy
+//!
+//! ```text
+//! ┌──────────────────────────────┐ ← chrome_frame border (frame() thick)
+//! │ Title text                   │ ← title bar, TITLE_BAR_HEIGHT px
+//! ├──────────────────────────────┤ ← divider, hair() thick
+//! │                              │
+//! │  body (clipped)              │
+//! │                              │
+//! └──────────────────────────────┘
+//! ```
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! use phantom_ui::widgets::panel::Panel;
+//! use phantom_ui::layout::Rect;
+//!
+//! let panel = Panel::new(Some("Agent Output".to_owned()));
+//! let quads = panel.render_quads(&rect);
+//! let texts = panel.render_text(&rect);
+//! ```
+
+use crate::layout::Rect;
+use crate::render_ctx::RenderCtx;
+use crate::tokens::Tokens;
+use crate::widgets::{TextSegment, Widget};
+use phantom_renderer::quads::QuadInstance;
+
+/// Height of the title bar region in pixels.
+///
+/// Token-driven typography for panels: 18px fits a single monospace line
+/// with 1px top + 1px bottom internal padding at the default 16px cell height.
+pub const TITLE_BAR_HEIGHT: f32 = 18.0;
+
+/// A bordered container widget with an optional title bar.
+///
+/// Construct via [`Panel::new`] or [`Panel::untitled`]. Call
+/// [`Widget::render_quads`] and [`Widget::render_text`] to obtain the
+/// rendering primitives the compositor should draw.
+///
+/// All color and sizing decisions flow through [`Tokens::phosphor`]; the
+/// panel adapts automatically when `RenderCtx` changes font metrics.
+#[derive(Debug, Clone)]
+pub struct Panel {
+    /// Optional title displayed in the header bar. `None` → no title bar.
+    title: Option<String>,
+    /// Live render context for text measurement and spacing.
+    ctx: RenderCtx,
+}
+
+impl Panel {
+    /// Create a panel, optionally with a title bar.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// let with_title = Panel::new(Some("Inspector".to_owned()));
+    /// let bare       = Panel::new(None);
+    /// ```
+    pub fn new(title: Option<String>) -> Self {
+        Self { title, ctx: RenderCtx::fallback() }
+    }
+
+    /// Convenience constructor for a panel without a title bar.
+    pub fn untitled() -> Self {
+        Self::new(None)
+    }
+
+    /// Update the live render context (typically called once per frame before
+    /// `render_quads` / `render_text`).
+    pub fn set_render_ctx(&mut self, ctx: RenderCtx) {
+        self.ctx = ctx;
+    }
+
+    /// Update the title. `None` removes the title bar entirely.
+    pub fn set_title(&mut self, title: Option<String>) {
+        self.title = title;
+    }
+
+    /// `true` when a title bar is present.
+    pub fn has_title(&self) -> bool {
+        self.title.is_some()
+    }
+
+    /// Height (px) consumed by the title bar. Returns `0.0` when untitled.
+    pub fn title_bar_height(&self) -> f32 {
+        if self.has_title() { TITLE_BAR_HEIGHT } else { 0.0 }
+    }
+
+    /// The clipped body rectangle — the area inside the border and below the
+    /// (optional) title bar that is safe for child content.
+    ///
+    /// Returns [`Rect::ZERO`] for degenerate rects where the borders consume
+    /// all available space.
+    pub fn body_rect(&self, outer: &Rect) -> Rect {
+        let t = Tokens::phosphor(self.ctx);
+        let border = t.frame(); // 2.0 px
+        let divider = if self.has_title() { t.hair() } else { 0.0 };
+        let header_h = self.title_bar_height() + divider;
+
+        let x = outer.x + border;
+        let y = outer.y + border + header_h;
+        let width = (outer.width - border * 2.0).max(0.0);
+        let height = (outer.height - border * 2.0 - header_h).max(0.0);
+
+        Rect { x, y, width, height }
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────────────
+
+    /// Resolve the title-bar background rect (positioned inside the outer border).
+    fn title_bar_rect(&self, outer: &Rect) -> Rect {
+        let t = Tokens::phosphor(self.ctx);
+        let border = t.frame();
+        Rect {
+            x: outer.x + border,
+            y: outer.y + border,
+            width: (outer.width - border * 2.0).max(0.0),
+            height: TITLE_BAR_HEIGHT,
+        }
+    }
+
+    /// Resolve the horizontal divider rect (sits between title bar and body).
+    fn divider_rect(&self, outer: &Rect) -> Rect {
+        let t = Tokens::phosphor(self.ctx);
+        let border = t.frame();
+        let div_h = t.hair();
+        Rect {
+            x: outer.x + border,
+            y: outer.y + border + TITLE_BAR_HEIGHT,
+            width: (outer.width - border * 2.0).max(0.0),
+            height: div_h,
+        }
+    }
+}
+
+impl Default for Panel {
+    fn default() -> Self {
+        Self::untitled()
+    }
+}
+
+impl Widget for Panel {
+    /// Emit quads for:
+    /// 1. Full outer background (`surface_raised`) — the visible "card" face.
+    /// 2. Four border quads (`chrome_frame`) at `frame()` thickness.
+    /// 3. Title bar background (`surface_recessed`) when a title is present.
+    /// 4. Divider line (`chrome_divider`) separating title from body.
+    fn render_quads(&self, rect: &Rect) -> Vec<QuadInstance> {
+        let t = Tokens::phosphor(self.ctx);
+        let border = t.frame();
+
+        // Capacity: 1 bg + 4 borders + 2 optional (title bg + divider).
+        let cap = if self.has_title() { 7 } else { 5 };
+        let mut quads = Vec::with_capacity(cap);
+
+        // 1. Panel surface background.
+        quads.push(QuadInstance {
+            pos: [rect.x, rect.y],
+            size: [rect.width, rect.height],
+            color: t.colors.surface_raised,
+            border_radius: 0.0,
+        });
+
+        // 2. Four border edges (frame color).
+        // Top
+        quads.push(QuadInstance {
+            pos: [rect.x, rect.y],
+            size: [rect.width, border],
+            color: t.colors.chrome_frame,
+            border_radius: 0.0,
+        });
+        // Bottom
+        quads.push(QuadInstance {
+            pos: [rect.x, rect.y + rect.height - border],
+            size: [rect.width, border],
+            color: t.colors.chrome_frame,
+            border_radius: 0.0,
+        });
+        // Left
+        quads.push(QuadInstance {
+            pos: [rect.x, rect.y],
+            size: [border, rect.height],
+            color: t.colors.chrome_frame,
+            border_radius: 0.0,
+        });
+        // Right
+        quads.push(QuadInstance {
+            pos: [rect.x + rect.width - border, rect.y],
+            size: [border, rect.height],
+            color: t.colors.chrome_frame,
+            border_radius: 0.0,
+        });
+
+        if self.has_title() {
+            // 3. Title bar background.
+            let tb = self.title_bar_rect(rect);
+            quads.push(QuadInstance {
+                pos: [tb.x, tb.y],
+                size: [tb.width, tb.height],
+                color: t.colors.surface_recessed,
+                border_radius: 0.0,
+            });
+
+            // 4. Divider line.
+            let dv = self.divider_rect(rect);
+            quads.push(QuadInstance {
+                pos: [dv.x, dv.y],
+                size: [dv.width, dv.height],
+                color: t.colors.chrome_divider,
+                border_radius: 0.0,
+            });
+        }
+
+        quads
+    }
+
+    /// Emit one [`TextSegment`] for the title when present.
+    ///
+    /// The title is left-aligned with `space_3()` horizontal padding and
+    /// vertically centered in the title bar, matching the [`NotificationBanner`]
+    /// text-placement idiom.
+    fn render_text(&self, rect: &Rect) -> Vec<TextSegment> {
+        let Some(ref title) = self.title else {
+            return Vec::new();
+        };
+
+        let t = Tokens::phosphor(self.ctx);
+        let tb = self.title_bar_rect(rect);
+        let pad_x = t.space_3();
+        // Vertically center: top-of-glyph ≈ midline − half cell height.
+        let text_y = tb.y + (tb.height * 0.5) - (self.ctx.cell_h() * 0.5);
+
+        vec![TextSegment {
+            text: title.clone(),
+            x: tb.x + pad_x,
+            y: text_y,
+            color: t.colors.text_primary,
+        }]
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Standard test rect — 400×300 at (10, 20) so we can verify absolute
+    /// positions rather than asserting == 0 for everything.
+    fn panel_rect() -> Rect {
+        Rect { x: 10.0, y: 20.0, width: 400.0, height: 300.0 }
+    }
+
+    fn tokens() -> Tokens {
+        Tokens::phosphor(RenderCtx::fallback())
+    }
+
+    // ── Without title bar ─────────────────────────────────────────────────
+
+    #[test]
+    fn untitled_renders_five_quads() {
+        // Arrange
+        let panel = Panel::untitled();
+        // Act
+        let quads = panel.render_quads(&panel_rect());
+        // Assert: 1 surface + 4 border edges
+        assert_eq!(quads.len(), 5, "untitled panel must emit exactly 5 quads");
+    }
+
+    #[test]
+    fn untitled_renders_no_text() {
+        let panel = Panel::untitled();
+        assert!(
+            panel.render_text(&panel_rect()).is_empty(),
+            "untitled panel must not emit any text segments"
+        );
+    }
+
+    #[test]
+    fn untitled_has_no_title_bar() {
+        let panel = Panel::untitled();
+        assert!(!panel.has_title());
+        assert_eq!(panel.title_bar_height(), 0.0);
+    }
+
+    #[test]
+    fn untitled_body_rect_inset_by_border_only() {
+        let panel = Panel::untitled();
+        let outer = panel_rect();
+        let body = panel.body_rect(&outer);
+        let t = tokens();
+        let border = t.frame();
+
+        // Body starts immediately after the border on all sides.
+        assert!((body.x - (outer.x + border)).abs() < 0.01, "body.x wrong");
+        assert!((body.y - (outer.y + border)).abs() < 0.01, "body.y wrong");
+        assert!((body.width - (outer.width - border * 2.0)).abs() < 0.01, "body.width wrong");
+        assert!((body.height - (outer.height - border * 2.0)).abs() < 0.01, "body.height wrong");
+    }
+
+    // ── With title bar ────────────────────────────────────────────────────
+
+    #[test]
+    fn titled_renders_seven_quads() {
+        // Arrange
+        let panel = Panel::new(Some("Inspector".to_owned()));
+        // Act
+        let quads = panel.render_quads(&panel_rect());
+        // Assert: 1 surface + 4 borders + 1 title bg + 1 divider
+        assert_eq!(quads.len(), 7, "titled panel must emit exactly 7 quads");
+    }
+
+    #[test]
+    fn titled_renders_one_text_segment() {
+        let panel = Panel::new(Some("Agent Log".to_owned()));
+        let texts = panel.render_text(&panel_rect());
+        assert_eq!(texts.len(), 1, "titled panel must emit exactly one text segment");
+        assert_eq!(texts[0].text, "Agent Log");
+    }
+
+    #[test]
+    fn titled_has_title_bar_flag() {
+        let panel = Panel::new(Some("X".to_owned()));
+        assert!(panel.has_title());
+        assert_eq!(panel.title_bar_height(), TITLE_BAR_HEIGHT);
+    }
+
+    #[test]
+    fn titled_body_rect_inset_by_border_and_title_bar() {
+        let panel = Panel::new(Some("Title".to_owned()));
+        let outer = panel_rect();
+        let body = panel.body_rect(&outer);
+        let t = tokens();
+        let border = t.frame();
+        let divider = t.hair();
+        let expected_y = outer.y + border + TITLE_BAR_HEIGHT + divider;
+        let expected_h = outer.height - border * 2.0 - TITLE_BAR_HEIGHT - divider;
+
+        assert!((body.x - (outer.x + border)).abs() < 0.01, "body.x wrong");
+        assert!((body.y - expected_y).abs() < 0.01, "body.y wrong: got {}, expected {}", body.y, expected_y);
+        assert!((body.width - (outer.width - border * 2.0)).abs() < 0.01, "body.width wrong");
+        assert!((body.height - expected_h).abs() < 0.01, "body.height wrong");
+    }
+
+    // ── Token compliance ──────────────────────────────────────────────────
+
+    #[test]
+    fn surface_background_uses_token_color() {
+        let t = tokens();
+        let panel = Panel::untitled();
+        let quads = panel.render_quads(&panel_rect());
+        // First quad is the panel surface.
+        assert_eq!(
+            quads[0].color, t.colors.surface_raised,
+            "panel background must use surface_raised token"
+        );
+    }
+
+    #[test]
+    fn border_quads_use_chrome_frame_token() {
+        let t = tokens();
+        let panel = Panel::untitled();
+        let quads = panel.render_quads(&panel_rect());
+        // Quads 1-4 are the four border edges.
+        for quad in &quads[1..5] {
+            assert_eq!(
+                quad.color, t.colors.chrome_frame,
+                "border quad must use chrome_frame token, got {:?}", quad.color
+            );
+        }
+    }
+
+    #[test]
+    fn title_bar_background_uses_surface_recessed_token() {
+        let t = tokens();
+        let panel = Panel::new(Some("Panel".to_owned()));
+        let quads = panel.render_quads(&panel_rect());
+        // Quad 5 (index 5) is the title bar background.
+        assert_eq!(
+            quads[5].color, t.colors.surface_recessed,
+            "title bar must use surface_recessed token"
+        );
+    }
+
+    #[test]
+    fn divider_uses_chrome_divider_token() {
+        let t = tokens();
+        let panel = Panel::new(Some("Panel".to_owned()));
+        let quads = panel.render_quads(&panel_rect());
+        // Quad 6 (index 6) is the divider.
+        assert_eq!(
+            quads[6].color, t.colors.chrome_divider,
+            "divider must use chrome_divider token"
+        );
+    }
+
+    #[test]
+    fn title_text_uses_text_primary_token() {
+        let t = tokens();
+        let panel = Panel::new(Some("My Panel".to_owned()));
+        let texts = panel.render_text(&panel_rect());
+        assert_eq!(
+            texts[0].color, t.colors.text_primary,
+            "title text must use text_primary token"
+        );
+    }
+
+    // ── Border geometry ───────────────────────────────────────────────────
+
+    #[test]
+    fn border_thickness_equals_frame_token() {
+        let t = tokens();
+        let border = t.frame();
+        let panel = Panel::untitled();
+        let outer = panel_rect();
+        let quads = panel.render_quads(&outer);
+
+        // Top border: size[1] == border thickness
+        assert!((quads[1].size[1] - border).abs() < 0.01, "top border thickness mismatch");
+        // Bottom border: size[1] == border thickness
+        assert!((quads[2].size[1] - border).abs() < 0.01, "bottom border thickness mismatch");
+        // Left border: size[0] == border thickness
+        assert!((quads[3].size[0] - border).abs() < 0.01, "left border thickness mismatch");
+        // Right border: size[0] == border thickness
+        assert!((quads[4].size[0] - border).abs() < 0.01, "right border thickness mismatch");
+    }
+
+    #[test]
+    fn top_border_positioned_at_outer_top() {
+        let panel = Panel::untitled();
+        let outer = panel_rect();
+        let quads = panel.render_quads(&outer);
+        let top_border = &quads[1];
+        assert!((top_border.pos[0] - outer.x).abs() < 0.01, "top border x wrong");
+        assert!((top_border.pos[1] - outer.y).abs() < 0.01, "top border y wrong");
+        assert!((top_border.size[0] - outer.width).abs() < 0.01, "top border width wrong");
+    }
+
+    #[test]
+    fn bottom_border_positioned_at_outer_bottom() {
+        let t = tokens();
+        let panel = Panel::untitled();
+        let outer = panel_rect();
+        let quads = panel.render_quads(&outer);
+        let bottom_border = &quads[2];
+        let expected_y = outer.y + outer.height - t.frame();
+        assert!((bottom_border.pos[1] - expected_y).abs() < 0.01, "bottom border y wrong");
+    }
+
+    // ── Body is inside border ─────────────────────────────────────────────
+
+    #[test]
+    fn body_rect_is_strictly_inside_outer_rect_untitled() {
+        let panel = Panel::untitled();
+        let outer = panel_rect();
+        let body = panel.body_rect(&outer);
+        assert!(body.x > outer.x, "body.x must be inside left border");
+        assert!(body.y > outer.y, "body.y must be inside top border");
+        assert!(body.x + body.width < outer.x + outer.width, "body right must be inside right border");
+        assert!(body.y + body.height < outer.y + outer.height, "body bottom must be inside bottom border");
+    }
+
+    #[test]
+    fn body_rect_is_strictly_inside_outer_rect_titled() {
+        let panel = Panel::new(Some("T".to_owned()));
+        let outer = panel_rect();
+        let body = panel.body_rect(&outer);
+        assert!(body.x > outer.x, "body.x must be inside left border");
+        assert!(body.y > outer.y + TITLE_BAR_HEIGHT, "body.y must be below title bar");
+        assert!(body.x + body.width < outer.x + outer.width, "body right inside border");
+        assert!(body.y + body.height < outer.y + outer.height, "body bottom inside border");
+    }
+
+    // ── Dynamic mutation ──────────────────────────────────────────────────
+
+    #[test]
+    fn set_title_changes_render_output() {
+        let mut panel = Panel::untitled();
+        assert_eq!(panel.render_quads(&panel_rect()).len(), 5);
+        assert!(panel.render_text(&panel_rect()).is_empty());
+
+        panel.set_title(Some("Now has title".to_owned()));
+        assert_eq!(panel.render_quads(&panel_rect()).len(), 7);
+        assert_eq!(panel.render_text(&panel_rect()).len(), 1);
+    }
+
+    #[test]
+    fn removing_title_collapses_to_untitled_output() {
+        let mut panel = Panel::new(Some("Remove me".to_owned()));
+        panel.set_title(None);
+        assert_eq!(panel.render_quads(&panel_rect()).len(), 5);
+        assert!(panel.render_text(&panel_rect()).is_empty());
+    }
+
+    #[test]
+    fn default_is_untitled() {
+        let panel = Panel::default();
+        assert!(!panel.has_title());
+        assert_eq!(panel.render_quads(&panel_rect()).len(), 5);
+    }
+
+    // ── Widget trait object safety ────────────────────────────────────────
+
+    #[test]
+    fn panel_is_object_safe() {
+        let panel = Panel::new(Some("Dyn".to_owned()));
+        let widget: &dyn Widget = &panel;
+        let quads = widget.render_quads(&panel_rect());
+        assert!(!quads.is_empty());
+    }
+
+    // ── Degenerate rect ───────────────────────────────────────────────────
+
+    #[test]
+    fn degenerate_rect_body_clamped_to_zero() {
+        let panel = Panel::new(Some("Small".to_owned()));
+        let tiny = Rect { x: 0.0, y: 0.0, width: 1.0, height: 1.0 };
+        let body = panel.body_rect(&tiny);
+        // Dimensions must never go negative.
+        assert!(body.width >= 0.0, "body.width must not be negative");
+        assert!(body.height >= 0.0, "body.height must not be negative");
+    }
+}

--- a/crates/phantom-ui/src/widgets/status_strip.rs
+++ b/crates/phantom-ui/src/widgets/status_strip.rs
@@ -1,0 +1,530 @@
+//! Issue #21 — Bottom-of-pane status strip.
+//!
+//! A fixed-height horizontal bar divided into three slots — left, center, and
+//! right — that each hold a single string. Content that overflows its slot is
+//! truncated with a trailing ellipsis (`…`) so the strip never wraps or
+//! expands beyond its 22 px height.
+//!
+//! ## Layout
+//!
+//! ```text
+//! ┌───────────────────────────────────────────────────────────────────┐
+//! │  left text           center text                     right text   │
+//! └───────────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! The available width is divided into three equal thirds (each ~33 % of the
+//! total rect width). Padding of [`TOKEN_PAD`] pixels is subtracted from each
+//! slot's inner budget before truncation. Slot content is positioned as
+//! follows:
+//! - **Left**: flush to the left edge of the left slot (+ padding).
+//! - **Center**: horizontally centered within the center slot.
+//! - **Right**: flush to the right edge of the right slot (- padding).
+//!
+//! ## Token compliance
+//!
+//! All colors flow through [`Tokens`] / [`ColorRoles`]:
+//! - Background: `tokens.colors.surface_recessed`
+//! - Foreground text: `tokens.colors.text_secondary`
+//!
+//! No raw RGBA constants appear outside the `#[cfg(test)]` block where they
+//! are pulled from `Tokens::phosphor` for assertion purposes.
+
+use crate::layout::Rect;
+use crate::render_ctx::RenderCtx;
+use crate::tokens::Tokens;
+use crate::widgets::{TextSegment, Widget};
+use phantom_renderer::quads::QuadInstance;
+
+/// Fixed pixel height of the [`StatusStrip`] widget.
+pub const STATUS_STRIP_HEIGHT: f32 = 22.0;
+
+/// Horizontal padding applied at each slot edge (pixels).
+///
+/// Keeps text away from the slot boundaries and from the CRT barrel-distortion
+/// zone at the very edges of the screen.
+const TOKEN_PAD: f32 = 8.0;
+
+// ────────────────────────────────────────────────────────────────────────────
+// StatusStrip
+// ────────────────────────────────────────────────────────────────────────────
+
+/// A horizontal, fixed-height status strip positioned at the bottom of a pane.
+///
+/// Content is split into three independent slots — left, center, and right.
+/// Each slot truncates with an ellipsis (`…`) when the text is wider than the
+/// slot allows. All colors are resolved from the live [`Tokens`] table so a
+/// theme change recolors the strip without touching this widget.
+///
+/// # Examples
+///
+/// ```
+/// use phantom_ui::widgets::status_strip::StatusStrip;
+///
+/// let strip = StatusStrip::new("NORMAL", "src/main.rs", "Ln 42 Col 8");
+/// ```
+#[derive(Debug, Clone)]
+pub struct StatusStrip {
+    /// Content for the left slot.
+    left: String,
+    /// Content for the center slot.
+    center: String,
+    /// Content for the right slot.
+    right: String,
+    /// Render context for cell metrics (cell width drives truncation math).
+    ctx: RenderCtx,
+}
+
+impl StatusStrip {
+    /// Construct a [`StatusStrip`] with explicit slot content.
+    ///
+    /// Uses [`RenderCtx::fallback`] for metrics; call [`Self::set_render_ctx`]
+    /// to provide live font metrics once available.
+    pub fn new(left: impl Into<String>, center: impl Into<String>, right: impl Into<String>) -> Self {
+        Self {
+            left: left.into(),
+            center: center.into(),
+            right: right.into(),
+            ctx: RenderCtx::fallback(),
+        }
+    }
+
+    /// Update the render context with live font metrics.
+    pub fn set_render_ctx(&mut self, ctx: RenderCtx) {
+        self.ctx = ctx;
+    }
+
+    /// Replace the left slot text.
+    pub fn set_left(&mut self, text: impl Into<String>) {
+        self.left = text.into();
+    }
+
+    /// Replace the center slot text.
+    pub fn set_center(&mut self, text: impl Into<String>) {
+        self.center = text.into();
+    }
+
+    /// Replace the right slot text.
+    pub fn set_right(&mut self, text: impl Into<String>) {
+        self.right = text.into();
+    }
+
+    // ── Internal helpers ───────────────────────────────────────────────────
+
+    /// Compute the pixel width of one slot given the total rect width.
+    ///
+    /// The strip is divided into three equal thirds.
+    fn slot_width(rect_width: f32) -> f32 {
+        rect_width / 3.0
+    }
+
+    /// Truncate `text` so that it fits within `max_chars` characters, appending
+    /// `…` when truncation occurs.
+    ///
+    /// Returns an empty string when `max_chars` is 0.
+    fn truncate(text: &str, max_chars: usize) -> String {
+        if max_chars == 0 {
+            return String::new();
+        }
+        let chars: Vec<char> = text.chars().collect();
+        if chars.len() <= max_chars {
+            text.to_owned()
+        } else {
+            // Reserve one char for the ellipsis.
+            let keep = max_chars.saturating_sub(1);
+            let truncated: String = chars[..keep].iter().collect();
+            format!("{truncated}…")
+        }
+    }
+
+    /// Pixel budget (in chars) available inside a slot after padding.
+    fn chars_in_slot(&self, slot_w: f32) -> usize {
+        let inner = (slot_w - TOKEN_PAD * 2.0).max(0.0);
+        (inner / self.ctx.cell_w()) as usize
+    }
+}
+
+impl Default for StatusStrip {
+    fn default() -> Self {
+        Self::new("", "", "")
+    }
+}
+
+impl Widget for StatusStrip {
+    /// Emits a single full-width background quad in `surface_recessed`.
+    fn render_quads(&self, rect: &Rect) -> Vec<QuadInstance> {
+        let t = Tokens::phosphor(self.ctx);
+        vec![QuadInstance {
+            pos: [rect.x, rect.y],
+            size: [rect.width, rect.height],
+            color: t.colors.surface_recessed,
+            border_radius: 0.0,
+        }]
+    }
+
+    /// Emits up to three text segments (one per slot), each truncated to fit.
+    ///
+    /// Slots with an empty string after truncation are omitted from the output
+    /// so the renderer's append pattern is a no-op for blank content.
+    fn render_text(&self, rect: &Rect) -> Vec<TextSegment> {
+        let t = Tokens::phosphor(self.ctx);
+        let fg = t.colors.text_secondary;
+        let slot_w = Self::slot_width(rect.width);
+        let text_y = rect.y + (rect.height * 0.5) - (self.ctx.cell_h() * 0.5);
+        let char_w = self.ctx.cell_w();
+        let max_chars = self.chars_in_slot(slot_w);
+
+        let mut segments = Vec::with_capacity(3);
+
+        // ── Left slot: flush-left ──────────────────────────────────────────
+        let left_text = Self::truncate(&self.left, max_chars);
+        if !left_text.is_empty() {
+            segments.push(TextSegment {
+                text: left_text,
+                x: rect.x + TOKEN_PAD,
+                y: text_y,
+                color: fg,
+            });
+        }
+
+        // ── Center slot: horizontally centered within its third ───────────
+        let center_text = Self::truncate(&self.center, max_chars);
+        if !center_text.is_empty() {
+            let center_slot_x = rect.x + slot_w;
+            let text_w = center_text.chars().count() as f32 * char_w;
+            let text_x = center_slot_x + (slot_w - text_w) * 0.5;
+            segments.push(TextSegment {
+                text: center_text,
+                x: text_x,
+                y: text_y,
+                color: fg,
+            });
+        }
+
+        // ── Right slot: flush-right ────────────────────────────────────────
+        let right_text = Self::truncate(&self.right, max_chars);
+        if !right_text.is_empty() {
+            let right_slot_x = rect.x + slot_w * 2.0;
+            let text_w = right_text.chars().count() as f32 * char_w;
+            let text_x = right_slot_x + slot_w - TOKEN_PAD - text_w;
+            segments.push(TextSegment {
+                text: right_text,
+                x: text_x,
+                y: text_y,
+                color: fg,
+            });
+        }
+
+        segments
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tokens::ColorRoles;
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    fn wide_rect() -> Rect {
+        Rect { x: 0.0, y: 980.0, width: 1200.0, height: STATUS_STRIP_HEIGHT }
+    }
+
+    fn narrow_rect(width: f32) -> Rect {
+        Rect { x: 0.0, y: 980.0, width, height: STATUS_STRIP_HEIGHT }
+    }
+
+    fn strip_with_ctx(left: &str, center: &str, right: &str, ctx: RenderCtx) -> StatusStrip {
+        let mut s = StatusStrip::new(left, center, right);
+        s.set_render_ctx(ctx);
+        s
+    }
+
+    // ── Construction & defaults ───────────────────────────────────────────────
+
+    #[test]
+    fn default_has_empty_slots() {
+        let s = StatusStrip::default();
+        assert!(s.left.is_empty());
+        assert!(s.center.is_empty());
+        assert!(s.right.is_empty());
+    }
+
+    #[test]
+    fn new_stores_slot_content() {
+        let s = StatusStrip::new("L", "C", "R");
+        assert_eq!(s.left, "L");
+        assert_eq!(s.center, "C");
+        assert_eq!(s.right, "R");
+    }
+
+    #[test]
+    fn setters_update_slots() {
+        let mut s = StatusStrip::default();
+        s.set_left("left");
+        s.set_center("mid");
+        s.set_right("right");
+        assert_eq!(s.left, "left");
+        assert_eq!(s.center, "mid");
+        assert_eq!(s.right, "right");
+    }
+
+    // ── Quad rendering ───────────────────────────────────────────────────────
+
+    #[test]
+    fn render_quads_emits_single_background() {
+        let s = StatusStrip::new("L", "C", "R");
+        let quads = s.render_quads(&wide_rect());
+        assert_eq!(quads.len(), 1, "exactly one background quad");
+        assert_eq!(quads[0].pos, [0.0, 980.0]);
+        assert_eq!(quads[0].size, [1200.0, STATUS_STRIP_HEIGHT]);
+        assert_eq!(quads[0].border_radius, 0.0);
+    }
+
+    /// Token compliance: background color must equal `surface_recessed` from
+    /// the Phosphor token set — no hardcoded RGBA values allowed.
+    #[test]
+    fn background_color_is_surface_recessed_token() {
+        let ctx = RenderCtx::fallback();
+        let expected = Tokens::phosphor(ctx).colors.surface_recessed;
+
+        let s = StatusStrip::new("X", "Y", "Z");
+        let quads = s.render_quads(&wide_rect());
+        assert_eq!(quads[0].color, expected, "background must use surface_recessed token");
+    }
+
+    /// Cross-check: `surface_recessed` must not equal `surface_base` (ensures
+    /// we are using the correct depth token).
+    #[test]
+    fn surface_recessed_differs_from_surface_base() {
+        let roles = ColorRoles::phosphor();
+        assert_ne!(
+            roles.surface_recessed, roles.surface_base,
+            "surface_recessed and surface_base should differ for visual depth"
+        );
+    }
+
+    // ── Text rendering — normal width ────────────────────────────────────────
+
+    #[test]
+    fn all_three_slots_render_when_content_fits() {
+        let s = StatusStrip::new("LEFT", "CENTER", "RIGHT");
+        let texts = s.render_text(&wide_rect());
+        assert_eq!(texts.len(), 3);
+        assert!(texts.iter().any(|t| t.text == "LEFT"), "left slot missing");
+        assert!(texts.iter().any(|t| t.text == "CENTER"), "center slot missing");
+        assert!(texts.iter().any(|t| t.text == "RIGHT"), "right slot missing");
+    }
+
+    /// Token compliance: text color must equal `text_secondary`.
+    #[test]
+    fn text_color_is_text_secondary_token() {
+        let ctx = RenderCtx::fallback();
+        let expected = Tokens::phosphor(ctx).colors.text_secondary;
+
+        let s = strip_with_ctx("L", "C", "R", ctx);
+        let texts = s.render_text(&wide_rect());
+        for seg in &texts {
+            assert_eq!(
+                seg.color, expected,
+                "segment '{}' must use text_secondary token, got {:?}",
+                seg.text, seg.color
+            );
+        }
+    }
+
+    #[test]
+    fn empty_slots_are_omitted() {
+        let s = StatusStrip::new("", "CENTER", "");
+        let texts = s.render_text(&wide_rect());
+        assert_eq!(texts.len(), 1);
+        assert_eq!(texts[0].text, "CENTER");
+    }
+
+    #[test]
+    fn all_empty_slots_produce_no_text() {
+        let s = StatusStrip::default();
+        let texts = s.render_text(&wide_rect());
+        assert!(texts.is_empty(), "all-empty strip should emit no text segments");
+    }
+
+    // ── Truncation behavior ───────────────────────────────────────────────────
+
+    /// Core truncation unit test: long text must end with `…` and fit within
+    /// `max_chars` when the text length exceeds the budget.
+    #[test]
+    fn truncate_long_text_ends_with_ellipsis() {
+        let result = StatusStrip::truncate("abcdefghijklmnop", 8);
+        assert!(result.ends_with('…'), "truncated text should end with ellipsis");
+        assert!(
+            result.chars().count() <= 8,
+            "truncated result must fit within max_chars: got {}",
+            result.chars().count()
+        );
+    }
+
+    #[test]
+    fn truncate_short_text_unchanged() {
+        let result = StatusStrip::truncate("hello", 20);
+        assert_eq!(result, "hello", "text shorter than budget must not be modified");
+    }
+
+    #[test]
+    fn truncate_exact_fit_unchanged() {
+        let result = StatusStrip::truncate("exact", 5);
+        assert_eq!(result, "exact", "text that exactly fits must not be truncated");
+    }
+
+    #[test]
+    fn truncate_zero_budget_returns_empty() {
+        let result = StatusStrip::truncate("anything", 0);
+        assert!(result.is_empty(), "zero budget must produce empty string");
+    }
+
+    #[test]
+    fn truncate_budget_of_one_gives_ellipsis_only() {
+        let result = StatusStrip::truncate("hello", 1);
+        assert_eq!(result, "…", "budget=1 should give just the ellipsis");
+    }
+
+    /// Slot truncation under a 60 px wide rect with the fallback cell width of
+    /// 8 px. Each slot = 20 px; inner budget = 20 - 16 (2×8 pad) = 4 px →
+    /// max_chars = 0 (floor division), so even a short label is suppressed.
+    #[test]
+    fn very_narrow_strip_suppresses_all_text() {
+        // 60 px total → 20 px per slot → inner = 4 px → 0 chars
+        let ctx = RenderCtx::fallback(); // cell_w = 8.0
+        let s = strip_with_ctx("ABC", "DEF", "GHI", ctx);
+        let texts = s.render_text(&narrow_rect(60.0));
+        assert!(
+            texts.is_empty(),
+            "60 px strip should produce no text at 8 px cell width"
+        );
+    }
+
+    /// At 300 px total with an 8 px cell: each slot = 100 px, inner = 84 px,
+    /// max_chars = 10. A 15-char string must be truncated to ≤10 chars and
+    /// end with `…`.
+    #[test]
+    fn moderate_narrow_strip_truncates_long_labels() {
+        let ctx = RenderCtx::fallback(); // cell_w = 8.0
+        // slot_w = 100 px; inner = 100 - 16 = 84 px; max_chars = floor(84/8) = 10
+        let long = "123456789ABCDEF"; // 15 chars — too long
+        let s = strip_with_ctx(long, long, long, ctx);
+        let texts = s.render_text(&narrow_rect(300.0));
+
+        assert_eq!(texts.len(), 3, "all slots should still emit text at 300 px");
+        for seg in &texts {
+            let n = seg.text.chars().count();
+            assert!(
+                n <= 10,
+                "segment '{}' has {} chars, expected ≤10",
+                seg.text, n
+            );
+            assert!(
+                seg.text.ends_with('…'),
+                "truncated segment '{}' should end with ellipsis",
+                seg.text
+            );
+        }
+    }
+
+    /// At 480 px total with an 8 px cell: each slot = 160 px, inner = 144 px,
+    /// max_chars = 18. A 10-char string fits without truncation.
+    #[test]
+    fn medium_width_short_labels_not_truncated() {
+        let ctx = RenderCtx::fallback();
+        // slot_w = 160; inner = 144; max_chars = 18
+        let s = strip_with_ctx("NORMAL", "file.rs", "Ln 1 Col 1", ctx);
+        let texts = s.render_text(&narrow_rect(480.0));
+        assert_eq!(texts.len(), 3);
+        assert!(texts.iter().any(|t| t.text == "NORMAL"));
+        assert!(texts.iter().any(|t| t.text == "file.rs"));
+        assert!(texts.iter().any(|t| t.text == "Ln 1 Col 1"));
+    }
+
+    // ── Slot positioning ─────────────────────────────────────────────────────
+
+    /// Left text must start at (rect.x + TOKEN_PAD).
+    #[test]
+    fn left_slot_x_position() {
+        let ctx = RenderCtx::fallback();
+        let s = strip_with_ctx("LEFT", "", "", ctx);
+        let texts = s.render_text(&wide_rect());
+        assert_eq!(texts.len(), 1);
+        assert_eq!(texts[0].x, 0.0 + TOKEN_PAD, "left slot must start at rect.x + TOKEN_PAD");
+    }
+
+    /// Right text must end at (rect.x + rect.width - TOKEN_PAD).
+    #[test]
+    fn right_slot_x_position() {
+        let ctx = RenderCtx::fallback();
+        let s = strip_with_ctx("", "", "RIGHT", ctx);
+        let texts = s.render_text(&wide_rect());
+        assert_eq!(texts.len(), 1);
+
+        let text_w = "RIGHT".chars().count() as f32 * ctx.cell_w();
+        let _expected_x = wide_rect().width - TOKEN_PAD - text_w;
+        let slot_w = wide_rect().width / 3.0;
+        let right_slot_x = slot_w * 2.0;
+        let actual_expected = right_slot_x + slot_w - TOKEN_PAD - text_w;
+
+        assert!(
+            (texts[0].x - actual_expected).abs() < 0.01,
+            "right text x={} expected={actual_expected}",
+            texts[0].x
+        );
+        // Right edge must not exceed rect boundary minus padding.
+        let right_edge = texts[0].x + text_w;
+        assert!(
+            right_edge <= wide_rect().width + 0.01,
+            "right text bleeds past rect boundary: right_edge={right_edge}"
+        );
+    }
+
+    /// Center text must be within the center slot (second third).
+    #[test]
+    fn center_slot_x_is_within_center_third() {
+        let ctx = RenderCtx::fallback();
+        let s = strip_with_ctx("", "CENTER", "", ctx);
+        let texts = s.render_text(&wide_rect());
+        assert_eq!(texts.len(), 1);
+
+        let slot_w = wide_rect().width / 3.0;
+        let center_slot_start = slot_w;
+        let center_slot_end = slot_w * 2.0;
+        let text_w = "CENTER".chars().count() as f32 * ctx.cell_w();
+
+        assert!(
+            texts[0].x >= center_slot_start,
+            "center text starts before center slot: x={}",
+            texts[0].x
+        );
+        assert!(
+            texts[0].x + text_w <= center_slot_end + 0.01,
+            "center text exceeds center slot: x+w={}",
+            texts[0].x + text_w
+        );
+    }
+
+    // ── Widget object-safety ─────────────────────────────────────────────────
+
+    #[test]
+    fn status_strip_is_object_safe() {
+        let s = StatusStrip::new("A", "B", "C");
+        let widget: &dyn Widget = &s;
+        let quads = widget.render_quads(&wide_rect());
+        assert_eq!(quads.len(), 1);
+    }
+
+    // ── Height constant ──────────────────────────────────────────────────────
+
+    #[test]
+    fn height_constant_is_22() {
+        assert_eq!(STATUS_STRIP_HEIGHT, 22.0);
+    }
+}

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,0 +1,174 @@
+# Provider Trait Audit — `ChatBackend` capability matrix
+
+> Issue #19 · audited 2026-04-28 against `crates/phantom-agents/src/chat.rs`
+
+---
+
+## 1. Trait surface (as-shipped)
+
+```rust
+pub trait ChatBackend: Send + Sync {
+    fn name(&self) -> &'static str;
+    fn complete(&self, request: ChatRequest<'_>) -> Result<ChatResponse, ChatError>;
+}
+
+pub struct ChatRequest<'a> {
+    pub agent:        &'a Agent,       // carries system prompt + message history
+    pub tools:        &'a [ToolDefinition],
+    pub tool_use_ids: &'a [String],    // correlate prior tool calls / results
+    pub max_tokens:   u32,
+}
+```
+
+`ChatResponse` wraps `ApiHandle` — a non-blocking `mpsc::Receiver<ApiEvent>` polled
+each render frame. The canonical event vocabulary is:
+
+| Event | Meaning |
+|---|---|
+| `TextDelta(String)` | assistant text chunk |
+| `ToolUse { id, call }` | model invoked a tool |
+| `Done` | stream finished cleanly |
+| `Error(String)` | transport or API error |
+
+---
+
+## 2. Capability audit
+
+### 2.1 Dimensions checked
+
+| # | Capability | Claude | OpenAI | LocalBackend (planned) | Notes |
+|---|---|:---:|:---:|:---:|---|
+| 1 | **Streaming responses** | partial | partial | partial | Both impls use blocking HTTP + full-body parse; events drip via mpsc but the wire is not truly streamed. `ApiEvent::TextDelta` is the right slot — wire streaming is a backend-internal concern and does not require a trait change. |
+| 2 | **Tool use (structured)** | implemented | implemented | polyfillable | Anthropic: `content[].tool_use` blocks. OpenAI: `message.tool_calls[]`. Both translate to `ApiEvent::ToolUse`. Local models (llama.cpp, Ollama): most expose an OpenAI-compatible `/v1/chat/completions`; an `OllamaBackend` can reuse the OpenAI shaping logic verbatim. |
+| 3 | **System prompt** | implemented | implemented | transparent | `agent.system_prompt()` is passed as the top-level Anthropic `system` field (Claude) and a `role:"system"` message (OpenAI). A local backend receives it identically via `request.agent`. No trait change needed. |
+| 4 | **`max_tokens`** | implemented | implemented | transparent | Carried in `ChatRequest::max_tokens`, applied per-request. Local models honour the same field in the OpenAI wire format. |
+| 5 | **Temperature / sampling params** | not exposed | not exposed | not applicable | Neither existing backend exposes temperature. Phantom agents are task-oriented; determinism is preferred. If needed: add `Option<f32>` to `ChatRequest` (non-breaking — see §3). |
+| 6 | **JSON mode / structured output** | not exposed | not exposed | not applicable | OpenAI supports `response_format: { type: "json_object" }`. Claude has no equivalent. Not needed by the current agent loop. If added: a `response_format: Option<ResponseFormat>` field on `ChatRequest`. |
+| 7 | **Vision input (image data)** | not exposed | not exposed | not applicable | Both APIs accept base-64 image content blocks. The agent message history (`AgentMessage`) carries only `String` content; no image variant exists. Not needed today; would require extending `AgentMessage` and the trait together. |
+| 8 | **Audio input** | unsupported | unsupported | unsupported | OpenAI Whisper/Realtime is a separate API surface. Claude has no audio input at present. Out of scope for Phantom agents. |
+| 9 | **Token usage / cost tracking** | not exposed | not exposed | not applicable | Both response bodies contain usage counters (`usage.input_tokens`, etc.). Not parsed today. Could be added as an optional field on a future `ChatMetadata` without changing `ChatBackend`. |
+| 10 | **Retry / rate-limit handling** | not implemented | not implemented | not applicable | HTTP errors are forwarded as `ApiEvent::Error`. Back-off and retry are the caller's responsibility. Could be a wrapper backend (`RetryBackend<B: ChatBackend>`) — no trait change needed. |
+| 11 | **Model ID override at request time** | not exposed | not exposed | not applicable | Model is baked into the backend at construction (`with_model()`). Per-request model selection would require a field on `ChatRequest`. Not a gap for current use. |
+| 12 | **Context window / token budget** | not exposed | not exposed | not applicable | `max_tokens` controls output budget only. Input context is not enforced by the trait; the backend or caller is responsible for truncating message history. |
+
+### 2.2 Summary verdict
+
+**The trait is sufficient for all current functionality and for a `LocalBackend`.**
+
+- The only genuinely missing fields are `temperature` and `response_format`, both optional and additive — they do not require a breaking change.
+- The `ChatRequest` struct is `#[non_exhaustive]` in spirit (all callers construct it inline), so adding `Option<f32>` fields is a one-line non-breaking extension.
+- Vision and audio are out of scope for the agent use-case today.
+
+---
+
+## 3. What a `LocalBackend` needs
+
+A backend targeting **llama.cpp server** or **Ollama** can reuse the existing OpenAI
+request/response shape almost unchanged.
+
+### Minimum viable `LocalBackend`
+
+```rust
+pub struct LocalBackend {
+    /// Base URL, e.g. "http://localhost:11434/v1" (Ollama)
+    /// or "http://localhost:8080/v1" (llama.cpp server).
+    base_url: String,
+    model:    String,
+}
+
+impl ChatBackend for LocalBackend {
+    fn name(&self) -> &'static str { "local" }
+
+    fn complete(&self, request: ChatRequest<'_>) -> Result<ChatResponse, ChatError> {
+        // Reuse build_openai_request_body (already pub(crate)).
+        // POST to {base_url}/chat/completions with no auth header.
+        // Parse with parse_openai_response — Ollama and llama.cpp both
+        // speak the OpenAI wire format.
+        todo!("LocalBackend::complete")
+    }
+}
+```
+
+### Differences from OpenAI
+
+| Concern | Ollama | llama.cpp server | Mitigation |
+|---|---|---|---|
+| Auth header | none required | none required | omit `Authorization` header |
+| TLS | plain HTTP (localhost) | plain HTTP (localhost) | platform verifier still works; or skip TLS entirely |
+| Tool use | models vary (llama3, mistral support it; older don't) | same | caller should pass `tools: &[]` for models without tool support |
+| `stream` field | supported | supported | not needed — both return full body if omitted |
+| Rate limits / 429 | none | none | existing error path is sufficient |
+| Model id format | `"llama3:8b"` etc. | `"default"` or path | pass through as-is |
+
+### `ChatModel` extension (when `LocalBackend` ships)
+
+```rust
+pub enum ChatModel {
+    Claude(String),
+    OpenAi(String),
+    Local { base_url: String, model: String },  // new
+}
+```
+
+And `build_backend` gains a third arm. **No changes to `ChatBackend` trait.**
+
+---
+
+## 4. Optional future extensions (non-breaking)
+
+These can be added to `ChatRequest` as `Option<T>` fields at any time without
+breaking existing callers because all callers construct the struct by name.
+
+| Field | Type | When useful |
+|---|---|---|
+| `temperature` | `Option<f32>` | creative / exploratory agents |
+| `response_format` | `Option<ResponseFormat>` | structured JSON output agents |
+| `stop_sequences` | `Option<Vec<String>>` | output boundary control |
+| `seed` | `Option<u64>` | reproducible test runs |
+
+---
+
+## 5. Trait change decision
+
+**No trait changes made.**
+
+All identified gaps are either:
+- Out of scope for current Phantom agents (vision, audio, JSON mode), or
+- Addable as `Option<T>` fields on `ChatRequest` without touching the trait, or
+- Backend-internal concerns (streaming wire, retry, TLS).
+
+The existing trait is stable and correct.
+
+---
+
+## 6. Provider × Capability matrix (quick reference)
+
+Legend: ✅ implemented · 🟡 polyfillable/planned · ❌ unsupported · — not applicable
+
+| Capability | Claude | OpenAI | LocalBackend (planned) |
+|---|:---:|:---:|:---:|
+| Streaming (event model) | ✅ | ✅ | 🟡 |
+| Tool use | ✅ | ✅ | 🟡 (model-dependent) |
+| System prompt | ✅ | ✅ | 🟡 |
+| max_tokens | ✅ | ✅ | 🟡 |
+| Temperature | — | — | — |
+| JSON mode | — | — | — |
+| Vision input | ❌ | ❌ | ❌ |
+| Audio input | ❌ | ❌ | ❌ |
+| Token usage reporting | — | — | — |
+| Per-request model id | — | — | — |
+| Retry / back-off | — | — | — |
+
+---
+
+## 7. Test coverage (no new tests required)
+
+The existing test suite in `chat.rs` covers:
+- `ClaudeBackend` and `OpenAiChatBackend` construct and name correctly
+- `build_openai_request_body` shape (system, user, tools, tool_choice)
+- `parse_openai_response` for text-only, tool-use, API error, unknown tool
+- Tool-use round-trip (call → result → next request `tool_call_id` propagation)
+- `ChatModel::from_env_str` parser
+
+A `LocalBackend` will add unit tests following the same pattern as the OpenAI
+backend (inject a synthetic `mpsc::Receiver<ApiEvent>` without hitting the network).


### PR DESCRIPTION
## Summary

- Adds `crates/phantom-ui/src/widgets/message_block.rs` with the `MessageBlock` widget and `MessageRole` enum
- Registers the module in `crates/phantom-ui/src/widgets/mod.rs` with public re-exports
- 5 roles (User, Agent, System, ToolUse, ToolResult) each mapped to a distinct semantic token color (text_primary, text_accent, text_secondary, status_info, status_ok)
- 16 px avatar glyph column, role label row, body text that word-wraps honoring `RenderCtx::cell_w()`
- Height auto-computes as `(1 + wrapped_line_count) * cell_h`
- Implements `Widget` trait (`render_quads` / `render_text`)

## Test plan

- [x] `cargo test -p phantom-ui --lib -- widgets::message_block` → 25/25 pass
- [x] All 112 existing `phantom-ui` tests continue to pass
- [x] role→color mapping: each role asserts exact token color
- [x] height growth: single-line = 2 rows, multiline = 1 + N rows, empty = 1 row
- [x] wrap at word boundary, hard-break when no space, degenerate zero-width rect
- [x] avatar initial and label use role color, body uses text_primary
- [x] all role initials and colors are distinct
- [x] `render_quads` height matches `compute_height`

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)