### PR TITLE
feat(#25,#23,#30): TabStrip, InputBar, FocusRing widgets

### DIFF
--- a/crates/phantom-ui/src/tokens.rs
+++ b/crates/phantom-ui/src/tokens.rs
@@ -30,6 +30,11 @@ pub struct ColorRoles {
     /// alpha channel stored here is the *base* alpha — callers may further
     /// modulate it (e.g. dim when the pane loses focus).
     pub selection_bg: [f32; 4],
+    /// Focus ring / keyboard-navigation outline color.
+    ///
+    /// Used by [`FocusRing`](crate::widgets::focus_ring::FocusRing) as the
+    /// 2 px outline drawn around the focused pane or widget.
+    pub accent_focus: [f32; 4],
 }
 
 impl ColorRoles {
@@ -53,6 +58,9 @@ impl ColorRoles {
             status_info: [0.40, 0.85, 1.00, 1.00],
             // Phosphor green at 50 % alpha — legible without hiding text.
             selection_bg: [0.30, 1.00, 0.55, 0.50],
+            // Bright cyan-green focus outline — high contrast on the phosphor
+            // background without clashing with the green text palette.
+            accent_focus: [0.20, 0.90, 1.00, 1.00],
         }
     }
 }
@@ -165,6 +173,13 @@ mod tests {
         // Must exist and be semi-transparent (alpha in 0..1 exclusive).
         let a = r.selection_bg[3];
         assert!(a > 0.0 && a < 1.0, "selection_bg alpha must be semi-transparent, got {a}");
+    }
+
+    #[test]
+    fn accent_focus_token_is_opaque_and_bright() {
+        let r = ColorRoles::phosphor();
+        assert_eq!(r.accent_focus[3], 1.0, "accent_focus alpha must be 1.0 (opaque)");
+        assert!(r.accent_focus[2] > 0.5, "accent_focus should have elevated blue channel");
     }
 }
 

--- a/crates/phantom-ui/src/widgets/focus_ring.rs
+++ b/crates/phantom-ui/src/widgets/focus_ring.rs
@@ -5,7 +5,7 @@
 //! to avoid jarring visual pops.
 //!
 //! The widget is associated with a specific pane via [`phantom_adapter::AppId`]
-//! so the caller can cycle focus across panes by updating [`FocusRing::focused`].
+//! so the caller can cycle focus across panes by calling [`FocusRing::set_focused`].
 //! When `focused` is `None` the ring is invisible (alpha = 0).
 //!
 //! Corner radius matches `tokens.radius_sm()` (2 px by default).
@@ -62,7 +62,7 @@ const RING_THICKNESS: f32 = 2.0;
 #[derive(Debug, Clone)]
 pub struct FocusRing {
     /// The pane that currently has focus, or `None` when no pane is focused.
-    pub focused: Option<AppId>,
+    focused: Option<AppId>,
     /// Animation opacity — 0.0 (invisible) to 1.0 (fully opaque).
     opacity: f32,
     /// Previous focus for detecting transitions.
@@ -91,6 +91,11 @@ impl FocusRing {
     /// Update the live render context.
     pub fn set_render_ctx(&mut self, ctx: RenderCtx) {
         self.ctx = ctx;
+    }
+
+    /// The pane that currently has focus, or `None` when no pane is focused.
+    pub fn focused(&self) -> Option<AppId> {
+        self.focused
     }
 
     /// Return the current animated opacity in `[0.0, 1.0]`.
@@ -207,7 +212,7 @@ mod tests {
     #[test]
     fn new_is_unfocused_and_invisible() {
         let ring = FocusRing::new();
-        assert!(ring.focused.is_none());
+        assert!(ring.focused().is_none());
         assert_eq!(ring.opacity(), 0.0);
     }
 
@@ -215,8 +220,8 @@ mod tests {
     fn default_matches_new() {
         let a = FocusRing::new();
         let b = FocusRing::default();
-        assert_eq!(a.focused, b.focused);
-        assert_eq!(a.opacity, b.opacity);
+        assert_eq!(a.focused(), b.focused());
+        assert_eq!(a.opacity(), b.opacity());
     }
 
     // ── Focus state ───────────────────────────────────────────────────────────
@@ -225,7 +230,7 @@ mod tests {
     fn set_focused_updates_id() {
         let mut ring = FocusRing::new();
         ring.set_focused(Some(7));
-        assert_eq!(ring.focused, Some(7));
+        assert_eq!(ring.focused(), Some(7));
     }
 
     #[test]
@@ -233,7 +238,7 @@ mod tests {
         let mut ring = FocusRing::new();
         ring.set_focused(Some(1));
         ring.set_focused(None);
-        assert!(ring.focused.is_none());
+        assert!(ring.focused().is_none());
     }
 
     // ── Animation ────────────────────────────────────────────────────────────
@@ -388,13 +393,13 @@ mod tests {
         let mut ring = FocusRing::new();
         ring.set_focused(Some(1));
         ring.tick(FADE_DURATION_MS);
-        assert_eq!(ring.focused, Some(1));
+        assert_eq!(ring.focused(), Some(1));
         assert_eq!(ring.opacity(), 1.0);
 
         ring.set_focused(Some(2));
         // Opacity stays at 1.0 (still focused, just different pane).
         ring.tick(0.0);
-        assert_eq!(ring.focused, Some(2));
+        assert_eq!(ring.focused(), Some(2));
         assert_eq!(ring.opacity(), 1.0);
     }
 }

--- a/crates/phantom-ui/src/widgets/focus_ring.rs
+++ b/crates/phantom-ui/src/widgets/focus_ring.rs
@@ -1,0 +1,400 @@
+//! Issue #30 — `FocusRing` overlay widget.
+//!
+//! Draws a 2 px outline around the focused pane using `colors.accent_focus`
+//! from the token table. The ring fades in/out over 100 ms when focus changes
+//! to avoid jarring visual pops.
+//!
+//! The widget is associated with a specific pane via [`phantom_adapter::AppId`]
+//! so the caller can cycle focus across panes by updating [`FocusRing::focused`].
+//! When `focused` is `None` the ring is invisible (alpha = 0).
+//!
+//! Corner radius matches `tokens.radius_sm()` (2 px by default).
+//!
+//! # Animation model
+//!
+//! [`FocusRing`] tracks a `[0.0, 1.0]` opacity that lerps toward the target
+//! each frame:
+//! - Focus gained → target = 1.0, ramps up over [`FADE_DURATION_MS`].
+//! - Focus lost  → target = 0.0, ramps down over [`FADE_DURATION_MS`].
+//!
+//! Call [`FocusRing::tick`] once per frame with the elapsed milliseconds.
+//!
+//! # Examples
+//!
+//! ```rust,ignore
+//! use phantom_ui::widgets::focus_ring::FocusRing;
+//!
+//! let mut ring = FocusRing::new();
+//! ring.set_focused(Some(42)); // pane with AppId 42 gains focus
+//! ring.tick(50);              // advance 50 ms → half-way through fade-in
+//! let quads = ring.render_quads(&rect);
+//! ```
+
+use phantom_adapter::AppId;
+
+use crate::layout::Rect;
+use crate::render_ctx::RenderCtx;
+use crate::tokens::Tokens;
+use crate::widgets::{TextSegment, Widget};
+use phantom_renderer::quads::QuadInstance;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Fade-in / fade-out duration in milliseconds.
+pub const FADE_DURATION_MS: f32 = 100.0;
+
+/// Thickness of the focus outline in pixels (2 px per spec).
+const RING_THICKNESS: f32 = 2.0;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FocusRing
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Animated focus-ring overlay.
+///
+/// Wraps an optional [`AppId`] (the ID assigned by the adapter registry) so
+/// the application layer can cycle focus without this widget knowing anything
+/// about pane layout.
+///
+/// Derive `Debug` manually because `AppId = u32` is `Debug`-able.
+#[derive(Debug, Clone)]
+pub struct FocusRing {
+    /// The pane that currently has focus, or `None` when no pane is focused.
+    pub focused: Option<AppId>,
+    /// Animation opacity — 0.0 (invisible) to 1.0 (fully opaque).
+    opacity: f32,
+    /// Previous focus for detecting transitions.
+    prev_focused: Option<AppId>,
+    /// Live render metrics.
+    ctx: RenderCtx,
+}
+
+impl FocusRing {
+    /// Create a [`FocusRing`] with no pane focused (fully invisible).
+    pub fn new() -> Self {
+        Self {
+            focused: None,
+            opacity: 0.0,
+            prev_focused: None,
+            ctx: RenderCtx::fallback(),
+        }
+    }
+
+    /// Update the focused pane. If the new value differs from the current one
+    /// the animation immediately starts transitioning toward the new target.
+    pub fn set_focused(&mut self, id: Option<AppId>) {
+        self.focused = id;
+    }
+
+    /// Update the live render context.
+    pub fn set_render_ctx(&mut self, ctx: RenderCtx) {
+        self.ctx = ctx;
+    }
+
+    /// Return the current animated opacity in `[0.0, 1.0]`.
+    pub fn opacity(&self) -> f32 {
+        self.opacity
+    }
+
+    /// Advance the animation by `dt_ms` milliseconds.
+    ///
+    /// The opacity moves linearly toward `1.0` when a pane is focused and
+    /// toward `0.0` when no pane is focused. One full transition (0 → 1 or
+    /// 1 → 0) takes [`FADE_DURATION_MS`] milliseconds.
+    pub fn tick(&mut self, dt_ms: f32) {
+        // Detect a focus change and reset the transition direction.
+        if self.focused != self.prev_focused {
+            self.prev_focused = self.focused;
+        }
+
+        let target = if self.focused.is_some() { 1.0_f32 } else { 0.0_f32 };
+        let step = dt_ms / FADE_DURATION_MS;
+
+        self.opacity = if target > self.opacity {
+            (self.opacity + step).min(1.0)
+        } else {
+            (self.opacity - step).max(0.0)
+        };
+    }
+
+    // ── Private ───────────────────────────────────────────────────────────────
+
+    /// Modulate the `accent_focus` token color by the current animated opacity.
+    fn ring_color(&self, tokens: &Tokens) -> [f32; 4] {
+        let c = tokens.colors.accent_focus;
+        [c[0], c[1], c[2], c[3] * self.opacity]
+    }
+}
+
+impl Default for FocusRing {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Widget for FocusRing {
+    /// Emit four border quads forming the ring outline.
+    ///
+    /// Each quad is `RING_THICKNESS` pixels wide (top / bottom) or tall
+    /// (left / right), with the same corner radius as `tokens.radius_sm()`.
+    /// When `opacity == 0.0` (no pane focused or fade-out complete) the quads
+    /// have zero alpha and are invisible — but are still emitted so the
+    /// renderer pipeline stays constant.
+    fn render_quads(&self, rect: &Rect) -> Vec<QuadInstance> {
+        let t = Tokens::phosphor(self.ctx);
+        let color = self.ring_color(&t);
+        let r = t.radius_sm();
+
+        // Four border quads (top, bottom, left, right).
+        vec![
+            // Top
+            QuadInstance {
+                pos: [rect.x, rect.y],
+                size: [rect.width, RING_THICKNESS],
+                color,
+                border_radius: r,
+            },
+            // Bottom
+            QuadInstance {
+                pos: [rect.x, rect.y + rect.height - RING_THICKNESS],
+                size: [rect.width, RING_THICKNESS],
+                color,
+                border_radius: r,
+            },
+            // Left
+            QuadInstance {
+                pos: [rect.x, rect.y],
+                size: [RING_THICKNESS, rect.height],
+                color,
+                border_radius: r,
+            },
+            // Right
+            QuadInstance {
+                pos: [rect.x + rect.width - RING_THICKNESS, rect.y],
+                size: [RING_THICKNESS, rect.height],
+                color,
+                border_radius: r,
+            },
+        ]
+    }
+
+    /// The focus ring has no text content.
+    fn render_text(&self, _rect: &Rect) -> Vec<TextSegment> {
+        Vec::new()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::render_ctx::RenderCtx;
+    use crate::tokens::Tokens;
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn ring_rect() -> Rect {
+        Rect { x: 10.0, y: 20.0, width: 400.0, height: 300.0 }
+    }
+
+    // ── Construction ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn new_is_unfocused_and_invisible() {
+        let ring = FocusRing::new();
+        assert!(ring.focused.is_none());
+        assert_eq!(ring.opacity(), 0.0);
+    }
+
+    #[test]
+    fn default_matches_new() {
+        let a = FocusRing::new();
+        let b = FocusRing::default();
+        assert_eq!(a.focused, b.focused);
+        assert_eq!(a.opacity, b.opacity);
+    }
+
+    // ── Focus state ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn set_focused_updates_id() {
+        let mut ring = FocusRing::new();
+        ring.set_focused(Some(7));
+        assert_eq!(ring.focused, Some(7));
+    }
+
+    #[test]
+    fn clear_focused_sets_none() {
+        let mut ring = FocusRing::new();
+        ring.set_focused(Some(1));
+        ring.set_focused(None);
+        assert!(ring.focused.is_none());
+    }
+
+    // ── Animation ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn tick_with_focus_increases_opacity() {
+        let mut ring = FocusRing::new();
+        ring.set_focused(Some(1));
+        ring.tick(50.0); // 50 ms → 50 % of 100 ms = 0.5
+        assert!((ring.opacity() - 0.5).abs() < 0.01, "expected ~0.5, got {}", ring.opacity());
+    }
+
+    #[test]
+    fn tick_full_duration_reaches_full_opacity() {
+        let mut ring = FocusRing::new();
+        ring.set_focused(Some(1));
+        ring.tick(FADE_DURATION_MS);
+        assert_eq!(ring.opacity(), 1.0);
+    }
+
+    #[test]
+    fn tick_over_full_duration_clamps_at_one() {
+        let mut ring = FocusRing::new();
+        ring.set_focused(Some(1));
+        ring.tick(FADE_DURATION_MS * 5.0);
+        assert_eq!(ring.opacity(), 1.0);
+    }
+
+    #[test]
+    fn tick_without_focus_decreases_opacity() {
+        let mut ring = FocusRing::new();
+        ring.set_focused(Some(1));
+        ring.tick(FADE_DURATION_MS); // fully visible
+        ring.set_focused(None);
+        ring.tick(50.0); // fade out 50 ms → 0.5
+        assert!((ring.opacity() - 0.5).abs() < 0.01, "expected ~0.5, got {}", ring.opacity());
+    }
+
+    #[test]
+    fn tick_fade_out_reaches_zero() {
+        let mut ring = FocusRing::new();
+        ring.set_focused(Some(1));
+        ring.tick(FADE_DURATION_MS);
+        ring.set_focused(None);
+        ring.tick(FADE_DURATION_MS);
+        assert_eq!(ring.opacity(), 0.0);
+    }
+
+    // ── Quad rendering ────────────────────────────────────────────────────────
+
+    #[test]
+    fn always_emits_four_quads() {
+        // Invisible ring still emits quads (constant pipeline).
+        let ring = FocusRing::new();
+        let quads = ring.render_quads(&ring_rect());
+        assert_eq!(quads.len(), 4, "focus ring must emit exactly 4 border quads");
+    }
+
+    #[test]
+    fn unfocused_ring_has_zero_alpha() {
+        let ring = FocusRing::new(); // opacity = 0.0
+        let quads = ring.render_quads(&ring_rect());
+        for quad in &quads {
+            assert_eq!(quad.color[3], 0.0, "unfocused ring alpha must be 0");
+        }
+    }
+
+    #[test]
+    fn fully_focused_ring_uses_accent_focus_color() {
+        let ctx = RenderCtx::fallback();
+        let t = Tokens::phosphor(ctx);
+        let mut ring = FocusRing::new();
+        ring.set_focused(Some(1));
+        ring.tick(FADE_DURATION_MS); // opacity = 1.0
+        let quads = ring.render_quads(&ring_rect());
+        // All quads should have the accent_focus color (rgb channels match).
+        for quad in &quads {
+            assert!((quad.color[0] - t.colors.accent_focus[0]).abs() < 0.001);
+            assert!((quad.color[1] - t.colors.accent_focus[1]).abs() < 0.001);
+            assert!((quad.color[2] - t.colors.accent_focus[2]).abs() < 0.001);
+            assert_eq!(quad.color[3], 1.0, "fully focused ring alpha must be 1.0");
+        }
+    }
+
+    #[test]
+    fn ring_border_radius_matches_radius_sm_token() {
+        let ctx = RenderCtx::fallback();
+        let t = Tokens::phosphor(ctx);
+        let ring = FocusRing::new();
+        let quads = ring.render_quads(&ring_rect());
+        for quad in &quads {
+            assert_eq!(quad.border_radius, t.radius_sm());
+        }
+    }
+
+    #[test]
+    fn ring_thickness_is_two_pixels() {
+        let ring = FocusRing::new();
+        let rect = ring_rect();
+        let quads = ring.render_quads(&rect);
+        // Top and bottom quads: height == RING_THICKNESS.
+        assert!((quads[0].size[1] - RING_THICKNESS).abs() < 0.01, "top ring height");
+        assert!((quads[1].size[1] - RING_THICKNESS).abs() < 0.01, "bottom ring height");
+        // Left and right quads: width == RING_THICKNESS.
+        assert!((quads[2].size[0] - RING_THICKNESS).abs() < 0.01, "left ring width");
+        assert!((quads[3].size[0] - RING_THICKNESS).abs() < 0.01, "right ring width");
+    }
+
+    #[test]
+    fn ring_encloses_rect() {
+        let ring = FocusRing::new();
+        let rect = ring_rect();
+        let quads = ring.render_quads(&rect);
+
+        let top = &quads[0];
+        let bottom = &quads[1];
+        let left = &quads[2];
+        let right = &quads[3];
+
+        // Top edge at rect.y.
+        assert!((top.pos[1] - rect.y).abs() < 0.01);
+        // Bottom edge at rect.y + rect.height - RING_THICKNESS.
+        assert!((bottom.pos[1] - (rect.y + rect.height - RING_THICKNESS)).abs() < 0.01);
+        // Left edge at rect.x.
+        assert!((left.pos[0] - rect.x).abs() < 0.01);
+        // Right edge at rect.x + rect.width - RING_THICKNESS.
+        assert!((right.pos[0] - (rect.x + rect.width - RING_THICKNESS)).abs() < 0.01);
+    }
+
+    // ── Text rendering ────────────────────────────────────────────────────────
+
+    #[test]
+    fn render_text_is_always_empty() {
+        let ring = FocusRing::new();
+        assert!(ring.render_text(&ring_rect()).is_empty());
+    }
+
+    // ── Widget object safety ──────────────────────────────────────────────────
+
+    #[test]
+    fn focus_ring_is_object_safe() {
+        let ring = FocusRing::new();
+        let widget: &dyn Widget = &ring;
+        let quads = widget.render_quads(&ring_rect());
+        assert_eq!(quads.len(), 4);
+    }
+
+    // ── AppId association ─────────────────────────────────────────────────────
+
+    #[test]
+    fn cycling_focus_between_panes() {
+        let mut ring = FocusRing::new();
+        ring.set_focused(Some(1));
+        ring.tick(FADE_DURATION_MS);
+        assert_eq!(ring.focused, Some(1));
+        assert_eq!(ring.opacity(), 1.0);
+
+        ring.set_focused(Some(2));
+        // Opacity stays at 1.0 (still focused, just different pane).
+        ring.tick(0.0);
+        assert_eq!(ring.focused, Some(2));
+        assert_eq!(ring.opacity(), 1.0);
+    }
+}

--- a/crates/phantom-ui/src/widgets/input_bar.rs
+++ b/crates/phantom-ui/src/widgets/input_bar.rs
@@ -1,0 +1,674 @@
+//! Issue #23 — `InputBar` widget.
+//!
+//! A single-line text input with:
+//! - An optional prompt prefix (e.g. `"> "` or `"$ "`).
+//! - A cursor maintained at `cursor_pos` (byte index into `buffer`).
+//! - Cursor blink via [`crate::cursor::CursorBlink`].
+//! - Token-driven colors: input text = `text_primary`, prompt = `text_dim`,
+//!   cursor block = `text_primary` (modulated by blink state), background =
+//!   `surface_recessed`.
+//! - Keyboard event dispatch: `handle_key` interprets common keys and calls
+//!   `on_submit` on Enter.
+//! - A simple command-history ring accessible via `history_prev` / `history_next`.
+//!
+//! The widget does **not** depend on the agent runtime — it is usable
+//! standalone wherever a text input is needed.
+//!
+//! # Examples
+//!
+//! ```rust,ignore
+//! use phantom_ui::widgets::input_bar::InputBar;
+//!
+//! let mut bar = InputBar::new(Some("> ".into()), |text| println!("submit: {text}"));
+//! bar.handle_key(InputKey::Char('h'));
+//! bar.handle_key(InputKey::Char('i'));
+//! bar.handle_key(InputKey::Enter);
+//! ```
+
+use crate::cursor::CursorBlink;
+use crate::layout::Rect;
+use crate::render_ctx::RenderCtx;
+use crate::tokens::Tokens;
+use crate::widgets::{TextSegment, Widget};
+use phantom_renderer::quads::QuadInstance;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Fixed height of the input bar in pixels.
+pub const INPUT_BAR_HEIGHT: f32 = 28.0;
+
+/// Horizontal padding between the rect edge and the prompt / input text.
+const H_PAD: f32 = 8.0;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// InputKey
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Logical key events delivered to [`InputBar::handle_key`].
+///
+/// The caller maps hardware key codes to these variants before dispatching.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InputKey {
+    /// A printable character.
+    Char(char),
+    /// Backspace — delete the character before the cursor.
+    Backspace,
+    /// Delete — delete the character at the cursor.
+    Delete,
+    /// Move cursor left one character.
+    Left,
+    /// Move cursor right one character.
+    Right,
+    /// Move cursor to the beginning of the buffer.
+    Home,
+    /// Move cursor to the end of the buffer.
+    End,
+    /// Submit the buffer and fire `on_submit`.
+    Enter,
+    /// Scroll backwards in command history.
+    HistoryPrev,
+    /// Scroll forwards in command history.
+    HistoryNext,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// InputBar
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Single-line text input widget with prompt, cursor, blink, and history.
+///
+/// The widget is non-`Clone` because `on_submit` is a heap-allocated closure.
+/// Snapshot `buffer` and `cursor_pos` individually if you need serialisable
+/// state.
+pub struct InputBar {
+    /// Current text content of the input field.
+    pub buffer: String,
+    /// Cursor position as a **char** index into `buffer` (not byte offset).
+    pub cursor_pos: usize,
+    /// Optional prompt rendered before the user input (e.g. `"> "`).
+    pub prompt: Option<String>,
+    /// Called when the user presses Enter. Receives the buffer contents.
+    pub on_submit: Box<dyn FnMut(&str)>,
+    /// Cursor blink state.
+    blink: CursorBlink,
+    /// Command history ring (oldest → newest).
+    history: Vec<String>,
+    /// Current position in the history ring (`None` = live input, not in history).
+    history_pos: Option<usize>,
+    /// Saved live buffer when the user navigates into history.
+    live_buffer: String,
+    /// Live render metrics.
+    ctx: RenderCtx,
+}
+
+impl InputBar {
+    /// Create an [`InputBar`] with an optional prompt and submit callback.
+    ///
+    /// The buffer starts empty and the cursor is at position 0.
+    pub fn new(prompt: Option<String>, on_submit: impl FnMut(&str) + 'static) -> Self {
+        Self {
+            buffer: String::new(),
+            cursor_pos: 0,
+            prompt,
+            on_submit: Box::new(on_submit),
+            blink: CursorBlink::default(),
+            history: Vec::new(),
+            history_pos: None,
+            live_buffer: String::new(),
+            ctx: RenderCtx::fallback(),
+        }
+    }
+
+    /// Update the live render context.
+    pub fn set_render_ctx(&mut self, ctx: RenderCtx) {
+        self.ctx = ctx;
+    }
+
+    /// Advance the cursor-blink timer. Call once per frame with the current
+    /// wall-clock time in milliseconds.
+    pub fn tick(&mut self, now_ms: u64) {
+        self.blink.tick(now_ms);
+    }
+
+    /// Push a string onto the history ring (e.g. after a successful submit).
+    ///
+    /// Consecutive duplicates are deduplicated: if the new entry is identical
+    /// to the most-recent history entry it is silently dropped.
+    pub fn push_history(&mut self, entry: &str) {
+        if entry.is_empty() {
+            return;
+        }
+        if self.history.last().map(|s| s.as_str()) == Some(entry) {
+            return;
+        }
+        self.history.push(entry.to_owned());
+    }
+
+    /// Handle a logical key event, updating `buffer` and `cursor_pos`.
+    ///
+    /// Returns `true` when the key was consumed (always, for now).
+    pub fn handle_key(&mut self, key: InputKey) -> bool {
+        match key {
+            InputKey::Char(c) => {
+                self.buffer.insert(self.byte_offset(self.cursor_pos), c);
+                self.cursor_pos += 1;
+                self.blink.reset(0);
+                self.history_pos = None;
+            }
+            InputKey::Backspace => {
+                if self.cursor_pos > 0 {
+                    let byte = self.byte_offset(self.cursor_pos - 1);
+                    self.buffer.remove(byte);
+                    self.cursor_pos -= 1;
+                    self.blink.reset(0);
+                    self.history_pos = None;
+                }
+            }
+            InputKey::Delete => {
+                if self.cursor_pos < self.char_count() {
+                    let byte = self.byte_offset(self.cursor_pos);
+                    self.buffer.remove(byte);
+                    self.blink.reset(0);
+                    self.history_pos = None;
+                }
+            }
+            InputKey::Left => {
+                if self.cursor_pos > 0 {
+                    self.cursor_pos -= 1;
+                }
+            }
+            InputKey::Right => {
+                if self.cursor_pos < self.char_count() {
+                    self.cursor_pos += 1;
+                }
+            }
+            InputKey::Home => {
+                self.cursor_pos = 0;
+            }
+            InputKey::End => {
+                self.cursor_pos = self.char_count();
+            }
+            InputKey::Enter => {
+                let text = self.buffer.clone();
+                self.push_history(&text);
+                (self.on_submit)(&text);
+                self.buffer.clear();
+                self.cursor_pos = 0;
+                self.history_pos = None;
+                self.blink.reset(0);
+            }
+            InputKey::HistoryPrev => {
+                self.history_prev();
+            }
+            InputKey::HistoryNext => {
+                self.history_next();
+            }
+        }
+        true
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────────────
+
+    /// Number of chars in the current buffer.
+    fn char_count(&self) -> usize {
+        self.buffer.chars().count()
+    }
+
+    /// Convert a char-index `pos` to a byte offset in `buffer`.
+    ///
+    /// Clamps to `buffer.len()` so it is always valid for slicing.
+    fn byte_offset(&self, pos: usize) -> usize {
+        self.buffer
+            .char_indices()
+            .nth(pos)
+            .map(|(b, _)| b)
+            .unwrap_or(self.buffer.len())
+    }
+
+    /// Navigate backwards in history (older commands).
+    fn history_prev(&mut self) {
+        if self.history.is_empty() {
+            return;
+        }
+        let new_pos = match self.history_pos {
+            None => {
+                // Save the live buffer before entering history.
+                self.live_buffer = self.buffer.clone();
+                self.history.len() - 1
+            }
+            Some(0) => 0, // Already at the oldest entry.
+            Some(p) => p - 1,
+        };
+        self.history_pos = Some(new_pos);
+        self.buffer = self.history[new_pos].clone();
+        self.cursor_pos = self.char_count();
+    }
+
+    /// Navigate forwards in history (newer commands, back to live input).
+    fn history_next(&mut self) {
+        match self.history_pos {
+            None => {} // Already at live input.
+            Some(p) if p + 1 >= self.history.len() => {
+                // Past the newest entry: return to live buffer.
+                self.buffer = self.live_buffer.clone();
+                self.history_pos = None;
+                self.cursor_pos = self.char_count();
+            }
+            Some(p) => {
+                let new_pos = p + 1;
+                self.history_pos = Some(new_pos);
+                self.buffer = self.history[new_pos].clone();
+                self.cursor_pos = self.char_count();
+            }
+        }
+    }
+
+    /// Width in chars of the prompt (0 if absent).
+    fn prompt_char_width(&self) -> usize {
+        self.prompt.as_deref().map(|p| p.chars().count()).unwrap_or(0)
+    }
+}
+
+impl Widget for InputBar {
+    /// Emit:
+    /// 1. Full-width background quad (`surface_recessed`).
+    /// 2. Cursor block quad (`text_primary`, modulated by blink alpha) positioned
+    ///    at the character cell where the cursor currently sits.
+    fn render_quads(&self, rect: &Rect) -> Vec<QuadInstance> {
+        let t = Tokens::phosphor(self.ctx);
+        let char_w = self.ctx.cell_w();
+        let char_h = self.ctx.cell_h();
+
+        let mut quads = Vec::with_capacity(2);
+
+        // 1. Background.
+        quads.push(QuadInstance {
+            pos: [rect.x, rect.y],
+            size: [rect.width, rect.height],
+            color: t.colors.surface_recessed,
+            border_radius: 0.0,
+        });
+
+        // 2. Cursor block.
+        let prompt_w = self.prompt_char_width() as f32 * char_w;
+        let cursor_x = rect.x + H_PAD + prompt_w + self.cursor_pos as f32 * char_w;
+        let cursor_y = rect.y + (rect.height - char_h) * 0.5;
+
+        let cursor_color = self.blink.color(t.colors.text_primary);
+
+        quads.push(QuadInstance {
+            pos: [cursor_x, cursor_y],
+            size: [char_w, char_h],
+            color: cursor_color,
+            border_radius: 0.0,
+        });
+
+        quads
+    }
+
+    /// Emit text segments:
+    /// - Prompt (if any) in `text_dim`.
+    /// - Buffer text in `text_primary`.
+    fn render_text(&self, rect: &Rect) -> Vec<TextSegment> {
+        let t = Tokens::phosphor(self.ctx);
+        let char_w = self.ctx.cell_w();
+        let char_h = self.ctx.cell_h();
+        let text_y = rect.y + (rect.height - char_h) * 0.5;
+
+        let mut segments = Vec::with_capacity(2);
+
+        match &self.prompt {
+            Some(prompt) => {
+                // Prompt segment.
+                segments.push(TextSegment {
+                    text: prompt.clone(),
+                    x: rect.x + H_PAD,
+                    y: text_y,
+                    color: t.colors.text_dim,
+                });
+
+                // Buffer segment (offset by prompt width).
+                if !self.buffer.is_empty() {
+                    let prompt_w = prompt.chars().count() as f32 * char_w;
+                    segments.push(TextSegment {
+                        text: self.buffer.clone(),
+                        x: rect.x + H_PAD + prompt_w,
+                        y: text_y,
+                        color: t.colors.text_primary,
+                    });
+                }
+            }
+            None => {
+                if !self.buffer.is_empty() {
+                    segments.push(TextSegment {
+                        text: self.buffer.clone(),
+                        x: rect.x + H_PAD,
+                        y: text_y,
+                        color: t.colors.text_primary,
+                    });
+                }
+            }
+        }
+
+        segments
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::render_ctx::RenderCtx;
+    use crate::tokens::Tokens;
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn input_rect() -> Rect {
+        Rect { x: 0.0, y: 0.0, width: 800.0, height: INPUT_BAR_HEIGHT }
+    }
+
+    fn bare_bar() -> InputBar {
+        InputBar::new(None, |_| {})
+    }
+
+    fn prompted_bar() -> InputBar {
+        InputBar::new(Some("> ".into()), |_| {})
+    }
+
+    // ── Construction ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn new_buffer_is_empty() {
+        let bar = bare_bar();
+        assert!(bar.buffer.is_empty());
+        assert_eq!(bar.cursor_pos, 0);
+    }
+
+    #[test]
+    fn prompt_stored_correctly() {
+        let bar = InputBar::new(Some("$ ".into()), |_| {});
+        assert_eq!(bar.prompt.as_deref(), Some("$ "));
+    }
+
+    // ── Char input ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn typing_chars_appends_to_buffer() {
+        let mut bar = bare_bar();
+        bar.handle_key(InputKey::Char('h'));
+        bar.handle_key(InputKey::Char('i'));
+        assert_eq!(bar.buffer, "hi");
+        assert_eq!(bar.cursor_pos, 2);
+    }
+
+    #[test]
+    fn cursor_in_middle_inserts_at_cursor() {
+        let mut bar = bare_bar();
+        bar.handle_key(InputKey::Char('a'));
+        bar.handle_key(InputKey::Char('c'));
+        bar.handle_key(InputKey::Left);
+        bar.handle_key(InputKey::Char('b'));
+        assert_eq!(bar.buffer, "abc");
+        assert_eq!(bar.cursor_pos, 2);
+    }
+
+    // ── Backspace / Delete ────────────────────────────────────────────────────
+
+    #[test]
+    fn backspace_removes_char_before_cursor() {
+        let mut bar = bare_bar();
+        bar.handle_key(InputKey::Char('a'));
+        bar.handle_key(InputKey::Char('b'));
+        bar.handle_key(InputKey::Backspace);
+        assert_eq!(bar.buffer, "a");
+        assert_eq!(bar.cursor_pos, 1);
+    }
+
+    #[test]
+    fn backspace_at_start_is_no_op() {
+        let mut bar = bare_bar();
+        bar.handle_key(InputKey::Backspace); // must not panic
+        assert!(bar.buffer.is_empty());
+    }
+
+    #[test]
+    fn delete_removes_char_at_cursor() {
+        let mut bar = bare_bar();
+        bar.handle_key(InputKey::Char('a'));
+        bar.handle_key(InputKey::Char('b'));
+        bar.handle_key(InputKey::Left); // cursor before 'b'
+        bar.handle_key(InputKey::Delete);
+        assert_eq!(bar.buffer, "a");
+        assert_eq!(bar.cursor_pos, 1);
+    }
+
+    #[test]
+    fn delete_at_end_is_no_op() {
+        let mut bar = bare_bar();
+        bar.handle_key(InputKey::Char('x'));
+        bar.handle_key(InputKey::Delete); // cursor at end — no-op
+        assert_eq!(bar.buffer, "x");
+    }
+
+    // ── Navigation ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn left_decrements_cursor() {
+        let mut bar = bare_bar();
+        bar.handle_key(InputKey::Char('a'));
+        bar.handle_key(InputKey::Left);
+        assert_eq!(bar.cursor_pos, 0);
+    }
+
+    #[test]
+    fn left_at_start_is_clamped() {
+        let mut bar = bare_bar();
+        bar.handle_key(InputKey::Left); // must not underflow
+        assert_eq!(bar.cursor_pos, 0);
+    }
+
+    #[test]
+    fn right_increments_cursor() {
+        let mut bar = bare_bar();
+        bar.handle_key(InputKey::Char('a'));
+        bar.handle_key(InputKey::Left);
+        bar.handle_key(InputKey::Right);
+        assert_eq!(bar.cursor_pos, 1);
+    }
+
+    #[test]
+    fn right_at_end_is_clamped() {
+        let mut bar = bare_bar();
+        bar.handle_key(InputKey::Char('a'));
+        bar.handle_key(InputKey::Right); // already at end
+        assert_eq!(bar.cursor_pos, 1);
+    }
+
+    #[test]
+    fn home_moves_cursor_to_zero() {
+        let mut bar = bare_bar();
+        bar.handle_key(InputKey::Char('a'));
+        bar.handle_key(InputKey::Char('b'));
+        bar.handle_key(InputKey::Home);
+        assert_eq!(bar.cursor_pos, 0);
+    }
+
+    #[test]
+    fn end_moves_cursor_to_buffer_end() {
+        let mut bar = bare_bar();
+        bar.handle_key(InputKey::Char('a'));
+        bar.handle_key(InputKey::Char('b'));
+        bar.handle_key(InputKey::Home);
+        bar.handle_key(InputKey::End);
+        assert_eq!(bar.cursor_pos, 2);
+    }
+
+    // ── Enter / submit ────────────────────────────────────────────────────────
+
+    #[test]
+    fn enter_fires_callback_with_buffer() {
+        let submitted = std::sync::Arc::new(std::sync::Mutex::new(String::new()));
+        let submitted_clone = submitted.clone();
+        let mut bar = InputBar::new(None, move |text| {
+            *submitted_clone.lock().unwrap() = text.to_owned();
+        });
+        bar.handle_key(InputKey::Char('o'));
+        bar.handle_key(InputKey::Char('k'));
+        bar.handle_key(InputKey::Enter);
+        assert_eq!(submitted.lock().unwrap().as_str(), "ok");
+    }
+
+    #[test]
+    fn enter_clears_buffer_and_resets_cursor() {
+        let mut bar = bare_bar();
+        bar.handle_key(InputKey::Char('x'));
+        bar.handle_key(InputKey::Enter);
+        assert!(bar.buffer.is_empty());
+        assert_eq!(bar.cursor_pos, 0);
+    }
+
+    // ── History ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn history_prev_loads_last_entry() {
+        let mut bar = bare_bar();
+        bar.push_history("first");
+        bar.push_history("second");
+        bar.handle_key(InputKey::HistoryPrev);
+        assert_eq!(bar.buffer, "second");
+    }
+
+    #[test]
+    fn history_prev_twice_loads_earlier_entry() {
+        let mut bar = bare_bar();
+        bar.push_history("first");
+        bar.push_history("second");
+        bar.handle_key(InputKey::HistoryPrev);
+        bar.handle_key(InputKey::HistoryPrev);
+        assert_eq!(bar.buffer, "first");
+    }
+
+    #[test]
+    fn history_next_returns_to_live_buffer() {
+        let mut bar = bare_bar();
+        bar.push_history("cmd");
+        // Set a live buffer first.
+        bar.handle_key(InputKey::Char('l'));
+        bar.handle_key(InputKey::Char('i'));
+        bar.handle_key(InputKey::Char('v'));
+        bar.handle_key(InputKey::Char('e'));
+        bar.handle_key(InputKey::HistoryPrev); // → "cmd"
+        bar.handle_key(InputKey::HistoryNext); // → "live"
+        assert_eq!(bar.buffer, "live");
+        assert!(bar.history_pos.is_none());
+    }
+
+    #[test]
+    fn history_prev_on_empty_is_no_op() {
+        let mut bar = bare_bar();
+        bar.handle_key(InputKey::HistoryPrev); // must not panic
+        assert!(bar.buffer.is_empty());
+    }
+
+    #[test]
+    fn push_history_deduplicates_consecutive() {
+        let mut bar = bare_bar();
+        bar.push_history("dup");
+        bar.push_history("dup");
+        assert_eq!(bar.history.len(), 1);
+    }
+
+    #[test]
+    fn enter_pushes_to_history() {
+        let mut bar = bare_bar();
+        bar.handle_key(InputKey::Char('g'));
+        bar.handle_key(InputKey::Enter);
+        assert_eq!(bar.history, vec!["g"]);
+    }
+
+    // ── Quad rendering ────────────────────────────────────────────────────────
+
+    #[test]
+    fn render_quads_emits_two_quads() {
+        let bar = bare_bar();
+        let quads = bar.render_quads(&input_rect());
+        assert_eq!(quads.len(), 2, "background + cursor block");
+    }
+
+    #[test]
+    fn background_quad_uses_surface_recessed() {
+        let ctx = RenderCtx::fallback();
+        let t = Tokens::phosphor(ctx);
+        let bar = bare_bar();
+        let quads = bar.render_quads(&input_rect());
+        assert_eq!(quads[0].color, t.colors.surface_recessed);
+    }
+
+    #[test]
+    fn cursor_quad_uses_text_primary_when_visible() {
+        // Blink starts visible (phase = 0).
+        let ctx = RenderCtx::fallback();
+        let t = Tokens::phosphor(ctx);
+        let bar = bare_bar();
+        let quads = bar.render_quads(&input_rect());
+        assert_eq!(quads[1].color, t.colors.text_primary);
+    }
+
+    // ── Text rendering ────────────────────────────────────────────────────────
+
+    #[test]
+    fn empty_bar_without_prompt_emits_no_text() {
+        let bar = bare_bar();
+        assert!(bar.render_text(&input_rect()).is_empty());
+    }
+
+    #[test]
+    fn prompt_only_emits_one_segment() {
+        let bar = prompted_bar();
+        let texts = bar.render_text(&input_rect());
+        assert_eq!(texts.len(), 1);
+        assert_eq!(texts[0].text, "> ");
+    }
+
+    #[test]
+    fn prompt_uses_text_dim_color() {
+        let ctx = RenderCtx::fallback();
+        let t = Tokens::phosphor(ctx);
+        let bar = prompted_bar();
+        let texts = bar.render_text(&input_rect());
+        assert_eq!(texts[0].color, t.colors.text_dim);
+    }
+
+    #[test]
+    fn buffer_text_uses_text_primary() {
+        let ctx = RenderCtx::fallback();
+        let t = Tokens::phosphor(ctx);
+        let mut bar = bare_bar();
+        bar.handle_key(InputKey::Char('x'));
+        let texts = bar.render_text(&input_rect());
+        assert_eq!(texts.len(), 1);
+        assert_eq!(texts[0].color, t.colors.text_primary);
+    }
+
+    #[test]
+    fn prompted_bar_with_text_emits_two_segments() {
+        let mut bar = prompted_bar();
+        bar.handle_key(InputKey::Char('a'));
+        let texts = bar.render_text(&input_rect());
+        assert_eq!(texts.len(), 2);
+        assert!(texts.iter().any(|s| s.text == "> "));
+        assert!(texts.iter().any(|s| s.text == "a"));
+    }
+
+    // ── Height constant ───────────────────────────────────────────────────────
+
+    #[test]
+    fn height_constant_defined() {
+        assert!(INPUT_BAR_HEIGHT > 0.0);
+    }
+}

--- a/crates/phantom-ui/src/widgets/input_bar.rs
+++ b/crates/phantom-ui/src/widgets/input_bar.rs
@@ -80,17 +80,17 @@ pub enum InputKey {
 /// Single-line text input widget with prompt, cursor, blink, and history.
 ///
 /// The widget is non-`Clone` because `on_submit` is a heap-allocated closure.
-/// Snapshot `buffer` and `cursor_pos` individually if you need serialisable
+/// Snapshot `buffer()` and `cursor_pos()` individually if you need serialisable
 /// state.
 pub struct InputBar {
     /// Current text content of the input field.
-    pub buffer: String,
+    buffer: String,
     /// Cursor position as a **char** index into `buffer` (not byte offset).
-    pub cursor_pos: usize,
+    cursor_pos: usize,
     /// Optional prompt rendered before the user input (e.g. `"> "`).
-    pub prompt: Option<String>,
+    prompt: Option<String>,
     /// Called when the user presses Enter. Receives the buffer contents.
-    pub on_submit: Box<dyn FnMut(&str)>,
+    on_submit: Box<dyn FnMut(&str)>,
     /// Cursor blink state.
     blink: CursorBlink,
     /// Command history ring (oldest → newest).
@@ -124,6 +124,21 @@ impl InputBar {
     /// Update the live render context.
     pub fn set_render_ctx(&mut self, ctx: RenderCtx) {
         self.ctx = ctx;
+    }
+
+    /// Current text content of the input field.
+    pub fn buffer(&self) -> &str {
+        &self.buffer
+    }
+
+    /// Cursor position as a char index into the buffer (not byte offset).
+    pub fn cursor_pos(&self) -> usize {
+        self.cursor_pos
+    }
+
+    /// Optional prompt string rendered before the user input.
+    pub fn prompt(&self) -> Option<&str> {
+        self.prompt.as_deref()
     }
 
     /// Advance the cursor-blink timer. Call once per frame with the current
@@ -385,14 +400,14 @@ mod tests {
     #[test]
     fn new_buffer_is_empty() {
         let bar = bare_bar();
-        assert!(bar.buffer.is_empty());
-        assert_eq!(bar.cursor_pos, 0);
+        assert!(bar.buffer().is_empty());
+        assert_eq!(bar.cursor_pos(), 0);
     }
 
     #[test]
     fn prompt_stored_correctly() {
         let bar = InputBar::new(Some("$ ".into()), |_| {});
-        assert_eq!(bar.prompt.as_deref(), Some("$ "));
+        assert_eq!(bar.prompt(), Some("$ "));
     }
 
     // ── Char input ────────────────────────────────────────────────────────────
@@ -402,8 +417,8 @@ mod tests {
         let mut bar = bare_bar();
         bar.handle_key(InputKey::Char('h'));
         bar.handle_key(InputKey::Char('i'));
-        assert_eq!(bar.buffer, "hi");
-        assert_eq!(bar.cursor_pos, 2);
+        assert_eq!(bar.buffer(), "hi");
+        assert_eq!(bar.cursor_pos(), 2);
     }
 
     #[test]
@@ -413,8 +428,8 @@ mod tests {
         bar.handle_key(InputKey::Char('c'));
         bar.handle_key(InputKey::Left);
         bar.handle_key(InputKey::Char('b'));
-        assert_eq!(bar.buffer, "abc");
-        assert_eq!(bar.cursor_pos, 2);
+        assert_eq!(bar.buffer(), "abc");
+        assert_eq!(bar.cursor_pos(), 2);
     }
 
     // ── Backspace / Delete ────────────────────────────────────────────────────
@@ -425,15 +440,15 @@ mod tests {
         bar.handle_key(InputKey::Char('a'));
         bar.handle_key(InputKey::Char('b'));
         bar.handle_key(InputKey::Backspace);
-        assert_eq!(bar.buffer, "a");
-        assert_eq!(bar.cursor_pos, 1);
+        assert_eq!(bar.buffer(), "a");
+        assert_eq!(bar.cursor_pos(), 1);
     }
 
     #[test]
     fn backspace_at_start_is_no_op() {
         let mut bar = bare_bar();
         bar.handle_key(InputKey::Backspace); // must not panic
-        assert!(bar.buffer.is_empty());
+        assert!(bar.buffer().is_empty());
     }
 
     #[test]
@@ -443,8 +458,8 @@ mod tests {
         bar.handle_key(InputKey::Char('b'));
         bar.handle_key(InputKey::Left); // cursor before 'b'
         bar.handle_key(InputKey::Delete);
-        assert_eq!(bar.buffer, "a");
-        assert_eq!(bar.cursor_pos, 1);
+        assert_eq!(bar.buffer(), "a");
+        assert_eq!(bar.cursor_pos(), 1);
     }
 
     #[test]
@@ -452,7 +467,7 @@ mod tests {
         let mut bar = bare_bar();
         bar.handle_key(InputKey::Char('x'));
         bar.handle_key(InputKey::Delete); // cursor at end — no-op
-        assert_eq!(bar.buffer, "x");
+        assert_eq!(bar.buffer(), "x");
     }
 
     // ── Navigation ────────────────────────────────────────────────────────────
@@ -462,14 +477,14 @@ mod tests {
         let mut bar = bare_bar();
         bar.handle_key(InputKey::Char('a'));
         bar.handle_key(InputKey::Left);
-        assert_eq!(bar.cursor_pos, 0);
+        assert_eq!(bar.cursor_pos(), 0);
     }
 
     #[test]
     fn left_at_start_is_clamped() {
         let mut bar = bare_bar();
         bar.handle_key(InputKey::Left); // must not underflow
-        assert_eq!(bar.cursor_pos, 0);
+        assert_eq!(bar.cursor_pos(), 0);
     }
 
     #[test]
@@ -478,7 +493,7 @@ mod tests {
         bar.handle_key(InputKey::Char('a'));
         bar.handle_key(InputKey::Left);
         bar.handle_key(InputKey::Right);
-        assert_eq!(bar.cursor_pos, 1);
+        assert_eq!(bar.cursor_pos(), 1);
     }
 
     #[test]
@@ -486,7 +501,7 @@ mod tests {
         let mut bar = bare_bar();
         bar.handle_key(InputKey::Char('a'));
         bar.handle_key(InputKey::Right); // already at end
-        assert_eq!(bar.cursor_pos, 1);
+        assert_eq!(bar.cursor_pos(), 1);
     }
 
     #[test]
@@ -495,7 +510,7 @@ mod tests {
         bar.handle_key(InputKey::Char('a'));
         bar.handle_key(InputKey::Char('b'));
         bar.handle_key(InputKey::Home);
-        assert_eq!(bar.cursor_pos, 0);
+        assert_eq!(bar.cursor_pos(), 0);
     }
 
     #[test]
@@ -505,7 +520,7 @@ mod tests {
         bar.handle_key(InputKey::Char('b'));
         bar.handle_key(InputKey::Home);
         bar.handle_key(InputKey::End);
-        assert_eq!(bar.cursor_pos, 2);
+        assert_eq!(bar.cursor_pos(), 2);
     }
 
     // ── Enter / submit ────────────────────────────────────────────────────────
@@ -528,8 +543,8 @@ mod tests {
         let mut bar = bare_bar();
         bar.handle_key(InputKey::Char('x'));
         bar.handle_key(InputKey::Enter);
-        assert!(bar.buffer.is_empty());
-        assert_eq!(bar.cursor_pos, 0);
+        assert!(bar.buffer().is_empty());
+        assert_eq!(bar.cursor_pos(), 0);
     }
 
     // ── History ───────────────────────────────────────────────────────────────
@@ -540,7 +555,7 @@ mod tests {
         bar.push_history("first");
         bar.push_history("second");
         bar.handle_key(InputKey::HistoryPrev);
-        assert_eq!(bar.buffer, "second");
+        assert_eq!(bar.buffer(), "second");
     }
 
     #[test]
@@ -550,7 +565,7 @@ mod tests {
         bar.push_history("second");
         bar.handle_key(InputKey::HistoryPrev);
         bar.handle_key(InputKey::HistoryPrev);
-        assert_eq!(bar.buffer, "first");
+        assert_eq!(bar.buffer(), "first");
     }
 
     #[test]
@@ -564,7 +579,7 @@ mod tests {
         bar.handle_key(InputKey::Char('e'));
         bar.handle_key(InputKey::HistoryPrev); // → "cmd"
         bar.handle_key(InputKey::HistoryNext); // → "live"
-        assert_eq!(bar.buffer, "live");
+        assert_eq!(bar.buffer(), "live");
         assert!(bar.history_pos.is_none());
     }
 
@@ -572,7 +587,7 @@ mod tests {
     fn history_prev_on_empty_is_no_op() {
         let mut bar = bare_bar();
         bar.handle_key(InputKey::HistoryPrev); // must not panic
-        assert!(bar.buffer.is_empty());
+        assert!(bar.buffer().is_empty());
     }
 
     #[test]

--- a/crates/phantom-ui/src/widgets/mod.rs
+++ b/crates/phantom-ui/src/widgets/mod.rs
@@ -40,6 +40,21 @@ pub use panel::{Panel, TITLE_BAR_HEIGHT};
 pub mod scrollbar;
 pub use scrollbar::{ScrollState, Scrollbar, SCROLLBAR_WIDTH, track_y_to_offset};
 
+// Issue #25 — horizontal tab strip with badge and keyboard nav.
+pub mod tab_strip;
+// Note: `Tab` is not re-exported here to avoid a name conflict with the
+// legacy private `Tab` struct used by `TabBar` in this module. Import it
+// directly: `use phantom_ui::widgets::tab_strip::Tab`.
+pub use tab_strip::{TabStrip, TAB_MIN_W};
+
+// Issue #23 — single-line text input with prompt, cursor, and history.
+pub mod input_bar;
+pub use input_bar::{InputBar, InputKey, INPUT_BAR_HEIGHT};
+
+// Issue #30 — animated focus-ring overlay keyed to an AppId.
+pub mod focus_ring;
+pub use focus_ring::{FocusRing, FADE_DURATION_MS};
+
 // -----------------------------------------------------------------------
 // Color palette
 // -----------------------------------------------------------------------

--- a/crates/phantom-ui/src/widgets/tab_strip.rs
+++ b/crates/phantom-ui/src/widgets/tab_strip.rs
@@ -1,0 +1,570 @@
+//! Issue #25 — `TabStrip` widget.
+//!
+//! A horizontal tab strip with:
+//! - Active tab uses `text_primary` token color.
+//! - Inactive tabs use `text_secondary` token color.
+//! - Optional numeric badge on each tab (unread count, error count, etc.).
+//! - Click selection via `on_click(x)` pixel-coordinate dispatch.
+//! - Keyboard navigation: `next()` / `prev()` for Tab / Shift-Tab.
+//! - Selection callback fired via [`TabStrip::on_click`] and the nav methods.
+//!
+//! # Layout
+//!
+//! ```text
+//! ┌────────────────┬────────────────┬────────────────┐
+//! │  Alpha         │  Beta [3]      │  Gamma         │
+//! └────────────────┴────────────────┴────────────────┘
+//! ```
+//!
+//! Each tab occupies an equal share of the strip width (minimum [`TAB_MIN_W`]
+//! px). The active tab receives a background highlight (`surface_raised`) and
+//! a bottom accent bar (`accent_focus`). Badges render as `[N]` appended to
+//! the label in `status_warn` color.
+//!
+//! # Examples
+//!
+//! ```rust,ignore
+//! use phantom_ui::widgets::tab_strip::{Tab, TabStrip};
+//!
+//! let mut strip = TabStrip::new(
+//!     vec![
+//!         Tab { label: "Terminal".into(), badge: None },
+//!         Tab { label: "Agent".into(),    badge: Some(2) },
+//!     ],
+//!     0,
+//!     |idx| println!("selected tab {idx}"),
+//! );
+//! ```
+
+use crate::layout::Rect;
+use crate::render_ctx::RenderCtx;
+use crate::tokens::Tokens;
+use crate::widgets::{TextSegment, Widget};
+use phantom_renderer::quads::QuadInstance;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Minimum pixel width of a single tab button.
+pub const TAB_MIN_W: f32 = 80.0;
+
+/// Horizontal padding inside each tab cell.
+const H_PAD: f32 = 12.0;
+
+/// Thickness of the active-tab bottom accent bar (pixels).
+const ACCENT_BAR_H: f32 = 2.0;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tab
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A single entry in a [`TabStrip`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Tab {
+    /// Display label rendered inside the tab cell.
+    pub label: String,
+    /// Optional badge count (unread messages, error count, etc.).
+    /// Rendered as `[N]` appended to the label in `status_warn` color.
+    pub badge: Option<u32>,
+}
+
+impl Tab {
+    /// Compose the rendered label string: `"Label"` or `"Label [N]"`.
+    ///
+    /// Used in tests to verify the full display string without going through
+    /// the render pipeline.
+    #[cfg(test)]
+    fn display_label(&self) -> String {
+        match self.badge {
+            Some(n) => format!("{} [{}]", self.label, n),
+            None => self.label.clone(),
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TabStrip
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Horizontal tab strip widget.
+///
+/// Owns the tab list and the active index. Selection changes are reported via
+/// `on_select` callback. The widget is non-`Clone` because `on_select` is a
+/// heap-allocated closure; clone individual [`Tab`]s if you need to snapshot
+/// state.
+///
+/// Use [`TabStrip::on_click`] to route mouse-click pixel coordinates to tab
+/// selection, and [`TabStrip::next`] / [`TabStrip::prev`] for keyboard nav.
+pub struct TabStrip {
+    /// Ordered list of tabs.
+    pub tabs: Vec<Tab>,
+    /// Index of the currently active tab. Always `< tabs.len()` when
+    /// `!tabs.is_empty()`, and `0` when empty.
+    pub active: usize,
+    /// Called whenever the active tab changes. Receives the new index.
+    pub on_select: Box<dyn FnMut(usize)>,
+    /// Live render metrics (cell width drives truncation math).
+    ctx: RenderCtx,
+}
+
+impl TabStrip {
+    /// Construct a [`TabStrip`] with the given tabs, initial active index, and
+    /// selection callback.
+    ///
+    /// `active` is clamped to `tabs.len().saturating_sub(1)` so passing an
+    /// out-of-range index on an empty list is safe.
+    pub fn new(tabs: Vec<Tab>, active: usize, on_select: impl FnMut(usize) + 'static) -> Self {
+        let clamped = if tabs.is_empty() { 0 } else { active.min(tabs.len() - 1) };
+        Self {
+            tabs,
+            active: clamped,
+            on_select: Box::new(on_select),
+            ctx: RenderCtx::fallback(),
+        }
+    }
+
+    /// Update the live render context (call once per frame before rendering).
+    pub fn set_render_ctx(&mut self, ctx: RenderCtx) {
+        self.ctx = ctx;
+    }
+
+    /// Number of tabs in the strip.
+    pub fn tab_count(&self) -> usize {
+        self.tabs.len()
+    }
+
+    /// Route a mouse click at `click_x` pixels (relative to the strip rect
+    /// origin) to the appropriate tab.
+    ///
+    /// Does nothing if `tabs` is empty.
+    pub fn on_click(&mut self, click_x: f32, rect_width: f32) {
+        if self.tabs.is_empty() {
+            return;
+        }
+        let tab_w = self.tab_width(rect_width);
+        let idx = ((click_x / tab_w) as usize).min(self.tabs.len() - 1);
+        self.select(idx);
+    }
+
+    /// Advance to the next tab (wraps around). Returns the new active index.
+    pub fn next(&mut self) -> usize {
+        if self.tabs.is_empty() {
+            return 0;
+        }
+        let idx = (self.active + 1) % self.tabs.len();
+        self.select(idx);
+        idx
+    }
+
+    /// Move to the previous tab (wraps around). Returns the new active index.
+    pub fn prev(&mut self) -> usize {
+        if self.tabs.is_empty() {
+            return 0;
+        }
+        let idx = if self.active == 0 {
+            self.tabs.len() - 1
+        } else {
+            self.active - 1
+        };
+        self.select(idx);
+        idx
+    }
+
+    // ── Private ───────────────────────────────────────────────────────────────
+
+    /// Set `active` to `idx` and fire the `on_select` callback.
+    fn select(&mut self, idx: usize) {
+        self.active = idx;
+        (self.on_select)(idx);
+    }
+
+    /// Compute the pixel width of one tab cell given the total strip width.
+    fn tab_width(&self, strip_width: f32) -> f32 {
+        if self.tabs.is_empty() {
+            return TAB_MIN_W;
+        }
+        (strip_width / self.tabs.len() as f32).max(TAB_MIN_W)
+    }
+}
+
+impl Widget for TabStrip {
+    /// Produce quads for:
+    /// 1. Full-width strip background (`surface_recessed`).
+    /// 2. Active-tab background highlight (`surface_raised`).
+    /// 3. Active-tab bottom accent bar (`accent_focus`).
+    fn render_quads(&self, rect: &Rect) -> Vec<QuadInstance> {
+        let t = Tokens::phosphor(self.ctx);
+        let mut quads = Vec::with_capacity(3);
+
+        // 1. Strip background.
+        quads.push(QuadInstance {
+            pos: [rect.x, rect.y],
+            size: [rect.width, rect.height],
+            color: t.colors.surface_recessed,
+            border_radius: 0.0,
+        });
+
+        if self.tabs.is_empty() {
+            return quads;
+        }
+
+        let tab_w = self.tab_width(rect.width);
+        let active_x = rect.x + self.active as f32 * tab_w;
+
+        // 2. Active tab background.
+        quads.push(QuadInstance {
+            pos: [active_x, rect.y],
+            size: [tab_w, rect.height],
+            color: t.colors.surface_raised,
+            border_radius: 0.0,
+        });
+
+        // 3. Active tab accent bar along the bottom edge.
+        quads.push(QuadInstance {
+            pos: [active_x, rect.y + rect.height - ACCENT_BAR_H],
+            size: [tab_w, ACCENT_BAR_H],
+            color: t.colors.accent_focus,
+            border_radius: 0.0,
+        });
+
+        quads
+    }
+
+    /// Produce text segments for every tab label.
+    ///
+    /// Active tab labels use `text_primary`; inactive labels use
+    /// `text_secondary`. When a tab carries a badge the badge suffix (`[N]`) is
+    /// rendered with `status_warn` color by emitting a second segment positioned
+    /// immediately after the base label.
+    fn render_text(&self, rect: &Rect) -> Vec<TextSegment> {
+        if self.tabs.is_empty() {
+            return Vec::new();
+        }
+
+        let t = Tokens::phosphor(self.ctx);
+        let tab_w = self.tab_width(rect.width);
+        let text_y = rect.y + (rect.height * 0.5) - (self.ctx.cell_h() * 0.5);
+        let char_w = self.ctx.cell_w();
+
+        let mut segments = Vec::with_capacity(self.tabs.len() * 2);
+
+        for (i, tab) in self.tabs.iter().enumerate() {
+            let tab_x = rect.x + i as f32 * tab_w;
+            let is_active = i == self.active;
+            let label_color = if is_active {
+                t.colors.text_primary
+            } else {
+                t.colors.text_secondary
+            };
+
+            // Available chars inside the tab cell (after padding both sides).
+            let avail_px = (tab_w - H_PAD * 2.0).max(0.0);
+            let max_chars = (avail_px / char_w) as usize;
+
+            // Base label (truncated to fit).
+            let label: String = tab.label.chars().take(max_chars).collect();
+            if label.is_empty() {
+                continue;
+            }
+
+            let label_w = label.chars().count() as f32 * char_w;
+
+            match tab.badge {
+                None => {
+                    // Center the label within the tab cell.
+                    let text_x = tab_x + (tab_w - label_w) * 0.5;
+                    segments.push(TextSegment {
+                        text: label,
+                        x: text_x,
+                        y: text_y,
+                        color: label_color,
+                    });
+                }
+                Some(n) => {
+                    // Render label + badge as two adjacent segments.
+                    let badge_text = format!(" [{}]", n);
+                    let badge_w = badge_text.chars().count() as f32 * char_w;
+                    let total_w = label_w + badge_w;
+                    let start_x = tab_x + (tab_w - total_w).max(0.0) * 0.5;
+
+                    segments.push(TextSegment {
+                        text: label,
+                        x: start_x,
+                        y: text_y,
+                        color: label_color,
+                    });
+                    segments.push(TextSegment {
+                        text: badge_text,
+                        x: start_x + label_w,
+                        y: text_y,
+                        color: t.colors.status_warn,
+                    });
+                }
+            }
+        }
+
+        segments
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::render_ctx::RenderCtx;
+    use crate::tokens::Tokens;
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn strip_rect() -> Rect {
+        Rect { x: 0.0, y: 0.0, width: 960.0, height: 30.0 }
+    }
+
+    fn make_tabs(n: usize) -> Vec<Tab> {
+        (0..n)
+            .map(|i| Tab { label: format!("Tab{i}"), badge: None })
+            .collect()
+    }
+
+    // ── Construction ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn new_stores_tabs_and_active() {
+        let strip = TabStrip::new(make_tabs(3), 1, |_| {});
+        assert_eq!(strip.tab_count(), 3);
+        assert_eq!(strip.active, 1);
+    }
+
+    #[test]
+    fn new_clamps_active_to_last_tab() {
+        let strip = TabStrip::new(make_tabs(2), 99, |_| {});
+        assert_eq!(strip.active, 1);
+    }
+
+    #[test]
+    fn new_empty_tabs_active_is_zero() {
+        let strip = TabStrip::new(vec![], 5, |_| {});
+        assert_eq!(strip.active, 0);
+        assert_eq!(strip.tab_count(), 0);
+    }
+
+    // ── Keyboard nav ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn next_advances_active() {
+        let mut strip = TabStrip::new(make_tabs(3), 0, |_| {});
+        assert_eq!(strip.next(), 1);
+        assert_eq!(strip.active, 1);
+    }
+
+    #[test]
+    fn next_wraps_around() {
+        let mut strip = TabStrip::new(make_tabs(3), 2, |_| {});
+        assert_eq!(strip.next(), 0);
+    }
+
+    #[test]
+    fn prev_decrements_active() {
+        let mut strip = TabStrip::new(make_tabs(3), 2, |_| {});
+        assert_eq!(strip.prev(), 1);
+    }
+
+    #[test]
+    fn prev_wraps_around() {
+        let mut strip = TabStrip::new(make_tabs(3), 0, |_| {});
+        assert_eq!(strip.prev(), 2);
+    }
+
+    #[test]
+    fn next_on_empty_returns_zero() {
+        let mut strip = TabStrip::new(vec![], 0, |_| {});
+        assert_eq!(strip.next(), 0);
+    }
+
+    // ── Selection callback ────────────────────────────────────────────────────
+
+    #[test]
+    fn selection_callback_fires_on_next() {
+        let fired = std::sync::Arc::new(std::sync::Mutex::new(None::<usize>));
+        let fired_clone = fired.clone();
+        let mut strip = TabStrip::new(make_tabs(3), 0, move |idx| {
+            *fired_clone.lock().unwrap() = Some(idx);
+        });
+        strip.next();
+        assert_eq!(*fired.lock().unwrap(), Some(1));
+    }
+
+    #[test]
+    fn selection_callback_fires_on_prev() {
+        let fired = std::sync::Arc::new(std::sync::Mutex::new(None::<usize>));
+        let fired_clone = fired.clone();
+        let mut strip = TabStrip::new(make_tabs(3), 1, move |idx| {
+            *fired_clone.lock().unwrap() = Some(idx);
+        });
+        strip.prev();
+        assert_eq!(*fired.lock().unwrap(), Some(0));
+    }
+
+    #[test]
+    fn selection_callback_fires_on_click() {
+        let fired = std::sync::Arc::new(std::sync::Mutex::new(None::<usize>));
+        let fired_clone = fired.clone();
+        let mut strip = TabStrip::new(make_tabs(3), 0, move |idx| {
+            *fired_clone.lock().unwrap() = Some(idx);
+        });
+        // Click in the middle third (tab index 1).
+        strip.on_click(350.0, 960.0);
+        assert_eq!(*fired.lock().unwrap(), Some(1));
+    }
+
+    // ── Click routing ────────────────────────────────────────────────────────
+
+    #[test]
+    fn click_on_first_tab_selects_zero() {
+        let mut strip = TabStrip::new(make_tabs(3), 0, |_| {});
+        strip.on_click(10.0, 960.0);
+        assert_eq!(strip.active, 0);
+    }
+
+    #[test]
+    fn click_on_last_tab_selects_last() {
+        let mut strip = TabStrip::new(make_tabs(3), 0, |_| {});
+        strip.on_click(900.0, 960.0);
+        assert_eq!(strip.active, 2);
+    }
+
+    #[test]
+    fn click_on_empty_strip_is_no_op() {
+        let mut strip = TabStrip::new(vec![], 0, |_| {});
+        strip.on_click(0.0, 960.0); // must not panic
+    }
+
+    // ── Quad rendering ────────────────────────────────────────────────────────
+
+    #[test]
+    fn empty_strip_renders_one_background_quad() {
+        let strip = TabStrip::new(vec![], 0, |_| {});
+        let quads = strip.render_quads(&strip_rect());
+        assert_eq!(quads.len(), 1);
+    }
+
+    #[test]
+    fn non_empty_strip_renders_three_quads() {
+        let strip = TabStrip::new(make_tabs(3), 0, |_| {});
+        let quads = strip.render_quads(&strip_rect());
+        // 1 background + 1 active bg + 1 accent bar
+        assert_eq!(quads.len(), 3);
+    }
+
+    #[test]
+    fn strip_background_color_is_surface_recessed() {
+        let ctx = RenderCtx::fallback();
+        let t = Tokens::phosphor(ctx);
+        let strip = TabStrip::new(make_tabs(2), 0, |_| {});
+        let quads = strip.render_quads(&strip_rect());
+        assert_eq!(quads[0].color, t.colors.surface_recessed);
+    }
+
+    #[test]
+    fn active_tab_bg_uses_surface_raised() {
+        let ctx = RenderCtx::fallback();
+        let t = Tokens::phosphor(ctx);
+        let strip = TabStrip::new(make_tabs(2), 0, |_| {});
+        let quads = strip.render_quads(&strip_rect());
+        assert_eq!(quads[1].color, t.colors.surface_raised);
+    }
+
+    #[test]
+    fn accent_bar_uses_accent_focus_token() {
+        let ctx = RenderCtx::fallback();
+        let t = Tokens::phosphor(ctx);
+        let strip = TabStrip::new(make_tabs(2), 0, |_| {});
+        let quads = strip.render_quads(&strip_rect());
+        // Third quad is the accent bar.
+        assert_eq!(quads[2].color, t.colors.accent_focus);
+    }
+
+    #[test]
+    fn accent_bar_is_at_strip_bottom() {
+        let strip = TabStrip::new(make_tabs(2), 0, |_| {});
+        let rect = strip_rect();
+        let quads = strip.render_quads(&rect);
+        let bar = &quads[2];
+        assert!((bar.pos[1] + bar.size[1] - (rect.y + rect.height)).abs() < 0.01);
+        assert!((bar.size[1] - ACCENT_BAR_H).abs() < 0.01);
+    }
+
+    // ── Text rendering ────────────────────────────────────────────────────────
+
+    #[test]
+    fn active_tab_text_uses_text_primary() {
+        let ctx = RenderCtx::fallback();
+        let t = Tokens::phosphor(ctx);
+        let strip = TabStrip::new(
+            vec![Tab { label: "Alpha".into(), badge: None }],
+            0,
+            |_| {},
+        );
+        let texts = strip.render_text(&strip_rect());
+        assert!(!texts.is_empty());
+        assert_eq!(texts[0].color, t.colors.text_primary);
+    }
+
+    #[test]
+    fn inactive_tab_text_uses_text_secondary() {
+        let ctx = RenderCtx::fallback();
+        let t = Tokens::phosphor(ctx);
+        let strip = TabStrip::new(
+            vec![
+                Tab { label: "A".into(), badge: None },
+                Tab { label: "B".into(), badge: None },
+            ],
+            0,
+            |_| {},
+        );
+        let texts = strip.render_text(&strip_rect());
+        // Second tab (inactive) should use text_secondary.
+        let b_seg = texts.iter().find(|s| s.text == "B").expect("B not found");
+        assert_eq!(b_seg.color, t.colors.text_secondary);
+    }
+
+    #[test]
+    fn badge_renders_as_additional_segment_in_status_warn() {
+        let ctx = RenderCtx::fallback();
+        let t = Tokens::phosphor(ctx);
+        let strip = TabStrip::new(
+            vec![Tab { label: "Errors".into(), badge: Some(5) }],
+            0,
+            |_| {},
+        );
+        let texts = strip.render_text(&strip_rect());
+        // Expect label segment + badge segment.
+        assert_eq!(texts.len(), 2, "badge tab should emit 2 text segments");
+        let badge_seg = texts.iter().find(|s| s.text.contains("[5]")).expect("badge missing");
+        assert_eq!(badge_seg.color, t.colors.status_warn);
+    }
+
+    #[test]
+    fn empty_strip_has_no_text_segments() {
+        let strip = TabStrip::new(vec![], 0, |_| {});
+        assert!(strip.render_text(&strip_rect()).is_empty());
+    }
+
+    // ── Tab display label ─────────────────────────────────────────────────────
+
+    #[test]
+    fn tab_display_label_no_badge() {
+        let tab = Tab { label: "Inspector".into(), badge: None };
+        assert_eq!(tab.display_label(), "Inspector");
+    }
+
+    #[test]
+    fn tab_display_label_with_badge() {
+        let tab = Tab { label: "Alerts".into(), badge: Some(3) };
+        assert_eq!(tab.display_label(), "Alerts [3]");
+    }
+}

--- a/crates/phantom-ui/src/widgets/tab_strip.rs
+++ b/crates/phantom-ui/src/widgets/tab_strip.rs
@@ -28,8 +28,8 @@
 //!
 //! let mut strip = TabStrip::new(
 //!     vec![
-//!         Tab { label: "Terminal".into(), badge: None },
-//!         Tab { label: "Agent".into(),    badge: Some(2) },
+//!         Tab::new("Terminal", None),
+//!         Tab::new("Agent", Some(2)),
 //!     ],
 //!     0,
 //!     |idx| println!("selected tab {idx}"),
@@ -63,13 +63,28 @@ const ACCENT_BAR_H: f32 = 2.0;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Tab {
     /// Display label rendered inside the tab cell.
-    pub label: String,
+    label: String,
     /// Optional badge count (unread messages, error count, etc.).
     /// Rendered as `[N]` appended to the label in `status_warn` color.
-    pub badge: Option<u32>,
+    badge: Option<u32>,
 }
 
 impl Tab {
+    /// Create a [`Tab`] with the given label and optional badge count.
+    pub fn new(label: impl Into<String>, badge: Option<u32>) -> Self {
+        Self { label: label.into(), badge }
+    }
+
+    /// The display label of this tab.
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    /// The optional badge count for this tab.
+    pub fn badge(&self) -> Option<u32> {
+        self.badge
+    }
+
     /// Compose the rendered label string: `"Label"` or `"Label [N]"`.
     ///
     /// Used in tests to verify the full display string without going through
@@ -98,12 +113,12 @@ impl Tab {
 /// selection, and [`TabStrip::next`] / [`TabStrip::prev`] for keyboard nav.
 pub struct TabStrip {
     /// Ordered list of tabs.
-    pub tabs: Vec<Tab>,
+    tabs: Vec<Tab>,
     /// Index of the currently active tab. Always `< tabs.len()` when
     /// `!tabs.is_empty()`, and `0` when empty.
-    pub active: usize,
+    active: usize,
     /// Called whenever the active tab changes. Receives the new index.
-    pub on_select: Box<dyn FnMut(usize)>,
+    on_select: Box<dyn FnMut(usize)>,
     /// Live render metrics (cell width drives truncation math).
     ctx: RenderCtx,
 }
@@ -127,6 +142,11 @@ impl TabStrip {
     /// Update the live render context (call once per frame before rendering).
     pub fn set_render_ctx(&mut self, ctx: RenderCtx) {
         self.ctx = ctx;
+    }
+
+    /// Index of the currently active tab.
+    pub fn active(&self) -> usize {
+        self.active
     }
 
     /// Number of tabs in the strip.
@@ -326,7 +346,7 @@ mod tests {
 
     fn make_tabs(n: usize) -> Vec<Tab> {
         (0..n)
-            .map(|i| Tab { label: format!("Tab{i}"), badge: None })
+            .map(|i| Tab::new(format!("Tab{i}"), None))
             .collect()
     }
 
@@ -336,19 +356,19 @@ mod tests {
     fn new_stores_tabs_and_active() {
         let strip = TabStrip::new(make_tabs(3), 1, |_| {});
         assert_eq!(strip.tab_count(), 3);
-        assert_eq!(strip.active, 1);
+        assert_eq!(strip.active(), 1);
     }
 
     #[test]
     fn new_clamps_active_to_last_tab() {
         let strip = TabStrip::new(make_tabs(2), 99, |_| {});
-        assert_eq!(strip.active, 1);
+        assert_eq!(strip.active(), 1);
     }
 
     #[test]
     fn new_empty_tabs_active_is_zero() {
         let strip = TabStrip::new(vec![], 5, |_| {});
-        assert_eq!(strip.active, 0);
+        assert_eq!(strip.active(), 0);
         assert_eq!(strip.tab_count(), 0);
     }
 
@@ -358,7 +378,7 @@ mod tests {
     fn next_advances_active() {
         let mut strip = TabStrip::new(make_tabs(3), 0, |_| {});
         assert_eq!(strip.next(), 1);
-        assert_eq!(strip.active, 1);
+        assert_eq!(strip.active(), 1);
     }
 
     #[test]
@@ -427,14 +447,14 @@ mod tests {
     fn click_on_first_tab_selects_zero() {
         let mut strip = TabStrip::new(make_tabs(3), 0, |_| {});
         strip.on_click(10.0, 960.0);
-        assert_eq!(strip.active, 0);
+        assert_eq!(strip.active(), 0);
     }
 
     #[test]
     fn click_on_last_tab_selects_last() {
         let mut strip = TabStrip::new(make_tabs(3), 0, |_| {});
         strip.on_click(900.0, 960.0);
-        assert_eq!(strip.active, 2);
+        assert_eq!(strip.active(), 2);
     }
 
     #[test]
@@ -505,7 +525,7 @@ mod tests {
         let ctx = RenderCtx::fallback();
         let t = Tokens::phosphor(ctx);
         let strip = TabStrip::new(
-            vec![Tab { label: "Alpha".into(), badge: None }],
+            vec![Tab::new("Alpha", None)],
             0,
             |_| {},
         );
@@ -520,8 +540,8 @@ mod tests {
         let t = Tokens::phosphor(ctx);
         let strip = TabStrip::new(
             vec![
-                Tab { label: "A".into(), badge: None },
-                Tab { label: "B".into(), badge: None },
+                Tab::new("A", None),
+                Tab::new("B", None),
             ],
             0,
             |_| {},
@@ -537,7 +557,7 @@ mod tests {
         let ctx = RenderCtx::fallback();
         let t = Tokens::phosphor(ctx);
         let strip = TabStrip::new(
-            vec![Tab { label: "Errors".into(), badge: Some(5) }],
+            vec![Tab::new("Errors", Some(5))],
             0,
             |_| {},
         );
@@ -558,13 +578,13 @@ mod tests {
 
     #[test]
     fn tab_display_label_no_badge() {
-        let tab = Tab { label: "Inspector".into(), badge: None };
+        let tab = Tab::new("Inspector", None);
         assert_eq!(tab.display_label(), "Inspector");
     }
 
     #[test]
     fn tab_display_label_with_badge() {
-        let tab = Tab { label: "Alerts".into(), badge: Some(3) };
+        let tab = Tab::new("Alerts", Some(3));
         assert_eq!(tab.display_label(), "Alerts [3]");
     }
 }


### PR DESCRIPTION
## Summary

- **TabStrip** (#25) — horizontal tab strip with token-driven active/inactive colors, optional numeric badges (`status_warn`), click routing via `on_click(x, width)`, Tab/Shift-Tab keyboard nav, and `on_select` callback
- **InputBar** (#23) — single-line text input with optional prompt prefix, cursor block driven by `CursorBlink`, full key dispatch (Backspace, Delete, arrows, Home, End, Enter), command-history ring. Standalone — no agent runtime required
- **FocusRing** (#30) — 2 px animated outline keyed to `phantom_adapter::AppId`; fades in/out over 100 ms; uses new `accent_focus` token; corner radius = `tokens.radius_sm()`; emits 4 constant border quads for a stable render pipeline

All three follow TDD: tests written first, 262 tests pass (0 failures).

Unblocked by #17 (Adapter trait + `AppId`).

## Changes

- `crates/phantom-ui/src/tokens.rs` — added `accent_focus: [f32; 4]` to `ColorRoles` + phosphor mapping + test
- `crates/phantom-ui/src/widgets/tab_strip.rs` — new (Issue #25)
- `crates/phantom-ui/src/widgets/input_bar.rs` — new (Issue #23)
- `crates/phantom-ui/src/widgets/focus_ring.rs` — new (Issue #30)
- `crates/phantom-ui/src/widgets/mod.rs` — wired all three modules + re-exports

## Test plan

- [x] `cargo test -p phantom-ui` — 262 pass, 0 fail
- [x] `cargo build -p phantom-app` — full dependency chain compiles cleanly
- [ ] Manual: Tab cycling shifts the FocusRing outline between panes
- [ ] Manual: InputBar prompt renders; Enter fires callback; Up/Down cycles history
- [ ] Manual: TabStrip badge counter appears in `status_warn` color

Closes #25
Closes #23
Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)