### PR TITLE
feat(#21): StatusStrip widget

### DIFF
--- a/crates/phantom-ui/src/widgets/status_strip.rs
+++ b/crates/phantom-ui/src/widgets/status_strip.rs
@@ -468,7 +468,6 @@ mod tests {
         assert_eq!(texts.len(), 1);
 
         let text_w = "RIGHT".chars().count() as f32 * ctx.cell_w();
-        let _expected_x = wide_rect().width - TOKEN_PAD - text_w;
         let slot_w = wide_rect().width / 3.0;
         let right_slot_x = slot_w * 2.0;
         let actual_expected = right_slot_x + slot_w - TOKEN_PAD - text_w;

--- a/crates/phantom-ui/src/widgets/status_strip.rs
+++ b/crates/phantom-ui/src/widgets/status_strip.rs
@@ -140,6 +140,8 @@ impl StatusStrip {
     /// Pixel budget (in chars) available inside a slot after padding.
     fn chars_in_slot(&self, slot_w: f32) -> usize {
         let inner = (slot_w - TOKEN_PAD * 2.0).max(0.0);
+        // Floor division (truncating cast) is intentional: we must not render a
+        // partial character that would overflow the slot's pixel boundary.
         (inner / self.ctx.cell_w()) as usize
     }
 }
@@ -406,6 +408,26 @@ mod tests {
         );
     }
 
+    /// A rect with width 0 must not panic and must produce no text segments.
+    /// Every slot's inner budget is ≤ 0, so `chars_in_slot` returns 0 and all
+    /// content is suppressed by `truncate`.
+    #[test]
+    fn zero_width_rect_produces_no_text_and_does_not_panic() {
+        let ctx = RenderCtx::fallback();
+        let s = strip_with_ctx("LEFT", "CENTER", "RIGHT", ctx);
+        let zero_rect = Rect { x: 0.0, y: 980.0, width: 0.0, height: STATUS_STRIP_HEIGHT };
+        // Must not panic.
+        let texts = s.render_text(&zero_rect);
+        assert!(
+            texts.is_empty(),
+            "zero-width rect should produce no text segments, got {}",
+            texts.len()
+        );
+        // Background quad should still be emitted (zero-area is valid for the renderer).
+        let quads = s.render_quads(&zero_rect);
+        assert_eq!(quads.len(), 1, "background quad must always be emitted");
+    }
+
     /// At 300 px total with an 8 px cell: each slot = 100 px, inner = 84 px,
     /// max_chars = 10. A 15-char string must be truncated to ≤10 chars and
     /// end with `…`.
@@ -485,7 +507,13 @@ mod tests {
         );
     }
 
-    /// Center text must be within the center slot (second third).
+    /// Center text must be within the center slot (second third) AND must be
+    /// symmetrically placed — equidistant from the left and right edges of that
+    /// slot (within 1 px for integer-rounding tolerance).
+    ///
+    /// The containment check alone would silently pass even if the text were
+    /// flush-left inside the slot. The symmetry assertion below catches that
+    /// regression.
     #[test]
     fn center_slot_x_is_within_center_third() {
         let ctx = RenderCtx::fallback();
@@ -498,6 +526,7 @@ mod tests {
         let center_slot_end = slot_w * 2.0;
         let text_w = "CENTER".chars().count() as f32 * ctx.cell_w();
 
+        // ── Containment ──────────────────────────────────────────────────────
         assert!(
             texts[0].x >= center_slot_start,
             "center text starts before center slot: x={}",
@@ -507,6 +536,17 @@ mod tests {
             texts[0].x + text_w <= center_slot_end + 0.01,
             "center text exceeds center slot: x+w={}",
             texts[0].x + text_w
+        );
+
+        // ── Symmetry ─────────────────────────────────────────────────────────
+        // Distance from the text's left edge to the slot's left edge must equal
+        // the distance from the text's right edge to the slot's right edge (±1 px).
+        let gap_left = texts[0].x - center_slot_start;
+        let gap_right = center_slot_end - (texts[0].x + text_w);
+        assert!(
+            (gap_left - gap_right).abs() <= 1.0,
+            "center text is not symmetric within its slot: \
+             gap_left={gap_left:.2} gap_right={gap_right:.2} (must be equal ±1 px)"
         );
     }
 


### PR DESCRIPTION
## Summary

- Adds `crates/phantom-ui/src/widgets/status_strip.rs` — a fixed-height (22 px) horizontal status strip with left / center / right slots, ellipsis truncation on overflow, and full token compliance.
- Registers and re-exports `StatusStrip` / `STATUS_STRIP_HEIGHT` in `crates/phantom-ui/src/widgets/mod.rs`.

## Implementation details

- `StatusStrip { left, center, right, ctx }` — each slot is a plain `String`; `RenderCtx` provides live cell metrics so truncation math scales with font size.
- Width is divided into three equal thirds. Left is flush-left, center is horizontally centered within its slot, right is flush-right.
- `truncate(text, max_chars)` appends the Unicode ellipsis character `…` (single code point) when truncation occurs; returns empty when budget = 0.
- Background color: `tokens.colors.surface_recessed`. Foreground: `tokens.colors.text_secondary`. No hardcoded RGBA constants in production code paths.
- Implements `Widget` trait (`render_quads` + `render_text`), `Default`, `Debug`, `Clone`.

## Test plan

- [x] 22 unit tests covering: construction, slot setters, quad emission, token-color compliance, all three positioning rules, truncation edge cases (zero budget, budget=1, exact fit, overflow), narrow-strip suppression, medium-width non-truncation, `Widget` object safety, `STATUS_STRIP_HEIGHT` constant value.
- [x] `cargo test -p phantom-ui` → **161 passed; 0 failed** (full suite, pre-existing workspace dep errors in unrelated crates are not introduced by this PR).

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)