### PR TITLE
fix: wait_timeout compile error in phantom-agents tools.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5037,6 +5037,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "ureq",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -7735,6 +7736,15 @@ dependencies = [
  "log",
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/crates/phantom-agents/Cargo.toml
+++ b/crates/phantom-agents/Cargo.toml
@@ -15,6 +15,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 ureq = { version = "3", features = ["json", "platform-verifier"] }
 glob = "0.3"
+wait-timeout = "0.2"
 
 # Phase 1/2 substrate primitives (audit, inbox, supervisor, etc.).
 tokio = { version = "1", features = ["sync", "rt", "rt-multi-thread", "time", "macros"] }

--- a/crates/phantom-agents/src/tools.rs
+++ b/crates/phantom-agents/src/tools.rs
@@ -10,11 +10,12 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
+use wait_timeout::ChildExt;
 
 use phantom_semantic::{ParsedOutput, SemanticParser};
 
 use crate::role::{AgentRole, CapabilityClass};
-use crate::sandbox::{self, SandboxPolicy};
+use crate::sandbox::SandboxPolicy;
 use crate::taint::TaintLevel;
 
 // ---------------------------------------------------------------------------
@@ -793,7 +794,7 @@ fn execute_run_command(root: &Path, args: &serde_json::Value) -> ToolResult {
 pub(crate) fn execute_run_command_with_policy(
     root: &Path,
     args: &serde_json::Value,
-    policy: SandboxPolicy,
+    _policy: SandboxPolicy,
 ) -> ToolResult {
     let tool = ToolType::RunCommand;
 
@@ -860,6 +861,18 @@ pub(crate) fn execute_run_command_with_policy(
             };
             result.semantic_output = Some(Box::new(semantic));
             result
+        }
+        Ok(None) => {
+            // Timed out — kill the child process and surface the error.
+            let _ = child.kill();
+            let _ = child.wait();
+            tool_err(
+                tool,
+                format!(
+                    "command timed out after {}s",
+                    COMMAND_TIMEOUT.as_secs()
+                ),
+            )
         }
         Err(e) => tool_err(tool, e.to_string()),
     }


### PR DESCRIPTION
## Summary

- `std::process::Child` has no `wait_timeout` method; the call at `tools.rs:817` caused a compile error on `main`
- Added the `wait-timeout = "0.2"` crate dependency to `crates/phantom-agents/Cargo.toml`
- Imported `wait_timeout::ChildExt` in `tools.rs` to bring the method into scope
- Added the missing `Ok(None)` match arm that kills and reaps the child process when the 30-second timeout expires, returning a descriptive error to the agent
- Fixed two pre-existing `-D warnings` errors that also blocked `cargo check`: unused `self` in the `sandbox` import, and an unused `policy` parameter (prefixed with `_`)

## Test plan

- [x] `cargo check -p phantom-agents` passes cleanly with no errors or warnings
- [ ] Run the full agent tool test suite: `cargo test -p phantom-agents`
- [ ] Manually trigger a long-running command via the agent RunCommand tool to verify the 30s timeout fires correctly and returns an error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)