### PR TITLE
feat(#20): Panel widget (clean)

### DIFF
--- a/crates/phantom-ui/src/widgets/mod.rs
+++ b/crates/phantom-ui/src/widgets/mod.rs
@@ -20,6 +20,10 @@ pub use notification_banner::{
     BannerSeverity, NotificationBanner, NOTIFICATION_BANNER_HEIGHT,
 };
 
+// Issue #20 — generic bordered panel with optional title bar.
+pub mod panel;
+pub use panel::{Panel, TITLE_BAR_HEIGHT};
+
 // -----------------------------------------------------------------------
 // Color palette
 // -----------------------------------------------------------------------


### PR DESCRIPTION
Closes #20

Replaces PR #116 — fresh branch to eliminate contamination.

## What changed

**Files changed: 1**

`crates/phantom-ui/src/widgets/mod.rs` — 4 lines added:
- `pub mod panel;`
- `pub use panel::{Panel, TITLE_BAR_HEIGHT};`

`panel.rs` was already present on `main` (landed separately); this PR adds the missing public re-export so `phantom_ui::widgets::Panel` and `phantom_ui::widgets::TITLE_BAR_HEIGHT` are part of the crate's public surface.

## Tests

`cargo test -p phantom-ui` → **138 passed, 0 failed** (includes all 20 Panel unit tests in `panel.rs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)