### PR TITLE
feat(#14): auto-skip boot animation on session restore

### DIFF
--- a/crates/phantom-app/src/app.rs
+++ b/crates/phantom-app/src/app.rs
@@ -37,7 +37,7 @@ use phantom_memory::MemoryStore;
 use phantom_plugins::PluginRegistry;
 use phantom_scene::node::{NodeKind, RenderLayer};
 use phantom_scene::tree::SceneTree;
-use phantom_session::session::{SessionManager, SessionState, PaneState};
+use phantom_session::session::{is_session_restore, SessionManager, SessionState, PaneState};
 use phantom_mcp::{spawn_listener, AppCommand, McpListener};
 
 use crate::boot::BootSequence;
@@ -345,7 +345,7 @@ impl App {
     /// Font size is multiplied by this to render at the correct visual size.
     pub fn with_config_scaled(
         gpu: GpuContext,
-        config: PhantomConfig,
+        mut config: PhantomConfig,
         supervisor_socket: Option<&Path>,
         scale_factor: f32,
     ) -> Result<Self> {
@@ -516,6 +516,17 @@ impl App {
                 None
             }
         };
+
+        // Auto-detect session restore: skip boot animation when a previous
+        // session exists for this project or PHANTOM_RESTORING=1 is set.
+        // Checked before the boot block below reads `config.skip_boot`.
+        if !config.skip_boot {
+            let session_dir = SessionManager::session_dir_path();
+            if is_session_restore(&session_dir, &project_dir) {
+                log::info!("Session restore detected — auto-skipping boot animation");
+                config.skip_boot = true;
+            }
+        }
 
         // Try to restore the most recent session for this project.
         if let Some(ref sm) = session_manager {

--- a/crates/phantom-app/src/config.rs
+++ b/crates/phantom-app/src/config.rs
@@ -120,6 +120,12 @@ impl PhantomConfig {
                             config.shader_overrides.noise_intensity = Some(v);
                         }
                     }
+                    "skip_boot" => {
+                        config.skip_boot = matches!(value, "true" | "1" | "yes");
+                    }
+                    "demo_mode" => {
+                        config.demo_mode = matches!(value, "true" | "1" | "yes");
+                    }
                     _ => {
                         warn!("Unknown config key: {key}");
                     }
@@ -204,4 +210,63 @@ font_size = 14.0
 # curvature = 0.06
 # vignette_intensity = 0.20
 # noise_intensity = 0.02
+
+# Boot animation (also auto-skipped on session restore)
+# skip_boot = false
 "#;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_skip_boot_is_false() {
+        let config = PhantomConfig::default();
+        assert!(!config.skip_boot, "cold-launch default must not skip boot");
+    }
+
+    #[test]
+    fn parse_skip_boot_true() {
+        let config = PhantomConfig::parse("skip_boot = true").unwrap();
+        assert!(config.skip_boot);
+    }
+
+    #[test]
+    fn parse_skip_boot_one() {
+        let config = PhantomConfig::parse("skip_boot = 1").unwrap();
+        assert!(config.skip_boot);
+    }
+
+    #[test]
+    fn parse_skip_boot_false() {
+        let config = PhantomConfig::parse("skip_boot = false").unwrap();
+        assert!(!config.skip_boot);
+    }
+
+    #[test]
+    fn parse_empty_config_yields_defaults() {
+        let config = PhantomConfig::parse("").unwrap();
+        assert!(!config.skip_boot);
+        assert!(!config.demo_mode);
+        assert_eq!(config.theme_name, "phosphor");
+    }
+
+    #[test]
+    fn parse_ignores_comments_and_blank_lines() {
+        let toml = "# This is a comment\n\nskip_boot = true\n";
+        let config = PhantomConfig::parse(toml).unwrap();
+        assert!(config.skip_boot);
+    }
+
+    #[test]
+    fn parse_theme_and_font_size() {
+        let toml = "theme = \"amber\"\nfont_size = 16.0\n";
+        let config = PhantomConfig::parse(toml).unwrap();
+        assert_eq!(config.theme_name, "amber");
+        assert!((config.font_size - 16.0).abs() < f32::EPSILON);
+    }
+}

--- a/crates/phantom-session/src/session.rs
+++ b/crates/phantom-session/src/session.rs
@@ -84,6 +84,20 @@ pub struct SessionManager {
 }
 
 impl SessionManager {
+    /// Return the default session directory path without creating it.
+    ///
+    /// Falls back to `"."` as an absolute last resort when `HOME` is unset.
+    pub fn session_dir_path() -> PathBuf {
+        if let Ok(home) = std::env::var("HOME") {
+            PathBuf::from(home)
+                .join(".config")
+                .join("phantom")
+                .join("sessions")
+        } else {
+            PathBuf::from(".")
+        }
+    }
+
     /// Create a session manager using the default session directory
     /// (`~/.config/phantom/sessions/`).
     pub fn new() -> Result<Self> {
@@ -292,6 +306,61 @@ fn now_epoch() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or(std::time::Duration::ZERO)
         .as_secs()
+}
+
+// ---------------------------------------------------------------------------
+// Session-restore detection
+// ---------------------------------------------------------------------------
+
+/// Returns `true` when this launch should skip the boot animation.
+///
+/// Two signals trigger a restore:
+/// 1. `PHANTOM_RESTORING=1` environment variable — set by the supervisor or a
+///    launch script when restarting after a crash or explicit restore.
+/// 2. A `{hash}_{timestamp}.json` session file exists in `session_dir` for
+///    `project_dir` — the normal case after a clean shutdown + re-launch.
+///
+/// The check is cheap: only filenames are inspected, no JSON is parsed.
+/// Returns `false` on any I/O error so the caller never has to handle an
+/// error just to decide whether to show the boot animation.
+pub fn is_session_restore(session_dir: &Path, project_dir: &str) -> bool {
+    is_session_restore_with_env(
+        session_dir,
+        project_dir,
+        std::env::var("PHANTOM_RESTORING").ok().as_deref(),
+    )
+}
+
+/// Inner implementation that accepts the env-var value as a parameter.
+///
+/// Separate from [`is_session_restore`] so tests can inject the value without
+/// mutating the process environment (which is unsafe in Rust 2024 and racy
+/// across parallel test threads).
+fn is_session_restore_with_env(
+    session_dir: &Path,
+    project_dir: &str,
+    phantom_restoring: Option<&str>,
+) -> bool {
+    if phantom_restoring == Some("1") {
+        return true;
+    }
+
+    let hash = project_hash(project_dir);
+    let prefix = format!("{hash}_");
+
+    let Ok(entries) = fs::read_dir(session_dir) else {
+        return false;
+    };
+
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if name.starts_with(&prefix) && name.ends_with(".json") {
+            return true;
+        }
+    }
+
+    false
 }
 
 // ---------------------------------------------------------------------------
@@ -704,5 +773,97 @@ mod tests {
         assert!(msg.contains("feature/agents"));
         assert!(msg.contains("2 panes"));
         assert!(msg.contains("Wiring the scene graph"));
+    }
+
+    // =======================================================================
+    // is_session_restore — boot-skip detection
+    // =======================================================================
+
+    #[test]
+    fn session_restore_cold_launch_no_files() {
+        let dir = TempDir::new().unwrap();
+        assert!(
+            !is_session_restore_with_env(dir.path(), "/home/dev/phantom", None),
+            "empty session dir must not be detected as a restore"
+        );
+    }
+
+    #[test]
+    fn session_restore_detects_existing_session_file() {
+        let dir = TempDir::new().unwrap();
+        let project_dir = "/home/dev/phantom";
+        let hash = project_hash(project_dir);
+        let filename = format!("{hash}_1700000000.json");
+        fs::write(dir.path().join(&filename), r#"{"version":1}"#).unwrap();
+        assert!(
+            is_session_restore_with_env(dir.path(), project_dir, None),
+            "session file for this project must trigger restore detection"
+        );
+    }
+
+    #[test]
+    fn session_restore_ignores_other_project_session_files() {
+        let dir = TempDir::new().unwrap();
+        let other_dir = "/home/dev/other-project";
+        let hash = project_hash(other_dir);
+        let filename = format!("{hash}_1700000000.json");
+        fs::write(dir.path().join(&filename), r#"{"version":1}"#).unwrap();
+        assert!(
+            !is_session_restore_with_env(dir.path(), "/home/dev/phantom", None),
+            "session file for another project must not trigger restore for the current project"
+        );
+    }
+
+    #[test]
+    fn session_restore_matches_only_own_project() {
+        let dir = TempDir::new().unwrap();
+        let our_dir = "/home/dev/phantom";
+        let other_dir = "/home/dev/other";
+        let our_hash = project_hash(our_dir);
+        let other_hash = project_hash(other_dir);
+        fs::write(
+            dir.path().join(format!("{our_hash}_1700000001.json")),
+            r#"{"version":1}"#,
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join(format!("{other_hash}_1700000002.json")),
+            r#"{"version":1}"#,
+        )
+        .unwrap();
+        assert!(is_session_restore_with_env(dir.path(), our_dir, None));
+        assert!(is_session_restore_with_env(dir.path(), other_dir, None));
+    }
+
+    #[test]
+    fn session_restore_env_var_overrides() {
+        let dir = TempDir::new().unwrap();
+        assert!(
+            is_session_restore_with_env(dir.path(), "/home/dev/phantom", Some("1")),
+            "PHANTOM_RESTORING=1 must signal restore even with an empty session directory"
+        );
+    }
+
+    #[test]
+    fn session_restore_env_var_must_be_exactly_one() {
+        let dir = TempDir::new().unwrap();
+        assert!(
+            !is_session_restore_with_env(dir.path(), "/home/dev/phantom", Some("true")),
+            "PHANTOM_RESTORING=true must not trigger restore"
+        );
+        assert!(
+            !is_session_restore_with_env(dir.path(), "/home/dev/phantom", Some("")),
+            "PHANTOM_RESTORING= must not trigger restore"
+        );
+    }
+
+    #[test]
+    fn session_restore_missing_directory_returns_false() {
+        let nonexistent =
+            std::path::Path::new("/tmp/phantom-sessions-nonexistent-a3f9b2c1d4e5f607");
+        assert!(
+            !is_session_restore_with_env(nonexistent, "/home/dev/phantom", None),
+            "missing session dir must return false without panicking"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #14

- **Detection**: `is_session_restore()` in `phantom-session` checks two signals: presence of a `{hash}_{timestamp}.json` session file for the current project directory, or `PHANTOM_RESTORING=1` env var (set by supervisor on crash-restart). Filename scan only — no JSON parsing.
- **Config auto-set**: `App::with_config_scaled` detects restore before the boot block and sets `config.skip_boot = true`, bypassing the ~5s cinematic on every non-first launch.
- **Config parser**: `skip_boot` and `demo_mode` keys now parse from `config.toml` (previously fields existed but were never read from file).
- **Bonus fix**: pre-existing `total_node_count` compile error in `coordinator.rs` tests resolved (`→ pane_count`).

## Test plan

- [x] `cargo test -p phantom-session -p phantom-app --lib` → **294 passed, 0 failed**
- [x] `phantom-session`: 7 new `is_session_restore` tests (cold launch, session found, other-project ignored, env var override, env var wrong value, missing dir)
- [x] `phantom-app/config`: 7 new parse tests (default false, `skip_boot = true/1/false`, empty config, comments, theme+font_size)
- [x] Cold launch (no session file): boot animation plays normally
- [x] Restore launch (session file present): boot animation skipped, goes straight to terminal
- [x] `PHANTOM_RESTORING=1`: boot animation skipped regardless of session files

🤖 Generated with [Claude Code](https://claude.com/claude-code)