### PR TITLE
feat(#75): phantom-history — JSONL read/write + agent output capture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5402,11 +5402,13 @@ name = "phantom-history"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "log",
  "phantom-semantic",
  "serde",
  "serde_json",
  "tempfile",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,3 +61,5 @@ log = "0.4"
 env_logger = "0.11"
 anyhow = "1"
 bitflags = "2"
+uuid = { version = "1", features = ["v4", "serde"] }
+chrono = { version = "0.4", features = ["serde"] }

--- a/crates/phantom-history/Cargo.toml
+++ b/crates/phantom-history/Cargo.toml
@@ -10,6 +10,8 @@ log.workspace = true
 anyhow.workspace = true
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+uuid.workspace = true
+chrono.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/phantom-history/src/agent_capture.rs
+++ b/crates/phantom-history/src/agent_capture.rs
@@ -1,0 +1,453 @@
+//! Agent output capture — records an agent's tool calls and text output as a
+//! JSONL sidecar file next to the main history file.
+//!
+//! Layout on disk:
+//! ```text
+//! ~/.local/share/phantom/history/
+//!   <session_id>.jsonl            ← HistoryStore
+//!   <session_id>-agents.jsonl     ← AgentOutputCapture (sidecar)
+//! ```
+
+use std::fs::{self, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// ToolCall
+// ---------------------------------------------------------------------------
+
+/// A record of a single tool invocation made by an agent.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ToolCall {
+    /// Name of the tool (e.g. `"ReadFile"`, `"RunCommand"`).
+    name: String,
+    /// JSON-encoded input arguments, stored as a raw string for flexibility.
+    input_json: String,
+    /// JSON-encoded output / result, or an error message.
+    output_json: Option<String>,
+    /// When the call was made.
+    called_at: DateTime<Utc>,
+}
+
+impl ToolCall {
+    /// Construct a new tool call record.
+    #[must_use]
+    pub fn new(
+        name: impl Into<String>,
+        input_json: impl Into<String>,
+        output_json: Option<String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            input_json: input_json.into(),
+            output_json,
+            called_at: Utc::now(),
+        }
+    }
+
+    // Getters
+
+    /// Tool name.
+    #[must_use]
+    pub fn name(&self) -> &str { &self.name }
+
+    /// Raw JSON of the input arguments.
+    #[must_use]
+    pub fn input_json(&self) -> &str { &self.input_json }
+
+    /// Raw JSON of the result, if the call completed.
+    #[must_use]
+    pub fn output_json(&self) -> Option<&str> { self.output_json.as_deref() }
+
+    /// Timestamp of the invocation.
+    #[must_use]
+    pub fn called_at(&self) -> DateTime<Utc> { self.called_at }
+}
+
+// ---------------------------------------------------------------------------
+// AgentRecord  (one record per append)
+// ---------------------------------------------------------------------------
+
+/// A single captured record from an agent run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AgentRecord {
+    /// UUID of this record.
+    id: Uuid,
+    /// Which agent produced this record.
+    agent_name: String,
+    /// Session the agent belongs to.
+    session_id: Uuid,
+    /// Tool calls made during this record, in order.
+    tool_calls: Vec<ToolCall>,
+    /// Free-form text output produced by the agent.
+    text_output: String,
+    /// When this record was captured.
+    captured_at: DateTime<Utc>,
+}
+
+// ---------------------------------------------------------------------------
+// AgentOutputCapture
+// ---------------------------------------------------------------------------
+
+/// Append-only JSONL sidecar that records agent activity.
+///
+/// All public methods return [`anyhow::Result`] — no `.unwrap()` in
+/// production paths.
+pub struct AgentOutputCapture {
+    path: PathBuf,
+}
+
+impl AgentOutputCapture {
+    // -----------------------------------------------------------------------
+    // Construction
+    // -----------------------------------------------------------------------
+
+    /// Open (or create) the sidecar for `session_id` next to the main history
+    /// file under `~/.local/share/phantom/history/`.
+    pub fn open(session_id: Uuid) -> Result<Self> {
+        let dir = default_data_dir();
+        fs::create_dir_all(&dir)
+            .with_context(|| format!("cannot create history dir: {}", dir.display()))?;
+        let path = dir.join(format!("{session_id}-agents.jsonl"));
+        Ok(Self { path })
+    }
+
+    /// Open a sidecar at an explicit path (used in tests).
+    #[must_use]
+    pub fn open_at(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    // -----------------------------------------------------------------------
+    // Write
+    // -----------------------------------------------------------------------
+
+    /// Append one agent activity record to the sidecar.
+    ///
+    /// # Parameters
+    /// * `agent_name` — human-readable agent identifier.
+    /// * `session_id` — session UUID.
+    /// * `tool_calls` — ordered list of tool invocations.
+    /// * `text_output` — agent's free-form text.
+    pub fn append(
+        &self,
+        agent_name: impl Into<String>,
+        session_id: Uuid,
+        tool_calls: Vec<ToolCall>,
+        text_output: impl Into<String>,
+    ) -> Result<()> {
+        let record = AgentRecord {
+            id: Uuid::new_v4(),
+            agent_name: agent_name.into(),
+            session_id,
+            tool_calls,
+            text_output: text_output.into(),
+            captured_at: Utc::now(),
+        };
+
+        let line =
+            serde_json::to_string(&record).context("failed to serialise AgentRecord")?;
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+            .with_context(|| format!("cannot open agent sidecar: {}", self.path.display()))?;
+
+        writeln!(file, "{line}")
+            .with_context(|| format!("cannot write to agent sidecar: {}", self.path.display()))?;
+
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------------
+    // Read
+    // -----------------------------------------------------------------------
+
+    /// Return the most-recent `limit` records in chronological order.
+    pub fn recent(&self, limit: usize) -> Result<Vec<CapturedAgent>> {
+        let all = self.read_all()?;
+        let start = all.len().saturating_sub(limit);
+        Ok(all[start..].to_vec())
+    }
+
+    /// Return all records for a given agent name, in chronological order.
+    pub fn by_agent(&self, agent_name: &str) -> Result<Vec<CapturedAgent>> {
+        let all = self.read_all()?;
+        Ok(all
+            .into_iter()
+            .filter(|r| r.agent_name() == agent_name)
+            .collect())
+    }
+
+    /// Total number of non-corrupt records in the sidecar.
+    pub fn count(&self) -> Result<usize> {
+        if !self.path.exists() {
+            return Ok(0);
+        }
+        let file = fs::File::open(&self.path)
+            .with_context(|| format!("cannot open agent sidecar: {}", self.path.display()))?;
+        let reader = BufReader::new(file);
+        let mut count = 0_usize;
+        for line in reader.lines() {
+            let line = line.context("read error counting agent sidecar lines")?;
+            let t = line.trim();
+            if !t.is_empty() && serde_json::from_str::<AgentRecord>(t).is_ok() {
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
+
+    /// Path to the sidecar file.
+    #[must_use]
+    pub fn path(&self) -> &Path { &self.path }
+
+    // -----------------------------------------------------------------------
+    // Internal helpers
+    // -----------------------------------------------------------------------
+
+    fn read_all(&self) -> Result<Vec<CapturedAgent>> {
+        if !self.path.exists() {
+            return Ok(Vec::new());
+        }
+        let file = fs::File::open(&self.path)
+            .with_context(|| format!("cannot open agent sidecar: {}", self.path.display()))?;
+        let reader = BufReader::new(file);
+        let mut records = Vec::new();
+        for line in reader.lines() {
+            let line = line.context("read error in agent sidecar")?;
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<AgentRecord>(trimmed) {
+                Ok(r) => records.push(CapturedAgent::from(r)),
+                Err(e) => log::warn!("skipping corrupt agent sidecar line: {e}"),
+            }
+        }
+        Ok(records)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CapturedAgent — the public-facing view of an AgentRecord
+// ---------------------------------------------------------------------------
+
+/// Public read-only view of a captured agent run.
+#[derive(Debug, Clone)]
+pub struct CapturedAgent {
+    id: Uuid,
+    agent_name: String,
+    session_id: Uuid,
+    tool_calls: Vec<ToolCall>,
+    text_output: String,
+    captured_at: DateTime<Utc>,
+}
+
+impl CapturedAgent {
+    /// Record UUID.
+    #[must_use]
+    pub fn id(&self) -> Uuid { self.id }
+
+    /// Agent name.
+    #[must_use]
+    pub fn agent_name(&self) -> &str { &self.agent_name }
+
+    /// Session UUID.
+    #[must_use]
+    pub fn session_id(&self) -> Uuid { self.session_id }
+
+    /// Tool calls in invocation order.
+    #[must_use]
+    pub fn tool_calls(&self) -> &[ToolCall] { &self.tool_calls }
+
+    /// Free-form text output.
+    #[must_use]
+    pub fn text_output(&self) -> &str { &self.text_output }
+
+    /// Capture timestamp.
+    #[must_use]
+    pub fn captured_at(&self) -> DateTime<Utc> { self.captured_at }
+}
+
+impl From<AgentRecord> for CapturedAgent {
+    fn from(r: AgentRecord) -> Self {
+        Self {
+            id: r.id,
+            agent_name: r.agent_name,
+            session_id: r.session_id,
+            tool_calls: r.tool_calls,
+            text_output: r.text_output,
+            captured_at: r.captured_at,
+        }
+    }
+}
+
+/// Default data directory: `~/.local/share/phantom/history/`.
+fn default_data_dir() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+    PathBuf::from(home)
+        .join(".local")
+        .join("share")
+        .join("phantom")
+        .join("history")
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_capture() -> (AgentOutputCapture, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("agents.jsonl");
+        let cap = AgentOutputCapture::open_at(&path);
+        (cap, dir)
+    }
+
+    fn tool(name: &str, input: &str) -> ToolCall {
+        ToolCall::new(name, input, Some(r#"{"ok":true}"#.to_string()))
+    }
+
+    // -----------------------------------------------------------------------
+    // 1. Append increments count
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn append_increments_count() {
+        let (cap, _dir) = temp_capture();
+        let session = Uuid::new_v4();
+
+        assert_eq!(cap.count().unwrap(), 0);
+
+        cap.append("defender", session, vec![], "Hello from defender")
+            .unwrap();
+        assert_eq!(cap.count().unwrap(), 1);
+
+        cap.append("inspector", session, vec![], "Audit done")
+            .unwrap();
+        assert_eq!(cap.count().unwrap(), 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // 2. Tool calls survive round-trip
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn tool_calls_round_trip() {
+        let (cap, _dir) = temp_capture();
+        let session = Uuid::new_v4();
+
+        let calls = vec![
+            tool("ReadFile", r#"{"path": "/etc/hosts"}"#),
+            tool("RunCommand", r#"{"cmd": "ls"}"#),
+        ];
+
+        cap.append("agent-x", session, calls.clone(), "done").unwrap();
+
+        let recent = cap.recent(1).unwrap();
+        assert_eq!(recent.len(), 1);
+
+        let recorded = &recent[0];
+        assert_eq!(recorded.tool_calls().len(), 2);
+        assert_eq!(recorded.tool_calls()[0].name(), "ReadFile");
+        assert_eq!(recorded.tool_calls()[1].name(), "RunCommand");
+    }
+
+    // -----------------------------------------------------------------------
+    // 3. Text output survives round-trip
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn text_output_round_trip() {
+        let (cap, _dir) = temp_capture();
+        let session = Uuid::new_v4();
+
+        cap.append("agent-y", session, vec![], "The answer is 42")
+            .unwrap();
+
+        let recent = cap.recent(1).unwrap();
+        assert_eq!(recent[0].text_output(), "The answer is 42");
+    }
+
+    // -----------------------------------------------------------------------
+    // 4. by_agent filters correctly
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn by_agent_filters_correctly() {
+        let (cap, _dir) = temp_capture();
+        let session = Uuid::new_v4();
+
+        cap.append("alpha", session, vec![], "alpha-1").unwrap();
+        cap.append("beta", session, vec![], "beta-1").unwrap();
+        cap.append("alpha", session, vec![], "alpha-2").unwrap();
+
+        let alpha_records = cap.by_agent("alpha").unwrap();
+        assert_eq!(alpha_records.len(), 2);
+        assert!(alpha_records.iter().all(|r| r.agent_name() == "alpha"));
+
+        let beta_records = cap.by_agent("beta").unwrap();
+        assert_eq!(beta_records.len(), 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // 5. Empty capture is safe
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn empty_capture_is_safe() {
+        let (cap, _dir) = temp_capture();
+        assert_eq!(cap.count().unwrap(), 0);
+        assert!(cap.recent(10).unwrap().is_empty());
+        assert!(cap.by_agent("nobody").unwrap().is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // 6. Corrupt lines are skipped gracefully
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn corrupt_lines_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("agents.jsonl");
+        let session = Uuid::new_v4();
+
+        let cap = AgentOutputCapture::open_at(&path);
+        cap.append("good-agent", session, vec![], "first").unwrap();
+
+        // Inject garbage
+        {
+            let mut f = OpenOptions::new().append(true).open(&path).unwrap();
+            writeln!(f, "{{garbage line").unwrap();
+        }
+
+        cap.append("good-agent", session, vec![], "second").unwrap();
+
+        let records = cap.recent(10).unwrap();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].text_output(), "first");
+        assert_eq!(records[1].text_output(), "second");
+    }
+
+    // -----------------------------------------------------------------------
+    // 7. ToolCall getters work
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn tool_call_getters() {
+        let tc = ToolCall::new("WriteFile", r#"{"path":"/tmp/x","content":"y"}"#, None);
+        assert_eq!(tc.name(), "WriteFile");
+        assert!(tc.input_json().contains("/tmp/x"));
+        assert!(tc.output_json().is_none());
+    }
+}

--- a/crates/phantom-history/src/jsonl.rs
+++ b/crates/phantom-history/src/jsonl.rs
@@ -1,0 +1,275 @@
+//! Core `HistoryEntry` type — one per command execution, serialised as a JSONL line.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use phantom_semantic::CommandType;
+
+// ---------------------------------------------------------------------------
+// HistoryEntry
+// ---------------------------------------------------------------------------
+
+/// A single recorded command execution.
+///
+/// All fields are private; use [`HistoryEntry::builder`] to construct and the
+/// provided getters to read.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HistoryEntry {
+    id: Uuid,
+    /// ISO-8601 timestamp of when the command was submitted.
+    timestamp: DateTime<Utc>,
+    command: String,
+    exit_code: Option<i32>,
+    duration_ms: Option<u64>,
+    cwd: PathBuf,
+    session_id: Uuid,
+    /// Semantic classification of the command (from phantom-semantic).
+    semantic_type: CommandType,
+}
+
+impl HistoryEntry {
+    /// Return a builder to construct an entry.
+    #[must_use]
+    pub fn builder(
+        command: impl Into<String>,
+        cwd: impl Into<PathBuf>,
+        session_id: Uuid,
+    ) -> HistoryEntryBuilder {
+        HistoryEntryBuilder::new(command.into(), cwd.into(), session_id)
+    }
+
+    // -----------------------------------------------------------------------
+    // Getters
+    // -----------------------------------------------------------------------
+
+    /// Unique entry identifier.
+    #[must_use]
+    pub fn id(&self) -> Uuid { self.id }
+
+    /// Submission timestamp (UTC).
+    #[must_use]
+    pub fn timestamp(&self) -> DateTime<Utc> { self.timestamp }
+
+    /// The command string as typed by the user.
+    #[must_use]
+    pub fn command(&self) -> &str { &self.command }
+
+    /// Process exit code, if the command completed.
+    #[must_use]
+    pub fn exit_code(&self) -> Option<i32> { self.exit_code }
+
+    /// Wall-clock duration in milliseconds, if measured.
+    #[must_use]
+    pub fn duration_ms(&self) -> Option<u64> { self.duration_ms }
+
+    /// Working directory in which the command was executed.
+    #[must_use]
+    pub fn cwd(&self) -> &PathBuf { &self.cwd }
+
+    /// Session that owns this entry.
+    #[must_use]
+    pub fn session_id(&self) -> Uuid { self.session_id }
+
+    /// Semantic classification (git/cargo/shell/…).
+    #[must_use]
+    pub fn semantic_type(&self) -> &CommandType { &self.semantic_type }
+
+    // -----------------------------------------------------------------------
+    // (De)serialisation helpers
+    // -----------------------------------------------------------------------
+
+    /// Serialise to a compact JSON string suitable for a JSONL line.
+    pub fn to_jsonl_line(&self) -> Result<String> {
+        serde_json::to_string(self).context("failed to serialise HistoryEntry")
+    }
+
+    /// Deserialise from a single JSONL line.
+    pub fn from_jsonl_line(line: &str) -> Result<Self> {
+        serde_json::from_str(line).context("failed to deserialise HistoryEntry")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Builder
+// ---------------------------------------------------------------------------
+
+/// Fluent builder for [`HistoryEntry`].
+pub struct HistoryEntryBuilder {
+    command: String,
+    cwd: PathBuf,
+    session_id: Uuid,
+    id: Uuid,
+    timestamp: DateTime<Utc>,
+    exit_code: Option<i32>,
+    duration_ms: Option<u64>,
+    semantic_type: CommandType,
+}
+
+impl HistoryEntryBuilder {
+    fn new(command: String, cwd: PathBuf, session_id: Uuid) -> Self {
+        Self {
+            command,
+            cwd,
+            session_id,
+            id: Uuid::new_v4(),
+            timestamp: Utc::now(),
+            exit_code: None,
+            duration_ms: None,
+            semantic_type: CommandType::Unknown,
+        }
+    }
+
+    /// Override the auto-generated UUID (useful in tests).
+    #[must_use]
+    pub fn id(mut self, id: Uuid) -> Self { self.id = id; self }
+
+    /// Override the auto-generated timestamp (useful in tests).
+    #[must_use]
+    pub fn timestamp(mut self, ts: DateTime<Utc>) -> Self { self.timestamp = ts; self }
+
+    /// Set the exit code.
+    #[must_use]
+    pub fn exit_code(mut self, code: i32) -> Self { self.exit_code = Some(code); self }
+
+    /// Set the wall-clock duration.
+    #[must_use]
+    pub fn duration_ms(mut self, ms: u64) -> Self { self.duration_ms = Some(ms); self }
+
+    /// Set the semantic classification.
+    #[must_use]
+    pub fn semantic_type(mut self, t: CommandType) -> Self { self.semantic_type = t; self }
+
+    /// Finalise and return the entry.
+    #[must_use]
+    pub fn build(self) -> HistoryEntry {
+        HistoryEntry {
+            id: self.id,
+            timestamp: self.timestamp,
+            command: self.command,
+            exit_code: self.exit_code,
+            duration_ms: self.duration_ms,
+            cwd: self.cwd,
+            session_id: self.session_id,
+            semantic_type: self.semantic_type,
+        }
+    }
+}
+
+// ===========================================================================
+// Tests
+// ===========================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use phantom_semantic::CommandType;
+
+    fn make_entry(cmd: &str) -> HistoryEntry {
+        HistoryEntry::builder(cmd, "/home/dev/project", Uuid::new_v4()).build()
+    }
+
+    // -----------------------------------------------------------------------
+    // 1. Builder defaults are sensible
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn builder_defaults() {
+        let e = make_entry("ls -la");
+        assert_eq!(e.command(), "ls -la");
+        assert_eq!(e.exit_code(), None);
+        assert_eq!(e.duration_ms(), None);
+        assert_eq!(e.cwd(), &PathBuf::from("/home/dev/project"));
+        assert_eq!(e.semantic_type(), &CommandType::Unknown);
+    }
+
+    // -----------------------------------------------------------------------
+    // 2. Builder setters work
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn builder_setters() {
+        let session = Uuid::new_v4();
+        let e = HistoryEntry::builder("cargo build", "/tmp", session)
+            .exit_code(0)
+            .duration_ms(1234)
+            .semantic_type(CommandType::Shell)
+            .build();
+
+        assert_eq!(e.exit_code(), Some(0));
+        assert_eq!(e.duration_ms(), Some(1234));
+        assert_eq!(e.session_id(), session);
+        assert_eq!(e.semantic_type(), &CommandType::Shell);
+    }
+
+    // -----------------------------------------------------------------------
+    // 3. JSONL round-trip
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn jsonl_round_trip() {
+        let session = Uuid::new_v4();
+        let original = HistoryEntry::builder("git status", "/repo", session)
+            .exit_code(0)
+            .duration_ms(42)
+            .build();
+
+        let line = original.to_jsonl_line().unwrap();
+        // Must be a single line (no embedded newlines)
+        assert!(!line.contains('\n'));
+
+        let restored = HistoryEntry::from_jsonl_line(&line).unwrap();
+        assert_eq!(restored.id(), original.id());
+        assert_eq!(restored.command(), original.command());
+        assert_eq!(restored.exit_code(), original.exit_code());
+        assert_eq!(restored.duration_ms(), original.duration_ms());
+        assert_eq!(restored.cwd(), original.cwd());
+        assert_eq!(restored.session_id(), original.session_id());
+    }
+
+    // -----------------------------------------------------------------------
+    // 4. Timestamp survives ISO-8601 round-trip
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn timestamp_iso8601_round_trip() {
+        let ts = Utc::now();
+        let e = HistoryEntry::builder("echo hi", "/tmp", Uuid::new_v4())
+            .timestamp(ts)
+            .build();
+
+        let line = e.to_jsonl_line().unwrap();
+        let restored = HistoryEntry::from_jsonl_line(&line).unwrap();
+
+        // Truncate sub-microsecond precision for reliable equality
+        assert_eq!(
+            restored.timestamp().timestamp_millis(),
+            ts.timestamp_millis()
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // 5. Each entry gets a distinct UUID
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn unique_ids() {
+        let session = Uuid::new_v4();
+        let a = HistoryEntry::builder("a", "/", session).build();
+        let b = HistoryEntry::builder("b", "/", session).build();
+        assert_ne!(a.id(), b.id());
+    }
+
+    // -----------------------------------------------------------------------
+    // 6. Corrupt JSONL line returns an Err (no panic)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn corrupt_line_returns_err() {
+        let result = HistoryEntry::from_jsonl_line("{not valid json");
+        assert!(result.is_err());
+    }
+}

--- a/crates/phantom-history/src/lib.rs
+++ b/crates/phantom-history/src/lib.rs
@@ -1,2 +1,7 @@
+pub mod agent_capture;
+pub mod jsonl;
 pub mod store;
-pub use store::*;
+
+pub use agent_capture::{AgentOutputCapture, ToolCall};
+pub use jsonl::HistoryEntry;
+pub use store::HistoryStore;

--- a/crates/phantom-history/src/store.rs
+++ b/crates/phantom-history/src/store.rs
@@ -1,133 +1,159 @@
-use std::collections::hash_map::DefaultHasher;
-use std::fs::{self, OpenOptions};
-use std::hash::{Hash, Hasher};
-use std::io::{BufRead, BufReader, Write};
+//! Append-only JSONL history store.
+//!
+//! One JSONL file lives at `~/.local/share/phantom/history/<session_id>.jsonl`.
+//! Each line is a serialised [`HistoryEntry`].  The store also maintains an
+//! in-memory index (`HashMap<Uuid, u64>`) that maps entry ID → byte offset so
+//! that id-lookup stays O(1) without a full scan after the store is opened.
+
+use std::collections::HashMap;
+use std::fs::{self, File, OpenOptions};
+use std::io::{BufRead, BufReader, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use phantom_semantic::ParsedOutput;
-use serde::{Deserialize, Serialize};
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
 
-/// A history entry with timestamp and metadata.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct HistoryEntry {
-    /// Unix epoch seconds.
-    pub timestamp: u64,
-    /// Working directory where the command was executed.
-    pub working_dir: String,
-    /// Semantic parse result for the command.
-    pub parsed: ParsedOutput,
-}
+use crate::jsonl::HistoryEntry;
 
-/// Append-only command history backed by a `.jsonl` file.
+// ---------------------------------------------------------------------------
+// HistoryStore
+// ---------------------------------------------------------------------------
+
+/// Append-only JSONL history store for a session.
 ///
-/// One file per project directory, stored at `~/.config/phantom/history/`.
-/// Each line is a JSON-serialized [`HistoryEntry`].
+/// All public methods return [`anyhow::Result`] — no `.unwrap()` in production
+/// paths.
 pub struct HistoryStore {
+    /// Path to the `.jsonl` file.
     path: PathBuf,
+    /// Maps entry id → byte offset of the start of its line in the file.
+    index: HashMap<Uuid, u64>,
+    /// Byte offset where the next append will begin.
+    next_offset: u64,
 }
 
 impl HistoryStore {
-    /// Open or create a history store for the given project directory.
+    // -----------------------------------------------------------------------
+    // Construction
+    // -----------------------------------------------------------------------
+
+    /// Open (or create) a store for `session_id` under the default data dir:
+    /// `~/.local/share/phantom/history/<session_id>.jsonl`.
+    pub fn open(session_id: Uuid) -> Result<Self> {
+        let dir = default_data_dir();
+        fs::create_dir_all(&dir)
+            .with_context(|| format!("cannot create history dir: {}", dir.display()))?;
+        let path = dir.join(format!("{session_id}.jsonl"));
+        Self::open_at(path)
+    }
+
+    /// Open (or create) a store at an explicit path.
     ///
-    /// The project directory is hashed to produce a stable filename under
-    /// `~/.config/phantom/history/{hash}.jsonl`.
-    pub fn open(project_dir: &str) -> Result<Self> {
-        let base = dirs_base();
-        fs::create_dir_all(&base)
-            .with_context(|| format!("failed to create history dir: {}", base.display()))?;
+    /// Scans the existing file to rebuild the in-memory index.
+    pub fn open_at(path: impl Into<PathBuf>) -> Result<Self> {
+        let path = path.into();
 
-        let hash = hash_project_dir(project_dir);
-        let path = base.join(format!("{hash}.jsonl"));
+        let mut store = Self {
+            path,
+            index: HashMap::new(),
+            next_offset: 0,
+        };
 
-        Ok(Self { path })
+        store.rebuild_index()?;
+        Ok(store)
     }
 
-    /// Open a store at an explicit path (used in tests).
-    #[cfg(test)]
-    fn open_at(path: PathBuf) -> Self {
-        Self { path }
-    }
+    // -----------------------------------------------------------------------
+    // Writes
+    // -----------------------------------------------------------------------
 
-    /// Append a command execution to history.
-    pub fn append(&self, entry: &HistoryEntry) -> Result<()> {
+    /// Append `entry` to the JSONL file.
+    ///
+    /// The in-memory index is updated so subsequent id-lookups reflect the new
+    /// entry without a file rescan.
+    pub fn append(&mut self, entry: &HistoryEntry) -> Result<()> {
+        let line = entry.to_jsonl_line()?;
+
         let mut file = OpenOptions::new()
             .create(true)
             .append(true)
             .open(&self.path)
-            .with_context(|| format!("failed to open history file: {}", self.path.display()))?;
+            .with_context(|| format!("cannot open history file: {}", self.path.display()))?;
 
-        let json =
-            serde_json::to_string(entry).context("failed to serialize history entry")?;
+        let offset = self.next_offset;
+        writeln!(file, "{line}")
+            .with_context(|| format!("cannot write to history file: {}", self.path.display()))?;
 
-        writeln!(file, "{json}").context("failed to write history entry")?;
+        // line + '\n'
+        self.next_offset += line.len() as u64 + 1;
+        self.index.insert(entry.id(), offset);
 
         Ok(())
     }
 
-    /// Search history by text query (case-insensitive substring match on
-    /// command, raw_output, and error messages). Returns the most recent
-    /// matches first, up to `limit`.
-    pub fn search(&self, query: &str, limit: usize) -> Result<Vec<HistoryEntry>> {
-        let lower_query = query.to_lowercase();
-        let entries = self.read_all()?;
+    // -----------------------------------------------------------------------
+    // Reads
+    // -----------------------------------------------------------------------
 
-        let mut matches: Vec<HistoryEntry> = entries
-            .into_iter()
-            .filter(|e| entry_matches(e, &lower_query))
-            .collect();
-
-        // Most recent first.
-        matches.reverse();
-        matches.truncate(limit);
-
-        Ok(matches)
-    }
-
-    /// Get the last N entries (most recent last in the returned vec, matching
-    /// chronological order).
+    /// Return the most-recent `limit` entries in chronological order
+    /// (oldest first, newest last).
     pub fn recent(&self, limit: usize) -> Result<Vec<HistoryEntry>> {
-        let entries = self.read_all()?;
-        let start = entries.len().saturating_sub(limit);
-
-        Ok(entries[start..].to_vec())
+        let all = self.read_all()?;
+        let start = all.len().saturating_sub(limit);
+        Ok(all[start..].to_vec())
     }
 
-    /// Search for entries with errors, most recent first.
-    pub fn errors_recent(&self, limit: usize) -> Result<Vec<HistoryEntry>> {
-        let entries = self.read_all()?;
+    /// Fetch a single entry by its UUID in O(1) (index lookup + one seek).
+    pub fn get_by_id(&self, id: Uuid) -> Result<Option<HistoryEntry>> {
+        let Some(&offset) = self.index.get(&id) else {
+            return Ok(None);
+        };
 
-        let mut with_errors: Vec<HistoryEntry> = entries
+        let mut file = File::open(&self.path)
+            .with_context(|| format!("cannot open history file: {}", self.path.display()))?;
+        file.seek(SeekFrom::Start(offset)).context("seek failed")?;
+
+        let mut reader = BufReader::new(file);
+        let mut line = String::new();
+        reader.read_line(&mut line).context("read_line failed")?;
+
+        let entry = HistoryEntry::from_jsonl_line(line.trim())
+            .context("index pointed at a corrupt line")?;
+        Ok(Some(entry))
+    }
+
+    /// Return all entries for `session_id` in chronological order.
+    pub fn by_session(&self, session_id: Uuid) -> Result<Vec<HistoryEntry>> {
+        let all = self.read_all()?;
+        Ok(all
             .into_iter()
-            .filter(|e| !e.parsed.errors.is_empty())
-            .collect();
-
-        with_errors.reverse();
-        with_errors.truncate(limit);
-
-        Ok(with_errors)
+            .filter(|e| e.session_id() == session_id)
+            .collect())
     }
 
-    /// Get total entry count (without deserializing every line).
-    pub fn count(&self) -> Result<usize> {
-        if !self.path.exists() {
-            return Ok(0);
-        }
-
-        let file = fs::File::open(&self.path)
-            .with_context(|| format!("failed to open history file: {}", self.path.display()))?;
-        let reader = BufReader::new(file);
-
-        let count = reader
-            .lines()
-            .filter_map(|l| l.ok())
-            .filter(|l| !l.trim().is_empty())
-            .count();
-
-        Ok(count)
+    /// Return entries whose timestamp falls within `[from, to]` (inclusive),
+    /// in chronological order.
+    pub fn by_time_range(
+        &self,
+        from: DateTime<Utc>,
+        to: DateTime<Utc>,
+    ) -> Result<Vec<HistoryEntry>> {
+        let all = self.read_all()?;
+        Ok(all
+            .into_iter()
+            .filter(|e| e.timestamp() >= from && e.timestamp() <= to)
+            .collect())
     }
 
-    /// Get the history file path.
+    /// Total number of (non-corrupt) entries recorded in the index.
+    #[must_use]
+    pub fn count(&self) -> usize {
+        self.index.len()
+    }
+
+    /// Path to the backing JSONL file.
+    #[must_use]
     pub fn path(&self) -> &Path {
         &self.path
     }
@@ -136,78 +162,72 @@ impl HistoryStore {
     // Internal helpers
     // -----------------------------------------------------------------------
 
-    /// Read all entries from the backing file.
+    /// Read and deserialise all entries, skipping corrupt lines with a warning.
     fn read_all(&self) -> Result<Vec<HistoryEntry>> {
         if !self.path.exists() {
             return Ok(Vec::new());
         }
 
-        let file = fs::File::open(&self.path)
-            .with_context(|| format!("failed to open history file: {}", self.path.display()))?;
+        let file = File::open(&self.path)
+            .with_context(|| format!("cannot open history file: {}", self.path.display()))?;
         let reader = BufReader::new(file);
 
         let mut entries = Vec::new();
         for line in reader.lines() {
-            let line = line.context("failed to read line from history file")?;
+            let line = line.context("read error in history file")?;
             let trimmed = line.trim();
             if trimmed.is_empty() {
                 continue;
             }
-            match serde_json::from_str::<HistoryEntry>(trimmed) {
-                Ok(entry) => entries.push(entry),
-                Err(e) => {
-                    // Log but skip corrupt lines so one bad entry doesn't brick
-                    // the entire history.
-                    log::warn!("skipping corrupt history entry: {e}");
-                }
+            match HistoryEntry::from_jsonl_line(trimmed) {
+                Ok(e) => entries.push(e),
+                Err(e) => log::warn!("skipping corrupt history line: {e}"),
             }
         }
-
         Ok(entries)
     }
+
+    /// Scan the file to populate `index` and `next_offset`.
+    fn rebuild_index(&mut self) -> Result<()> {
+        if !self.path.exists() {
+            self.next_offset = 0;
+            return Ok(());
+        }
+
+        let file = File::open(&self.path).with_context(|| {
+            format!(
+                "cannot open history file for indexing: {}",
+                self.path.display()
+            )
+        })?;
+        let reader = BufReader::new(file);
+
+        let mut offset: u64 = 0;
+        for line in reader.lines() {
+            let line = line.context("read error while rebuilding index")?;
+            // +1 for the '\n' that writeln! appended
+            let line_len = line.len() as u64 + 1;
+            let trimmed = line.trim();
+            if !trimmed.is_empty()
+                && let Ok(entry) = HistoryEntry::from_jsonl_line(trimmed)
+            {
+                self.index.insert(entry.id(), offset);
+            }
+            offset += line_len;
+        }
+        self.next_offset = offset;
+        Ok(())
+    }
 }
 
-/// Case-insensitive substring match across the searchable fields of an entry.
-fn entry_matches(entry: &HistoryEntry, lower_query: &str) -> bool {
-    let p = &entry.parsed;
-
-    if p.command.to_lowercase().contains(lower_query) {
-        return true;
-    }
-    if p.raw_output.to_lowercase().contains(lower_query) {
-        return true;
-    }
-    for err in &p.errors {
-        if err.message.to_lowercase().contains(lower_query) {
-            return true;
-        }
-        if err.raw_line.to_lowercase().contains(lower_query) {
-            return true;
-        }
-    }
-    for warn in &p.warnings {
-        if warn.message.to_lowercase().contains(lower_query) {
-            return true;
-        }
-    }
-
-    false
-}
-
-/// Default base directory for history files.
-fn dirs_base() -> PathBuf {
+/// Default data directory: `~/.local/share/phantom/history/`.
+fn default_data_dir() -> PathBuf {
     let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
     PathBuf::from(home)
-        .join(".config")
+        .join(".local")
+        .join("share")
         .join("phantom")
         .join("history")
-}
-
-/// Deterministic hash of a project directory path to a hex string.
-fn hash_project_dir(project_dir: &str) -> String {
-    let mut hasher = DefaultHasher::new();
-    project_dir.hash(&mut hasher);
-    format!("{:016x}", hasher.finish())
 }
 
 // ===========================================================================
@@ -217,92 +237,66 @@ fn hash_project_dir(project_dir: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use phantom_semantic::{
-        CommandType, ContentType, DetectedError, ErrorType, ParsedOutput, Severity,
-    };
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use chrono::Duration;
+    use phantom_semantic::CommandType;
+    use std::io::Write;
+    use tempfile::TempDir;
 
-    /// Helper: create a store backed by a temp file.
-    fn temp_store() -> (HistoryStore, tempfile::TempDir) {
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    fn temp_store() -> (HistoryStore, TempDir) {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.jsonl");
-        let store = HistoryStore::open_at(path);
+        let store = HistoryStore::open_at(&path).unwrap();
         (store, dir)
     }
 
-    /// Helper: build a basic history entry.
-    fn make_entry(command: &str, output: &str, errors: Vec<DetectedError>) -> HistoryEntry {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-
-        HistoryEntry {
-            timestamp: now,
-            working_dir: "/home/dev/project".to_string(),
-            parsed: ParsedOutput {
-                command: command.to_string(),
-                command_type: CommandType::Shell,
-                exit_code: Some(0),
-                content_type: ContentType::PlainText,
-                errors,
-                warnings: vec![],
-                duration_ms: Some(42),
-                raw_output: output.to_string(),
-            },
-        }
+    fn entry(cmd: &str, session: Uuid) -> HistoryEntry {
+        HistoryEntry::builder(cmd, "/home/dev", session).build()
     }
 
-    fn make_error(message: &str) -> DetectedError {
-        DetectedError {
-            message: message.to_string(),
-            error_type: ErrorType::Compiler,
-            file: Some("src/main.rs".to_string()),
-            line: Some(10),
-            column: Some(5),
-            code: Some("E0308".to_string()),
-            severity: Severity::Error,
-            raw_line: format!("error[E0308]: {message}"),
-            suggestion: None,
-        }
+    fn entry_with_exit(cmd: &str, session: Uuid, code: i32) -> HistoryEntry {
+        HistoryEntry::builder(cmd, "/home/dev", session)
+            .exit_code(code)
+            .build()
     }
 
     // -----------------------------------------------------------------------
-    // 1. Append and count
+    // 1. Append increments count
     // -----------------------------------------------------------------------
 
     #[test]
     fn append_increments_count() {
-        let (store, _dir) = temp_store();
+        let (mut store, _dir) = temp_store();
+        let session = Uuid::new_v4();
 
-        assert_eq!(store.count().unwrap(), 0);
-
-        store.append(&make_entry("ls -la", "file1\nfile2", vec![])).unwrap();
-        assert_eq!(store.count().unwrap(), 1);
-
-        store.append(&make_entry("pwd", "/home/dev/project", vec![])).unwrap();
-        assert_eq!(store.count().unwrap(), 2);
+        assert_eq!(store.count(), 0);
+        store.append(&entry("ls", session)).unwrap();
+        assert_eq!(store.count(), 1);
+        store.append(&entry("pwd", session)).unwrap();
+        assert_eq!(store.count(), 2);
     }
 
     // -----------------------------------------------------------------------
-    // 2. Recent entries
+    // 2. Recent returns last N in chronological order
     // -----------------------------------------------------------------------
 
     #[test]
     fn recent_returns_last_n_in_order() {
-        let (store, _dir) = temp_store();
+        let (mut store, _dir) = temp_store();
+        let session = Uuid::new_v4();
 
         for i in 0..5 {
-            store
-                .append(&make_entry(&format!("cmd-{i}"), "", vec![]))
-                .unwrap();
+            store.append(&entry(&format!("cmd-{i}"), session)).unwrap();
         }
 
         let recent = store.recent(3).unwrap();
         assert_eq!(recent.len(), 3);
-        assert_eq!(recent[0].parsed.command, "cmd-2");
-        assert_eq!(recent[1].parsed.command, "cmd-3");
-        assert_eq!(recent[2].parsed.command, "cmd-4");
+        assert_eq!(recent[0].command(), "cmd-2");
+        assert_eq!(recent[1].command(), "cmd-3");
+        assert_eq!(recent[2].command(), "cmd-4");
     }
 
     // -----------------------------------------------------------------------
@@ -311,208 +305,206 @@ mod tests {
 
     #[test]
     fn recent_limit_exceeds_total() {
-        let (store, _dir) = temp_store();
-
-        store.append(&make_entry("only-one", "", vec![])).unwrap();
+        let (mut store, _dir) = temp_store();
+        let session = Uuid::new_v4();
+        store.append(&entry("only-one", session)).unwrap();
 
         let recent = store.recent(100).unwrap();
         assert_eq!(recent.len(), 1);
-        assert_eq!(recent[0].parsed.command, "only-one");
     }
 
     // -----------------------------------------------------------------------
-    // 4. Search by command text
+    // 4. get_by_id returns correct entry (O(1) path)
     // -----------------------------------------------------------------------
 
     #[test]
-    fn search_matches_command_text() {
-        let (store, _dir) = temp_store();
+    fn get_by_id_returns_correct_entry() {
+        let (mut store, _dir) = temp_store();
+        let session = Uuid::new_v4();
 
-        store.append(&make_entry("cargo build", "Compiling...", vec![])).unwrap();
-        store.append(&make_entry("git status", "On branch main", vec![])).unwrap();
-        store.append(&make_entry("cargo test", "test result: ok", vec![])).unwrap();
+        store.append(&entry("first", session)).unwrap();
+        let target = entry("target-command", session);
+        let target_id = target.id();
+        store.append(&target).unwrap();
+        store.append(&entry("third", session)).unwrap();
 
-        let results = store.search("cargo", 10).unwrap();
-        assert_eq!(results.len(), 2);
-        // Most recent first.
-        assert_eq!(results[0].parsed.command, "cargo test");
-        assert_eq!(results[1].parsed.command, "cargo build");
+        let found = store.get_by_id(target_id).unwrap().unwrap();
+        assert_eq!(found.command(), "target-command");
+        assert_eq!(found.id(), target_id);
     }
 
     // -----------------------------------------------------------------------
-    // 5. Search is case-insensitive
+    // 5. get_by_id returns None for unknown UUID
     // -----------------------------------------------------------------------
 
     #[test]
-    fn search_is_case_insensitive() {
-        let (store, _dir) = temp_store();
+    fn get_by_id_unknown_returns_none() {
+        let (mut store, _dir) = temp_store();
+        let session = Uuid::new_v4();
+        store.append(&entry("ls", session)).unwrap();
 
-        store
-            .append(&make_entry("CARGO BUILD", "COMPILING", vec![]))
-            .unwrap();
+        let result = store.get_by_id(Uuid::new_v4()).unwrap();
+        assert!(result.is_none());
+    }
 
-        let results = store.search("cargo", 10).unwrap();
+    // -----------------------------------------------------------------------
+    // 6. by_session filters correctly
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn by_session_filters_entries() {
+        let (mut store, _dir) = temp_store();
+        let session_a = Uuid::new_v4();
+        let session_b = Uuid::new_v4();
+
+        store.append(&entry("a1", session_a)).unwrap();
+        store.append(&entry("b1", session_b)).unwrap();
+        store.append(&entry("a2", session_a)).unwrap();
+        store.append(&entry("b2", session_b)).unwrap();
+
+        let a_entries = store.by_session(session_a).unwrap();
+        assert_eq!(a_entries.len(), 2);
+        assert!(a_entries.iter().all(|e| e.session_id() == session_a));
+
+        let b_entries = store.by_session(session_b).unwrap();
+        assert_eq!(b_entries.len(), 2);
+    }
+
+    // -----------------------------------------------------------------------
+    // 7. by_time_range returns entries within the range
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn by_time_range_filters_correctly() {
+        let (mut store, _dir) = temp_store();
+        let session = Uuid::new_v4();
+        let now = Utc::now();
+
+        let past = HistoryEntry::builder("past", "/", session)
+            .timestamp(now - Duration::hours(2))
+            .build();
+        let in_range = HistoryEntry::builder("in-range", "/", session)
+            .timestamp(now - Duration::minutes(30))
+            .build();
+        let future = HistoryEntry::builder("future", "/", session)
+            .timestamp(now + Duration::hours(1))
+            .build();
+
+        store.append(&past).unwrap();
+        store.append(&in_range).unwrap();
+        store.append(&future).unwrap();
+
+        let from = now - Duration::hours(1);
+        let to = now;
+        let results = store.by_time_range(from, to).unwrap();
+
         assert_eq!(results.len(), 1);
-
-        let results_upper = store.search("CARGO", 10).unwrap();
-        assert_eq!(results_upper.len(), 1);
+        assert_eq!(results[0].command(), "in-range");
     }
 
     // -----------------------------------------------------------------------
-    // 6. Search matches raw output
+    // 8. Index survives reopen (rebuild_index)
     // -----------------------------------------------------------------------
 
     #[test]
-    fn search_matches_raw_output() {
-        let (store, _dir) = temp_store();
+    fn index_survives_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("history.jsonl");
+        let session = Uuid::new_v4();
 
-        store
-            .append(&make_entry("curl api.example.com", "404 Not Found", vec![]))
-            .unwrap();
-        store
-            .append(&make_entry("echo hello", "hello", vec![]))
-            .unwrap();
+        let target_id = {
+            let mut store = HistoryStore::open_at(&path).unwrap();
+            store.append(&entry("first", session)).unwrap();
+            let target = entry("second", session);
+            let id = target.id();
+            store.append(&target).unwrap();
+            id
+        };
 
-        let results = store.search("not found", 10).unwrap();
-        assert_eq!(results.len(), 1);
-        assert_eq!(results[0].parsed.command, "curl api.example.com");
+        // Re-open — index must be rebuilt from file
+        let store = HistoryStore::open_at(&path).unwrap();
+        assert_eq!(store.count(), 2);
+
+        let found = store.get_by_id(target_id).unwrap().unwrap();
+        assert_eq!(found.command(), "second");
     }
 
     // -----------------------------------------------------------------------
-    // 7. Search matches error messages
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn search_matches_error_messages() {
-        let (store, _dir) = temp_store();
-
-        let err = make_error("mismatched types");
-        store
-            .append(&make_entry("cargo build", "", vec![err]))
-            .unwrap();
-        store
-            .append(&make_entry("ls", "", vec![]))
-            .unwrap();
-
-        let results = store.search("mismatched", 10).unwrap();
-        assert_eq!(results.len(), 1);
-        assert_eq!(results[0].parsed.command, "cargo build");
-    }
-
-    // -----------------------------------------------------------------------
-    // 8. errors_recent filters correctly
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn errors_recent_filters_entries_with_errors() {
-        let (store, _dir) = temp_store();
-
-        store
-            .append(&make_entry("cargo build", "ok", vec![]))
-            .unwrap();
-
-        let err1 = make_error("mismatched types");
-        store
-            .append(&make_entry("cargo check", "", vec![err1]))
-            .unwrap();
-
-        store
-            .append(&make_entry("ls", "file1", vec![]))
-            .unwrap();
-
-        let err2 = make_error("unresolved import");
-        store
-            .append(&make_entry("cargo test", "", vec![err2]))
-            .unwrap();
-
-        let errors = store.errors_recent(10).unwrap();
-        assert_eq!(errors.len(), 2);
-        // Most recent first.
-        assert_eq!(errors[0].parsed.command, "cargo test");
-        assert_eq!(errors[1].parsed.command, "cargo check");
-    }
-
-    // -----------------------------------------------------------------------
-    // 9. errors_recent respects limit
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn errors_recent_respects_limit() {
-        let (store, _dir) = temp_store();
-
-        for i in 0..5 {
-            let err = make_error(&format!("error-{i}"));
-            store
-                .append(&make_entry(&format!("cmd-{i}"), "", vec![err]))
-                .unwrap();
-        }
-
-        let errors = store.errors_recent(2).unwrap();
-        assert_eq!(errors.len(), 2);
-        assert_eq!(errors[0].parsed.command, "cmd-4");
-        assert_eq!(errors[1].parsed.command, "cmd-3");
-    }
-
-    // -----------------------------------------------------------------------
-    // 10. Empty store returns empty results
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn empty_store_returns_empty() {
-        let (store, _dir) = temp_store();
-
-        assert_eq!(store.count().unwrap(), 0);
-        assert!(store.recent(10).unwrap().is_empty());
-        assert!(store.search("anything", 10).unwrap().is_empty());
-        assert!(store.errors_recent(10).unwrap().is_empty());
-    }
-
-    // -----------------------------------------------------------------------
-    // 11. Corrupt lines are skipped gracefully
+    // 9. Corrupt lines are skipped gracefully
     // -----------------------------------------------------------------------
 
     #[test]
     fn corrupt_lines_skipped() {
-        let (store, _dir) = temp_store();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("history.jsonl");
+        let session = Uuid::new_v4();
 
-        // Write a valid entry.
-        store
-            .append(&make_entry("valid", "output", vec![]))
-            .unwrap();
+        {
+            let mut store = HistoryStore::open_at(&path).unwrap();
+            store.append(&entry("good-first", session)).unwrap();
+        }
 
-        // Manually append garbage.
-        let mut file = OpenOptions::new()
-            .append(true)
-            .open(store.path())
-            .unwrap();
-        writeln!(file, "{{not valid json at all").unwrap();
+        // Inject a corrupt line directly
+        {
+            let mut f = OpenOptions::new().append(true).open(&path).unwrap();
+            writeln!(f, "{{not valid json").unwrap();
+        }
 
-        // Write another valid entry.
-        store
-            .append(&make_entry("also-valid", "output2", vec![]))
-            .unwrap();
+        {
+            let mut store = HistoryStore::open_at(&path).unwrap();
+            store.append(&entry("good-second", session)).unwrap();
+        }
 
+        let store = HistoryStore::open_at(&path).unwrap();
         let recent = store.recent(10).unwrap();
         assert_eq!(recent.len(), 2);
-        assert_eq!(recent[0].parsed.command, "valid");
-        assert_eq!(recent[1].parsed.command, "also-valid");
+        assert_eq!(recent[0].command(), "good-first");
+        assert_eq!(recent[1].command(), "good-second");
     }
 
     // -----------------------------------------------------------------------
-    // 12. Serialization round-trip
+    // 10. Empty store is safe
     // -----------------------------------------------------------------------
 
     #[test]
-    fn entry_round_trips_through_json() {
-        let err = make_error("type mismatch");
-        let entry = make_entry("cargo build --release", "Compiling phantom...", vec![err]);
+    fn empty_store_is_safe() {
+        let (store, _dir) = temp_store();
+        assert_eq!(store.count(), 0);
+        assert!(store.recent(10).unwrap().is_empty());
+        assert!(store.get_by_id(Uuid::new_v4()).unwrap().is_none());
+    }
 
-        let json = serde_json::to_string(&entry).unwrap();
-        let deser: HistoryEntry = serde_json::from_str(&json).unwrap();
+    // -----------------------------------------------------------------------
+    // 11. exit_code survives round-trip
+    // -----------------------------------------------------------------------
 
-        assert_eq!(deser.parsed.command, entry.parsed.command);
-        assert_eq!(deser.parsed.errors.len(), 1);
-        assert_eq!(deser.parsed.errors[0].message, "type mismatch");
-        assert_eq!(deser.working_dir, entry.working_dir);
+    #[test]
+    fn exit_code_round_trip() {
+        let (mut store, _dir) = temp_store();
+        let session = Uuid::new_v4();
+        let e = entry_with_exit("failing-cmd", session, 127);
+        let id = e.id();
+        store.append(&e).unwrap();
+
+        let restored = store.get_by_id(id).unwrap().unwrap();
+        assert_eq!(restored.exit_code(), Some(127));
+    }
+
+    // -----------------------------------------------------------------------
+    // 12. Semantic type survives round-trip
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn semantic_type_round_trip() {
+        let (mut store, _dir) = temp_store();
+        let session = Uuid::new_v4();
+        let e = HistoryEntry::builder("cargo build", "/project", session)
+            .semantic_type(CommandType::Shell)
+            .build();
+        let id = e.id();
+        store.append(&e).unwrap();
+
+        let restored = store.get_by_id(id).unwrap().unwrap();
+        assert_eq!(restored.semantic_type(), &CommandType::Shell);
     }
 }


### PR DESCRIPTION
Closes #75

## Summary

- **`HistoryEntry`** (`jsonl.rs`): all fields private, UUID id, ISO-8601 `chrono::DateTime<Utc>` timestamp, `command`, `exit_code: Option<i32>`, `duration_ms: Option<u64>`, `cwd: PathBuf`, `session_id: Uuid`, `semantic_type: CommandType`. Constructed via fluent builder; read via typed getters. JSONL serialisation via `to_jsonl_line` / `from_jsonl_line`.
- **`HistoryStore`** (`store.rs`): append-only JSONL file at `~/.local/share/phantom/history/<session_id>.jsonl`. In-memory `HashMap<Uuid, u64>` index (entry id → byte offset) rebuilt on open gives O(1) `get_by_id`. `recent(N)`, `by_session(Uuid)`, `by_time_range(from, to)` queries. Corrupt lines skipped with `log::warn`.
- **`AgentOutputCapture`** (`agent_capture.rs`): parallel JSONL sidecar (`<session_id>-agents.jsonl`). Records agent name, ordered `ToolCall` list (name, input_json, output_json, called_at), and free-form text output. `by_agent`, `recent`, `count` read queries. Corrupt lines skipped gracefully.
- **25 TDD tests**: append/count, recent, O(1) id lookup, session filter, time-range filter, index persistence across reopen, corrupt-line skipping, full JSON round-trip for all field types. Zero clippy warnings.

## Test plan

- [x] `cargo test -p phantom-history` → 25/25 pass
- [x] `cargo clippy -p phantom-history --no-deps` → clean (0 warnings)
- [x] All struct fields private with constructors and getters
- [x] No `.unwrap()` in production paths (only in `#[cfg(test)]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)