### PR TITLE
test(#131): verify CRT shader @group/@binding slot assignments

### DIFF
--- a/crates/phantom-renderer/tests/crt_shader.rs
+++ b/crates/phantom-renderer/tests/crt_shader.rs
@@ -7,6 +7,7 @@
 // naga is pulled in as a dev-dependency; the `wgsl-in` feature enables the
 // WGSL frontend used here.
 
+use naga::ResourceBinding;
 use phantom_renderer::postfx::CRT_WGSL;
 
 // ---------------------------------------------------------------------------
@@ -78,5 +79,171 @@ fn crt_wgsl_is_not_empty() {
     assert!(
         CRT_WGSL.contains("fs_main"),
         "CRT_WGSL must contain 'fs_main'"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Binding slot assertions — issue #131
+//
+// These tests parse the WGSL with naga and assert that every global variable's
+// @group/@binding annotation matches what `PostFxPipeline::new` registers in
+// its `BindGroupLayoutDescriptor`.  A mismatch compiles silently and only blows
+// up at runtime with a cryptic GPU error; these tests catch it at `cargo test`.
+//
+// Authoritative layout (shaders/crt.wgsl lines 52-54):
+//   @group(0) @binding(0)  var scene_texture : texture_2d<f32>
+//   @group(0) @binding(1)  var scene_sampler : sampler
+//   @group(0) @binding(2)  var<uniform> params : PostFxParams
+//
+// Rust BindGroupLayoutEntry descriptors in postfx.rs::PostFxPipeline::new:
+//   binding 0 → BindingType::Texture { … }
+//   binding 1 → BindingType::Sampler(SamplerBindingType::Filtering)
+//   binding 2 → BindingType::Buffer { ty: BufferBindingType::Uniform, … }
+// ---------------------------------------------------------------------------
+
+/// Helper: parse CRT_WGSL and return a map from variable name → ResourceBinding.
+///
+/// Panics if parsing fails — the calling test immediately fails with a clear message.
+fn crt_global_bindings() -> std::collections::HashMap<String, ResourceBinding> {
+    let module = naga::front::wgsl::parse_str(CRT_WGSL)
+        .expect("shaders/crt.wgsl must parse as valid WGSL");
+
+    module
+        .global_variables
+        .iter()
+        .filter_map(|(_, var)| {
+            var.binding
+                .as_ref()
+                .map(|b| (var.name.clone().unwrap_or_default(), b.clone()))
+        })
+        .collect()
+}
+
+/// `scene_texture` must be at @group(0) @binding(0).
+///
+/// The Rust layout assigns `BindGroupLayoutEntry { binding: 0, ty:
+/// BindingType::Texture { … } }` — any slot drift is caught here.
+#[test]
+fn crt_wgsl_scene_texture_at_group0_binding0() {
+    let bindings = crt_global_bindings();
+
+    let binding = bindings
+        .get("scene_texture")
+        .expect("global variable 'scene_texture' not found in shaders/crt.wgsl");
+
+    assert_eq!(
+        binding.group, 0,
+        "scene_texture: expected @group(0), got @group({})",
+        binding.group
+    );
+    assert_eq!(
+        binding.binding, 0,
+        "scene_texture: expected @binding(0), got @binding({})",
+        binding.binding
+    );
+}
+
+/// `scene_sampler` must be at @group(0) @binding(1).
+///
+/// The Rust layout assigns `BindGroupLayoutEntry { binding: 1, ty:
+/// BindingType::Sampler(SamplerBindingType::Filtering) }`.
+#[test]
+fn crt_wgsl_scene_sampler_at_group0_binding1() {
+    let bindings = crt_global_bindings();
+
+    let binding = bindings
+        .get("scene_sampler")
+        .expect("global variable 'scene_sampler' not found in shaders/crt.wgsl");
+
+    assert_eq!(
+        binding.group, 0,
+        "scene_sampler: expected @group(0), got @group({})",
+        binding.group
+    );
+    assert_eq!(
+        binding.binding, 1,
+        "scene_sampler: expected @binding(1), got @binding({})",
+        binding.binding
+    );
+}
+
+/// `params` (PostFxParams uniform buffer) must be at @group(0) @binding(2).
+///
+/// The Rust layout assigns `BindGroupLayoutEntry { binding: 2, ty:
+/// BindingType::Buffer { ty: BufferBindingType::Uniform, … } }`.
+#[test]
+fn crt_wgsl_params_uniform_at_group0_binding2() {
+    let bindings = crt_global_bindings();
+
+    let binding = bindings
+        .get("params")
+        .expect("global variable 'params' not found in shaders/crt.wgsl");
+
+    assert_eq!(
+        binding.group, 0,
+        "params: expected @group(0), got @group({})",
+        binding.group
+    );
+    assert_eq!(
+        binding.binding, 2,
+        "params: expected @binding(2), got @binding({})",
+        binding.binding
+    );
+}
+
+/// All bound globals must live in group 0 — the Rust pipeline only creates one
+/// bind group layout at index 0.  A stray @group(1) or higher would mean the
+/// Rust `PipelineLayoutDescriptor` is missing a bind group layout slot.
+#[test]
+fn crt_wgsl_all_bindings_in_group0() {
+    let bindings = crt_global_bindings();
+
+    assert!(
+        !bindings.is_empty(),
+        "Expected at least one bound global variable in shaders/crt.wgsl"
+    );
+
+    for (name, binding) in &bindings {
+        assert_eq!(
+            binding.group, 0,
+            "global '{}' is at @group({}) — only @group(0) is declared in the Rust pipeline layout",
+            name, binding.group
+        );
+    }
+}
+
+/// Exactly three globals are bound: scene_texture, scene_sampler, params.
+///
+/// An extra binding that someone adds to the WGSL but forgets to register in
+/// the Rust `BindGroupLayoutDescriptor` would be silently ignored by the GPU
+/// driver — catching it early here is cheap insurance.
+#[test]
+fn crt_wgsl_exactly_three_bindings() {
+    let bindings = crt_global_bindings();
+
+    assert_eq!(
+        bindings.len(),
+        3,
+        "Expected exactly 3 bound globals (scene_texture, scene_sampler, params), \
+         found {}: {:?}",
+        bindings.len(),
+        bindings.keys().collect::<Vec<_>>()
+    );
+}
+
+/// Binding slots 0, 1, and 2 must all be occupied — no gaps that would leave
+/// a Rust `BindGroupLayoutEntry` pointing at an empty WGSL slot.
+#[test]
+fn crt_wgsl_binding_slots_are_contiguous_0_1_2() {
+    let bindings = crt_global_bindings();
+
+    let mut slots: Vec<u32> = bindings.values().map(|b| b.binding).collect();
+    slots.sort_unstable();
+
+    assert_eq!(
+        slots,
+        vec![0, 1, 2],
+        "Expected binding slots [0, 1, 2] in @group(0), got {:?}",
+        slots
     );
 }


### PR DESCRIPTION
## Summary

Closes #131

- Adds 6 new naga-based tests to `crates/phantom-renderer/tests/crt_shader.rs` that parse `shaders/crt.wgsl` and assert every `@group/@binding` annotation matches the `BindGroupLayoutEntry` descriptors in `PostFxPipeline::new`
- Tests cover: per-variable slot assertions (`scene_texture` at 0/0, `scene_sampler` at 0/1, `params` at 0/2), all-in-group-0 guard, exact count (3 bindings), and contiguous-slot check [0,1,2]
- `naga` was already a dev-dependency with `wgsl-in` feature; no new deps added

## Binding layout verified

| WGSL global | @group | @binding | Rust `BindingType` |
|---|---|---|---|
| `scene_texture` | 0 | 0 | `Texture { sample_type: Float { filterable: true }, … }` |
| `scene_sampler` | 0 | 1 | `Sampler(SamplerBindingType::Filtering)` |
| `params` | 0 | 2 | `Buffer { ty: BufferBindingType::Uniform, … }` |

## Test plan

- [x] `cargo test -p phantom-renderer` — all 9 tests in `tests/crt_shader.rs` pass (3 pre-existing + 6 new)
- [x] Tests require no GPU device — pure CPU naga validation
- [x] A deliberate slot swap in `crt.wgsl` (e.g. moving `params` to `@binding(1)`) causes the relevant test to fail immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)