### PR TITLE
fix(#149): pass 1.0 as dpi_scale in RenderCtx::new, not cell height

### DIFF
--- a/crates/phantom-app/src/inspector.rs
+++ b/crates/phantom-app/src/inspector.rs
@@ -99,7 +99,11 @@ impl App {
         let inspector_tokens = self
             .inspector_tokens
             .get_or_insert_with(|| {
-                let ctx = RenderCtx::new(self.cell_size, self.cell_size.1);
+                // TODO(#149): wire real HiDPI scale factor from winit's
+                // `WindowEvent::ScaleFactorChanged` instead of hard-coding 1.0.
+                // `self.cell_size.1` (cell height in pixels) is not a valid
+                // dimensionless scale factor — passing it here was a bug.
+                let ctx = RenderCtx::new(self.cell_size, 1.0);
                 Arc::new(RwLock::new(Tokens::phosphor(ctx)))
             })
             .clone();


### PR DESCRIPTION
## Summary

- `RenderCtx::new(self.cell_size, self.cell_size.1)` in `inspector.rs` was passing cell height (a pixel dimension, e.g. `16.0`) as the `dpi_scale` argument, which expects a dimensionless HiDPI scale factor (e.g. `1.0` or `2.0` on Retina).
- Changed the second argument to `1.0` (safe, correct default for 1x displays).
- Added a `TODO(#149)` comment noting that the real scale factor should be wired from winit's `WindowEvent::ScaleFactorChanged` in a follow-up.

## Test plan

- [x] `cargo test -p phantom-app` — all tests pass (no regressions)
- [x] The `console_inspect_command_is_in_completions` and `console_inspect_command_parses_as_known_command` unit tests in `inspector.rs` continue to pass
- [ ] Manual: spawn inspector pane on a Retina display and verify tokens/theme render at the correct scale (requires full GPU context, deferred to HiDPI wiring follow-up)

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)