### PR TITLE
feat(#62,#78): durable NotificationStore + versioned EventLog schema for phantom-memory

### DIFF
--- a/crates/phantom-memory/src/lib.rs
+++ b/crates/phantom-memory/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod event_log;
 pub mod memory_blocks;
+pub mod notifications;
+pub mod schema;
 pub mod store;
 pub use store::*;

--- a/crates/phantom-memory/src/notifications.rs
+++ b/crates/phantom-memory/src/notifications.rs
@@ -1,0 +1,739 @@
+//! Durable notification store for the agent runtime.
+//!
+//! Every significant lifecycle transition — agent spawn, pipeline completion,
+//! denial detected — is recorded as a [`Notification`] that persists across
+//! process restarts.  Notifications are **not** ephemeral toasts; they are
+//! queryable, mark-as-read records backed by an append-write JSON file.
+//!
+//! # Storage format
+//!
+//! Notifications are stored as a JSON array in
+//! `~/.config/phantom/notifications/{project_hash}.json`.  Writes are atomic
+//! (write-then-rename).
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use phantom_memory::notifications::{NotificationStore, NotificationKind};
+//! use std::path::Path;
+//!
+//! let mut store = NotificationStore::open_in("/my/project", Path::new("/tmp/notif")).unwrap();
+//! store.push(NotificationKind::AgentRunning, "Agent started", "Agent #1 is running", None).unwrap();
+//! let unread = store.unread();
+//! assert_eq!(unread.len(), 1);
+//! ```
+
+use std::collections::hash_map::DefaultHasher;
+use std::fs;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// Opaque identifier for a notification.
+///
+/// Assigned monotonically by [`NotificationStore::push`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct NotificationId(u64);
+
+impl NotificationId {
+    /// The underlying integer value.
+    pub fn value(self) -> u64 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for NotificationId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "notification#{}", self.0)
+    }
+}
+
+/// Semantic classification of a notification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NotificationKind {
+    /// An AI plan is ready for review or execution.
+    PlanReady,
+    /// An agent has started and is actively running.
+    AgentRunning,
+    /// An agent completed and its memory/context is synced.
+    AgentSynced,
+    /// An agent died unexpectedly (no clean completion path).
+    AgentFlatlined,
+    /// A multi-step pipeline finished successfully.
+    PipelineCompleted,
+    /// A pipeline cannot proceed due to a blocked dependency or denial.
+    PipelineBlocked,
+}
+
+impl std::fmt::Display for NotificationKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            NotificationKind::PlanReady => "plan_ready",
+            NotificationKind::AgentRunning => "agent_running",
+            NotificationKind::AgentSynced => "agent_synced",
+            NotificationKind::AgentFlatlined => "agent_flatlined",
+            NotificationKind::PipelineCompleted => "pipeline_completed",
+            NotificationKind::PipelineBlocked => "pipeline_blocked",
+        };
+        write!(f, "{s}")
+    }
+}
+
+/// A single durable notification.
+///
+/// All fields are private; access them through the provided getters.
+/// Use [`NotificationStore::push`] to create and persist a new notification.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Notification {
+    id: NotificationId,
+    kind: NotificationKind,
+    title: String,
+    message: String,
+    /// Optional agent that produced this notification.
+    agent_id: Option<u64>,
+    read: bool,
+    /// Wall-clock time of creation in milliseconds since the Unix epoch.
+    created_at_ms: u64,
+}
+
+impl Notification {
+    /// The notification's unique, store-assigned identifier.
+    pub fn id(&self) -> NotificationId {
+        self.id
+    }
+
+    /// Semantic kind of this notification.
+    pub fn kind(&self) -> NotificationKind {
+        self.kind
+    }
+
+    /// Short human-readable title (suitable for a badge or toast header).
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    /// Full human-readable description of the event.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    /// The agent that produced this notification, if applicable.
+    pub fn agent_id(&self) -> Option<u64> {
+        self.agent_id
+    }
+
+    /// Whether this notification has been marked as read.
+    pub fn is_read(&self) -> bool {
+        self.read
+    }
+
+    /// Creation time in milliseconds since the Unix epoch.
+    pub fn created_at_ms(&self) -> u64 {
+        self.created_at_ms
+    }
+}
+
+/// Persistent notification store for a single project.
+///
+/// Backed by a JSON file at `<base_dir>/<project_hash>.json`.  All writes
+/// are atomic (write-tmp-then-rename).
+pub struct NotificationStore {
+    notifications: Vec<Notification>,
+    next_id: u64,
+    path: PathBuf,
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+fn now_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+fn project_hash(project_dir: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    project_dir.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+// ── NotificationStore ─────────────────────────────────────────────────────────
+
+impl NotificationStore {
+    /// Open or create the notification store for a project.
+    ///
+    /// The backing file is located at
+    /// `~/.config/phantom/notifications/<hash>.json` where `<hash>` is derived
+    /// from `project_dir`.  If the file already exists it is loaded; otherwise
+    /// the store starts empty.
+    pub fn open(project_dir: &str) -> Result<Self> {
+        let home = std::env::var("HOME").context("HOME not set")?;
+        let dir = PathBuf::from(home).join(".config/phantom/notifications");
+        Self::open_in(project_dir, &dir)
+    }
+
+    /// Open with an explicit base directory (useful for testing).
+    pub fn open_in(project_dir: &str, base_dir: &Path) -> Result<Self> {
+        fs::create_dir_all(base_dir).with_context(|| {
+            format!("failed to create notification dir: {}", base_dir.display())
+        })?;
+
+        let hash = project_hash(project_dir);
+        let path = base_dir.join(format!("{hash}.json"));
+
+        let notifications: Vec<Notification> = if path.exists() {
+            let data = fs::read_to_string(&path)
+                .with_context(|| format!("failed to read {}", path.display()))?;
+            serde_json::from_str(&data)
+                .with_context(|| format!("failed to parse {}", path.display()))?
+        } else {
+            Vec::new()
+        };
+
+        // Recover next_id from the highest existing id + 1.
+        let next_id = notifications
+            .iter()
+            .map(|n| n.id.0)
+            .max()
+            .map(|max| max + 1)
+            .unwrap_or(1);
+
+        Ok(Self {
+            notifications,
+            next_id,
+            path,
+        })
+    }
+
+    /// Append a new notification and persist it to disk.
+    ///
+    /// # Arguments
+    ///
+    /// - `kind` — the semantic kind of this notification.
+    /// - `title` — short display title (e.g. `"Agent started"`).
+    /// - `message` — full description of the event.
+    /// - `agent_id` — the agent that triggered the notification, if any.
+    ///
+    /// Returns the freshly persisted [`Notification`].
+    pub fn push(
+        &mut self,
+        kind: NotificationKind,
+        title: impl Into<String>,
+        message: impl Into<String>,
+        agent_id: Option<u64>,
+    ) -> Result<&Notification> {
+        let n = Notification {
+            id: NotificationId(self.next_id),
+            kind,
+            title: title.into(),
+            message: message.into(),
+            agent_id,
+            read: false,
+            created_at_ms: now_unix_ms(),
+        };
+        self.next_id += 1;
+        self.notifications.push(n);
+        self.save()?;
+        Ok(self.notifications.last().expect("just pushed"))
+    }
+
+    /// Mark a notification as read.
+    ///
+    /// Returns `true` if the notification was found and updated.
+    /// If it was already read or does not exist, returns `false`.
+    pub fn mark_read(&mut self, id: NotificationId) -> Result<bool> {
+        let Some(n) = self.notifications.iter_mut().find(|n| n.id == id) else {
+            return Ok(false);
+        };
+        if n.read {
+            return Ok(false);
+        }
+        n.read = true;
+        self.save()?;
+        Ok(true)
+    }
+
+    /// Mark all unread notifications as read.
+    ///
+    /// Returns the number of notifications that were marked read.
+    pub fn mark_all_read(&mut self) -> Result<usize> {
+        let count = self
+            .notifications
+            .iter_mut()
+            .filter(|n| !n.read)
+            .fold(0usize, |acc, n| {
+                n.read = true;
+                acc + 1
+            });
+        if count > 0 {
+            self.save()?;
+        }
+        Ok(count)
+    }
+
+    /// All notifications in insertion order (oldest first).
+    pub fn all(&self) -> &[Notification] {
+        &self.notifications
+    }
+
+    /// Unread notifications in insertion order (oldest first).
+    pub fn unread(&self) -> Vec<&Notification> {
+        self.notifications.iter().filter(|n| !n.read).collect()
+    }
+
+    /// Count of unread notifications.
+    pub fn unread_count(&self) -> usize {
+        self.notifications.iter().filter(|n| !n.read).count()
+    }
+
+    /// Notifications filtered by [`NotificationKind`], in insertion order.
+    pub fn by_kind(&self, kind: NotificationKind) -> Vec<&Notification> {
+        self.notifications
+            .iter()
+            .filter(|n| n.kind == kind)
+            .collect()
+    }
+
+    /// Look up a notification by id.
+    pub fn get(&self, id: NotificationId) -> Option<&Notification> {
+        self.notifications.iter().find(|n| n.id == id)
+    }
+
+    /// Total number of notifications (read and unread).
+    pub fn count(&self) -> usize {
+        self.notifications.len()
+    }
+
+    /// Soft-delete: remove a notification by id.
+    ///
+    /// Returns `true` if the notification existed and was removed.
+    pub fn remove(&mut self, id: NotificationId) -> Result<bool> {
+        let before = self.notifications.len();
+        self.notifications.retain(|n| n.id != id);
+        let removed = self.notifications.len() < before;
+        if removed {
+            self.save()?;
+        }
+        Ok(removed)
+    }
+
+    // ── Private ───────────────────────────────────────────────────────────────
+
+    /// Persist to disk atomically (write tmp, then rename).
+    fn save(&self) -> Result<()> {
+        let data = serde_json::to_string_pretty(&self.notifications)
+            .context("failed to serialize notifications")?;
+        let tmp = self.path.with_extension("json.tmp");
+        fs::write(&tmp, &data)
+            .with_context(|| format!("failed to write {}", tmp.display()))?;
+        fs::rename(&tmp, &self.path).with_context(|| {
+            format!(
+                "failed to rename {} -> {}",
+                tmp.display(),
+                self.path.display()
+            )
+        })?;
+        Ok(())
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_store(project: &str) -> (NotificationStore, tempfile::TempDir) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = NotificationStore::open_in(project, dir.path()).expect("open_in");
+        (store, dir)
+    }
+
+    // ── push / basics ────────────────────────────────────────────────────────
+
+    #[test]
+    fn push_assigns_monotonic_ids_from_one() {
+        let (mut store, _dir) = tmp_store("/proj");
+
+        let n1 = store
+            .push(NotificationKind::AgentRunning, "A", "msg", None)
+            .unwrap();
+        assert_eq!(n1.id().value(), 1);
+
+        let n2 = store
+            .push(NotificationKind::PlanReady, "B", "msg", None)
+            .unwrap();
+        assert_eq!(n2.id().value(), 2);
+
+        let n3 = store
+            .push(NotificationKind::PipelineCompleted, "C", "msg", Some(42))
+            .unwrap();
+        assert_eq!(n3.id().value(), 3);
+    }
+
+    #[test]
+    fn pushed_notification_starts_unread() {
+        let (mut store, _dir) = tmp_store("/proj");
+        let n = store
+            .push(NotificationKind::AgentRunning, "title", "message", None)
+            .unwrap();
+        assert!(!n.is_read());
+    }
+
+    #[test]
+    fn all_fields_accessible_via_getters() {
+        let (mut store, _dir) = tmp_store("/proj");
+        let n = store
+            .push(NotificationKind::AgentFlatlined, "Flatline", "Agent died", Some(7))
+            .unwrap();
+
+        assert_eq!(n.kind(), NotificationKind::AgentFlatlined);
+        assert_eq!(n.title(), "Flatline");
+        assert_eq!(n.message(), "Agent died");
+        assert_eq!(n.agent_id(), Some(7));
+        assert!(!n.is_read());
+        assert!(n.created_at_ms() > 0);
+    }
+
+    // ── mark_read ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn mark_read_flips_read_flag() {
+        let (mut store, _dir) = tmp_store("/proj");
+        store
+            .push(NotificationKind::AgentRunning, "t", "m", None)
+            .unwrap();
+        let id = NotificationId(1);
+
+        assert_eq!(store.unread_count(), 1);
+        assert!(store.mark_read(id).unwrap());
+        assert_eq!(store.unread_count(), 0);
+        assert!(store.get(id).unwrap().is_read());
+    }
+
+    #[test]
+    fn mark_read_already_read_returns_false() {
+        let (mut store, _dir) = tmp_store("/proj");
+        store
+            .push(NotificationKind::PlanReady, "t", "m", None)
+            .unwrap();
+        let id = NotificationId(1);
+
+        store.mark_read(id).unwrap();
+        let second = store.mark_read(id).unwrap();
+        assert!(!second, "already-read returns false");
+    }
+
+    #[test]
+    fn mark_read_missing_id_returns_false() {
+        let (mut store, _dir) = tmp_store("/proj");
+        let ghost = NotificationId(999);
+        assert!(!store.mark_read(ghost).unwrap());
+    }
+
+    // ── mark_all_read ────────────────────────────────────────────────────────
+
+    #[test]
+    fn mark_all_read_clears_all_unread() {
+        let (mut store, _dir) = tmp_store("/proj");
+        store
+            .push(NotificationKind::AgentRunning, "a", "m", None)
+            .unwrap();
+        store
+            .push(NotificationKind::PlanReady, "b", "m", None)
+            .unwrap();
+        store
+            .push(NotificationKind::AgentFlatlined, "c", "m", None)
+            .unwrap();
+
+        assert_eq!(store.unread_count(), 3);
+        let n = store.mark_all_read().unwrap();
+        assert_eq!(n, 3);
+        assert_eq!(store.unread_count(), 0);
+    }
+
+    #[test]
+    fn mark_all_read_skips_already_read() {
+        let (mut store, _dir) = tmp_store("/proj");
+        store
+            .push(NotificationKind::AgentRunning, "a", "m", None)
+            .unwrap();
+        store
+            .push(NotificationKind::PlanReady, "b", "m", None)
+            .unwrap();
+
+        store.mark_read(NotificationId(1)).unwrap();
+        let count = store.mark_all_read().unwrap();
+        assert_eq!(count, 1, "only one was still unread");
+        assert_eq!(store.unread_count(), 0);
+    }
+
+    #[test]
+    fn mark_all_read_on_empty_store_returns_zero() {
+        let (mut store, _dir) = tmp_store("/proj");
+        assert_eq!(store.mark_all_read().unwrap(), 0);
+    }
+
+    // ── unread / unread_count ─────────────────────────────────────────────────
+
+    #[test]
+    fn unread_returns_only_unread_in_order() {
+        let (mut store, _dir) = tmp_store("/proj");
+        store
+            .push(NotificationKind::AgentRunning, "a", "m", None)
+            .unwrap();
+        store
+            .push(NotificationKind::PlanReady, "b", "m", None)
+            .unwrap();
+        store
+            .push(NotificationKind::AgentSynced, "c", "m", None)
+            .unwrap();
+
+        store.mark_read(NotificationId(2)).unwrap();
+
+        let unread = store.unread();
+        assert_eq!(unread.len(), 2);
+        assert_eq!(unread[0].id().value(), 1);
+        assert_eq!(unread[1].id().value(), 3);
+    }
+
+    // ── by_kind ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn by_kind_filters_correctly() {
+        let (mut store, _dir) = tmp_store("/proj");
+        store
+            .push(NotificationKind::AgentRunning, "a", "m", Some(1))
+            .unwrap();
+        store
+            .push(NotificationKind::AgentRunning, "b", "m", Some(2))
+            .unwrap();
+        store
+            .push(NotificationKind::PipelineBlocked, "c", "m", None)
+            .unwrap();
+        store
+            .push(NotificationKind::PlanReady, "d", "m", None)
+            .unwrap();
+
+        let running = store.by_kind(NotificationKind::AgentRunning);
+        assert_eq!(running.len(), 2);
+        assert!(running.iter().all(|n| n.kind() == NotificationKind::AgentRunning));
+
+        let blocked = store.by_kind(NotificationKind::PipelineBlocked);
+        assert_eq!(blocked.len(), 1);
+
+        let synced = store.by_kind(NotificationKind::AgentSynced);
+        assert!(synced.is_empty());
+    }
+
+    // ── get ───────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn get_existing_id_returns_some() {
+        let (mut store, _dir) = tmp_store("/proj");
+        store
+            .push(NotificationKind::PlanReady, "t", "m", None)
+            .unwrap();
+        assert!(store.get(NotificationId(1)).is_some());
+    }
+
+    #[test]
+    fn get_missing_id_returns_none() {
+        let (store, _dir) = tmp_store("/proj");
+        assert!(store.get(NotificationId(99)).is_none());
+    }
+
+    // ── remove ────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn remove_existing_notification() {
+        let (mut store, _dir) = tmp_store("/proj");
+        store
+            .push(NotificationKind::AgentRunning, "t", "m", None)
+            .unwrap();
+        assert_eq!(store.count(), 1);
+
+        let removed = store.remove(NotificationId(1)).unwrap();
+        assert!(removed);
+        assert_eq!(store.count(), 0);
+        assert!(store.get(NotificationId(1)).is_none());
+    }
+
+    #[test]
+    fn remove_missing_returns_false() {
+        let (mut store, _dir) = tmp_store("/proj");
+        assert!(!store.remove(NotificationId(99)).unwrap());
+    }
+
+    // ── all / count ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn all_returns_every_notification_in_insertion_order() {
+        let (mut store, _dir) = tmp_store("/proj");
+        store
+            .push(NotificationKind::PlanReady, "a", "m1", None)
+            .unwrap();
+        store
+            .push(NotificationKind::AgentRunning, "b", "m2", Some(1))
+            .unwrap();
+        store
+            .push(NotificationKind::PipelineCompleted, "c", "m3", None)
+            .unwrap();
+
+        let all = store.all();
+        assert_eq!(all.len(), 3);
+        assert_eq!(all[0].title(), "a");
+        assert_eq!(all[1].title(), "b");
+        assert_eq!(all[2].title(), "c");
+    }
+
+    #[test]
+    fn count_tracks_push_and_remove() {
+        let (mut store, _dir) = tmp_store("/proj");
+        assert_eq!(store.count(), 0);
+
+        store
+            .push(NotificationKind::PlanReady, "a", "m", None)
+            .unwrap();
+        assert_eq!(store.count(), 1);
+
+        store
+            .push(NotificationKind::AgentRunning, "b", "m", None)
+            .unwrap();
+        assert_eq!(store.count(), 2);
+
+        store.remove(NotificationId(1)).unwrap();
+        assert_eq!(store.count(), 1);
+    }
+
+    // ── persistence ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn persistence_survives_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = "/home/user/myproject";
+
+        {
+            let mut store = NotificationStore::open_in(project, dir.path()).unwrap();
+            store
+                .push(NotificationKind::PlanReady, "Plan", "Ready to execute", None)
+                .unwrap();
+            store
+                .push(NotificationKind::AgentRunning, "Agent", "Running", Some(42))
+                .unwrap();
+            store.mark_read(NotificationId(1)).unwrap();
+        }
+
+        {
+            let store = NotificationStore::open_in(project, dir.path()).unwrap();
+            assert_eq!(store.count(), 2);
+
+            let n1 = store.get(NotificationId(1)).unwrap();
+            assert!(n1.is_read());
+            assert_eq!(n1.kind(), NotificationKind::PlanReady);
+            assert_eq!(n1.title(), "Plan");
+
+            let n2 = store.get(NotificationId(2)).unwrap();
+            assert!(!n2.is_read());
+            assert_eq!(n2.agent_id(), Some(42));
+        }
+    }
+
+    #[test]
+    fn next_id_recovers_after_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = "/proj";
+
+        {
+            let mut store = NotificationStore::open_in(project, dir.path()).unwrap();
+            store
+                .push(NotificationKind::PlanReady, "a", "m", None)
+                .unwrap();
+            store
+                .push(NotificationKind::AgentRunning, "b", "m", None)
+                .unwrap();
+        }
+
+        {
+            let mut store = NotificationStore::open_in(project, dir.path()).unwrap();
+            // Next id should continue from 3, not restart at 1.
+            let n = store
+                .push(NotificationKind::AgentSynced, "c", "m", None)
+                .unwrap();
+            assert_eq!(n.id().value(), 3);
+        }
+    }
+
+    #[test]
+    fn different_projects_are_isolated() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let mut store_a = NotificationStore::open_in("/project-a", dir.path()).unwrap();
+        store_a
+            .push(NotificationKind::PlanReady, "alpha", "m", None)
+            .unwrap();
+
+        let mut store_b = NotificationStore::open_in("/project-b", dir.path()).unwrap();
+        store_b
+            .push(NotificationKind::AgentRunning, "beta", "m", None)
+            .unwrap();
+
+        let store_a2 = NotificationStore::open_in("/project-a", dir.path()).unwrap();
+        assert_eq!(store_a2.count(), 1);
+        assert_eq!(store_a2.all()[0].title(), "alpha");
+
+        let store_b2 = NotificationStore::open_in("/project-b", dir.path()).unwrap();
+        assert_eq!(store_b2.count(), 1);
+        assert_eq!(store_b2.all()[0].title(), "beta");
+    }
+
+    // ── NotificationId display ────────────────────────────────────────────────
+
+    #[test]
+    fn notification_id_display() {
+        let id = NotificationId(42);
+        assert_eq!(format!("{id}"), "notification#42");
+    }
+
+    // ── NotificationKind display ──────────────────────────────────────────────
+
+    #[test]
+    fn notification_kind_display_variants() {
+        assert_eq!(NotificationKind::PlanReady.to_string(), "plan_ready");
+        assert_eq!(NotificationKind::AgentRunning.to_string(), "agent_running");
+        assert_eq!(NotificationKind::AgentSynced.to_string(), "agent_synced");
+        assert_eq!(NotificationKind::AgentFlatlined.to_string(), "agent_flatlined");
+        assert_eq!(
+            NotificationKind::PipelineCompleted.to_string(),
+            "pipeline_completed"
+        );
+        assert_eq!(
+            NotificationKind::PipelineBlocked.to_string(),
+            "pipeline_blocked"
+        );
+    }
+
+    // ── all six NotificationKind variants round-trip through serde ────────────
+
+    #[test]
+    fn all_kinds_serde_round_trip() {
+        let kinds = [
+            NotificationKind::PlanReady,
+            NotificationKind::AgentRunning,
+            NotificationKind::AgentSynced,
+            NotificationKind::AgentFlatlined,
+            NotificationKind::PipelineCompleted,
+            NotificationKind::PipelineBlocked,
+        ];
+        for kind in kinds {
+            let json = serde_json::to_string(&kind).unwrap();
+            let back: NotificationKind = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, kind);
+        }
+    }
+}

--- a/crates/phantom-memory/src/schema.rs
+++ b/crates/phantom-memory/src/schema.rs
@@ -1,0 +1,599 @@
+//! Versioned schema for the `phantom-memory` event log.
+//!
+//! Defines the canonical layout of an [`EventLogEntry`], a schema-version
+//! constant, and forward-compatible migration stubs.  The design follows
+//! skip-unknown semantics: a v1 reader silently ignores fields that were not
+//! present in v1, so a v2 log is readable by a v1 library (with data loss for
+//! the new fields, but no parse errors).
+//!
+//! # Schema versions
+//!
+//! | Version | Changes |
+//! |---------|---------|
+//! | 1       | Initial: `id`, `timestamp_ms`, `kind`, `payload`, `source_chain` |
+//!
+//! # Kind validation
+//!
+//! Every `kind` string must either:
+//!
+//! 1. Match a known dotted-path kind from [`KnownKind`], or
+//! 2. Begin with the `unknown.` prefix (for forward-compat with future kinds).
+//!
+//! Any other string is rejected by [`EventLogEntry::validate`].
+//!
+//! # Example
+//!
+//! ```rust
+//! use phantom_memory::schema::{EventLogEntry, SCHEMA_VERSION};
+//!
+//! assert_eq!(SCHEMA_VERSION, 1);
+//!
+//! let entry = EventLogEntry::new(
+//!     1,
+//!     1_700_000_000_000,
+//!     "agent.spawn",
+//!     serde_json::json!({"agent_id": 42}),
+//!     vec![],
+//! ).unwrap();
+//!
+//! assert_eq!(entry.id(), 1);
+//! assert!(entry.validate().is_ok());
+//! ```
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// The current schema version.
+///
+/// Increment this constant (and add a migration stub) whenever the
+/// [`EventLogEntry`] layout changes in a backward-incompatible way.
+pub const SCHEMA_VERSION: u32 = 1;
+
+// ── Known kind set ────────────────────────────────────────────────────────────
+
+/// All event kind strings that are valid under the current schema version.
+///
+/// Each variant maps to a dotted-path string that appears in the JSONL log.
+/// Extend this list when a new event kind is introduced; retired kinds should
+/// be moved to a `#[deprecated]` variant rather than removed, to preserve
+/// read-compatibility with historical logs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum KnownKind {
+    // ── Agent lifecycle ──────────────────────────────────────────────────────
+    AgentSpawn,
+    AgentComplete,
+    AgentFlatline,
+    AgentQuarantine,
+
+    // ── Tool calls ───────────────────────────────────────────────────────────
+    ToolInvoked,
+    ToolSucceeded,
+    ToolFailed,
+
+    // ── Pipeline ─────────────────────────────────────────────────────────────
+    PipelineStarted,
+    PipelineBlocked,
+    PipelineCompleted,
+
+    // ── Brain / OODA ─────────────────────────────────────────────────────────
+    BrainObserve,
+    BrainAct,
+
+    // ── User ─────────────────────────────────────────────────────────────────
+    UserCommand,
+}
+
+impl KnownKind {
+    /// The canonical dotted-path string for this kind.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            KnownKind::AgentSpawn => "agent.spawn",
+            KnownKind::AgentComplete => "agent.complete",
+            KnownKind::AgentFlatline => "agent.flatline",
+            KnownKind::AgentQuarantine => "agent.quarantine",
+            KnownKind::ToolInvoked => "tool.invoked",
+            KnownKind::ToolSucceeded => "tool.succeeded",
+            KnownKind::ToolFailed => "tool.failed",
+            KnownKind::PipelineStarted => "pipeline.started",
+            KnownKind::PipelineBlocked => "pipeline.blocked",
+            KnownKind::PipelineCompleted => "pipeline.completed",
+            KnownKind::BrainObserve => "brain.observe",
+            KnownKind::BrainAct => "brain.act",
+            KnownKind::UserCommand => "user.command",
+        }
+    }
+
+    /// Try to match a string against the full known-kind set.
+    ///
+    /// Returns `None` if the string is not a recognized kind (and not an
+    /// `unknown.*` prefix — callers must check that separately).
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "agent.spawn" => Some(KnownKind::AgentSpawn),
+            "agent.complete" => Some(KnownKind::AgentComplete),
+            "agent.flatline" => Some(KnownKind::AgentFlatline),
+            "agent.quarantine" => Some(KnownKind::AgentQuarantine),
+            "tool.invoked" => Some(KnownKind::ToolInvoked),
+            "tool.succeeded" => Some(KnownKind::ToolSucceeded),
+            "tool.failed" => Some(KnownKind::ToolFailed),
+            "pipeline.started" => Some(KnownKind::PipelineStarted),
+            "pipeline.blocked" => Some(KnownKind::PipelineBlocked),
+            "pipeline.completed" => Some(KnownKind::PipelineCompleted),
+            "brain.observe" => Some(KnownKind::BrainObserve),
+            "brain.act" => Some(KnownKind::BrainAct),
+            "user.command" => Some(KnownKind::UserCommand),
+            _ => None,
+        }
+    }
+
+    /// All known kinds, in declaration order.  Useful for exhaustive tests.
+    pub fn all() -> &'static [KnownKind] {
+        &[
+            KnownKind::AgentSpawn,
+            KnownKind::AgentComplete,
+            KnownKind::AgentFlatline,
+            KnownKind::AgentQuarantine,
+            KnownKind::ToolInvoked,
+            KnownKind::ToolSucceeded,
+            KnownKind::ToolFailed,
+            KnownKind::PipelineStarted,
+            KnownKind::PipelineBlocked,
+            KnownKind::PipelineCompleted,
+            KnownKind::BrainObserve,
+            KnownKind::BrainAct,
+            KnownKind::UserCommand,
+        ]
+    }
+}
+
+impl std::fmt::Display for KnownKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+// ── EventLogEntry ─────────────────────────────────────────────────────────────
+
+/// A single entry in the versioned event log.
+///
+/// All fields are private; construct with [`EventLogEntry::new`] and access
+/// them through the provided getters.
+///
+/// # Schema stability
+///
+/// The JSON representation of this struct is the on-disk format.  Fields must
+/// not be renamed or removed in a patch release — use `#[serde(rename)]` or
+/// `#[serde(skip_serializing_if)]` to maintain backward compatibility.
+///
+/// Optional fields added in future versions should be `Option<T>` and
+/// `#[serde(default)]` so that v1 entries remain decodable by v2+ readers.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EventLogEntry {
+    /// Monotonically increasing identifier assigned by the log writer.
+    id: u64,
+    /// Wall-clock time in milliseconds since the Unix epoch.
+    timestamp_ms: u64,
+    /// Dotted-path event kind (e.g. `"agent.spawn"`).
+    ///
+    /// Must be a known kind OR start with `unknown.` — enforced by
+    /// [`EventLogEntry::validate`].
+    kind: String,
+    /// Free-form structured payload specific to `kind`.
+    payload: serde_json::Value,
+    /// Ordered list of ancestor event ids for causal tracing.
+    ///
+    /// Empty for root events (no causal parent).
+    source_chain: Vec<u64>,
+    // ── v2 extension point ────────────────────────────────────────────────
+    // When schema v2 adds a field, add it here as `Option<T>` with
+    // `#[serde(default)]` and `#[serde(skip_serializing_if = "Option::is_none")]`.
+    // Example:
+    //   #[serde(default, skip_serializing_if = "Option::is_none")]
+    //   correlation_id: Option<String>,
+}
+
+/// Errors produced when constructing or validating an [`EventLogEntry`].
+#[derive(Debug, Error)]
+pub enum SchemaError {
+    /// The `kind` string is neither a known kind nor `unknown.*`-namespaced.
+    #[error("invalid kind string {kind:?}: must be a known kind or start with 'unknown.'")]
+    InvalidKind { kind: String },
+
+    /// A migration function detected an unrecognised source version.
+    #[error("unsupported schema version {version}: cannot migrate")]
+    UnsupportedVersion { version: u32 },
+}
+
+impl EventLogEntry {
+    /// Construct a new [`EventLogEntry`], validating `kind` immediately.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SchemaError::InvalidKind`] if `kind` is neither a known
+    /// dotted-path kind nor prefixed with `unknown.`.
+    pub fn new(
+        id: u64,
+        timestamp_ms: u64,
+        kind: impl Into<String>,
+        payload: serde_json::Value,
+        source_chain: Vec<u64>,
+    ) -> Result<Self, SchemaError> {
+        let kind = kind.into();
+        validate_kind(&kind)?;
+        Ok(Self {
+            id,
+            timestamp_ms,
+            kind,
+            payload,
+            source_chain,
+        })
+    }
+
+    /// Monotonically increasing log id.
+    pub fn id(&self) -> u64 {
+        self.id
+    }
+
+    /// Creation time in milliseconds since the Unix epoch.
+    pub fn timestamp_ms(&self) -> u64 {
+        self.timestamp_ms
+    }
+
+    /// Dotted-path event kind string.
+    pub fn kind(&self) -> &str {
+        &self.kind
+    }
+
+    /// Structured payload.
+    pub fn payload(&self) -> &serde_json::Value {
+        &self.payload
+    }
+
+    /// Ordered list of causal ancestor event ids.
+    pub fn source_chain(&self) -> &[u64] {
+        &self.source_chain
+    }
+
+    /// Validate this entry against the current schema.
+    ///
+    /// The primary check is kind-string validation (known OR `unknown.*`).
+    /// Additional field-level invariants may be added here without breaking
+    /// the constructor API.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SchemaError::InvalidKind`] if the kind string is invalid.
+    pub fn validate(&self) -> Result<(), SchemaError> {
+        validate_kind(&self.kind)
+    }
+
+    /// Deserialize an [`EventLogEntry`] from a JSON value using
+    /// skip-unknown semantics.
+    ///
+    /// Fields present in `value` that are not part of the current schema
+    /// are silently ignored.  Missing optional fields (introduced in later
+    /// schema versions) are filled with their defaults.
+    ///
+    /// This enables a v1 reader to decode a v2 entry without error.
+    pub fn from_json(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        serde_json::from_value(value)
+    }
+}
+
+// ── Kind validation ───────────────────────────────────────────────────────────
+
+/// Validate a kind string: must be a known kind OR start with `unknown.`.
+fn validate_kind(kind: &str) -> Result<(), SchemaError> {
+    if KnownKind::from_str(kind).is_some() || kind.starts_with("unknown.") {
+        Ok(())
+    } else {
+        Err(SchemaError::InvalidKind {
+            kind: kind.to_owned(),
+        })
+    }
+}
+
+// ── Schema migration stubs ────────────────────────────────────────────────────
+
+/// Migrate a raw JSON value from `from_version` to [`SCHEMA_VERSION`].
+///
+/// This function is a stub: it accepts v1 entries unchanged (since
+/// `SCHEMA_VERSION == 1`).  When schema v2 is introduced, add a
+/// `migrate_v1_to_v2` inner function and call it here.
+///
+/// # Errors
+///
+/// Returns [`SchemaError::UnsupportedVersion`] for any version other than
+/// those the current codebase knows how to handle.
+pub fn migrate(
+    value: serde_json::Value,
+    from_version: u32,
+) -> Result<serde_json::Value, SchemaError> {
+    match from_version {
+        1 => {
+            // v1 → current (v1): nothing to do — field set is identical.
+            Ok(value)
+        }
+        v => Err(SchemaError::UnsupportedVersion { version: v }),
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ── SCHEMA_VERSION ────────────────────────────────────────────────────────
+
+    #[test]
+    fn schema_version_is_one() {
+        assert_eq!(SCHEMA_VERSION, 1);
+    }
+
+    // ── KnownKind ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn all_known_kinds_round_trip_via_from_str() {
+        for &kind in KnownKind::all() {
+            let s = kind.as_str();
+            let back = KnownKind::from_str(s)
+                .unwrap_or_else(|| panic!("from_str({s:?}) returned None"));
+            assert_eq!(back, kind, "round-trip failed for {s:?}");
+        }
+    }
+
+    #[test]
+    fn known_kind_from_str_covers_all_13_variants() {
+        // Guard: if a variant is added to KnownKind::all() without updating
+        // from_str, this test catches the gap.
+        assert_eq!(KnownKind::all().len(), 13);
+    }
+
+    #[test]
+    fn unknown_kind_from_str_returns_none() {
+        assert!(KnownKind::from_str("not.a.real.kind").is_none());
+        assert!(KnownKind::from_str("unknown.future_field").is_none());
+        assert!(KnownKind::from_str("").is_none());
+    }
+
+    #[test]
+    fn known_kind_display_matches_as_str() {
+        for &kind in KnownKind::all() {
+            assert_eq!(kind.to_string(), kind.as_str());
+        }
+    }
+
+    // ── EventLogEntry construction ─────────────────────────────────────────────
+
+    #[test]
+    fn new_with_known_kind_succeeds() {
+        for &k in KnownKind::all() {
+            let entry = EventLogEntry::new(
+                1,
+                1_000_000,
+                k.as_str(),
+                json!({}),
+                vec![],
+            )
+            .unwrap_or_else(|e| panic!("new failed for {}: {e}", k.as_str()));
+            assert_eq!(entry.kind(), k.as_str());
+        }
+    }
+
+    #[test]
+    fn new_with_unknown_prefix_succeeds() {
+        let entry =
+            EventLogEntry::new(42, 2_000, "unknown.future_field", json!({"x": 1}), vec![1, 2])
+                .unwrap();
+        assert_eq!(entry.id(), 42);
+        assert_eq!(entry.kind(), "unknown.future_field");
+        assert_eq!(entry.source_chain(), &[1, 2]);
+    }
+
+    #[test]
+    fn new_with_invalid_kind_returns_error() {
+        let err =
+            EventLogEntry::new(1, 0, "bad-kind-string", json!({}), vec![]).unwrap_err();
+        assert!(matches!(err, SchemaError::InvalidKind { .. }));
+    }
+
+    #[test]
+    fn new_with_empty_kind_returns_error() {
+        let err = EventLogEntry::new(1, 0, "", json!({}), vec![]).unwrap_err();
+        assert!(matches!(err, SchemaError::InvalidKind { .. }));
+    }
+
+    // ── Getters ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn getters_return_constructor_values() {
+        let chain = vec![10u64, 20, 30];
+        let payload = json!({"agent_id": 7, "task": "test"});
+        let entry = EventLogEntry::new(99, 1_234_567_890, "agent.spawn", payload.clone(), chain.clone())
+            .unwrap();
+
+        assert_eq!(entry.id(), 99);
+        assert_eq!(entry.timestamp_ms(), 1_234_567_890);
+        assert_eq!(entry.kind(), "agent.spawn");
+        assert_eq!(entry.payload(), &payload);
+        assert_eq!(entry.source_chain(), chain.as_slice());
+    }
+
+    // ── validate ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn validate_known_kind_ok() {
+        let entry = EventLogEntry::new(1, 0, "tool.invoked", json!({}), vec![]).unwrap();
+        assert!(entry.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_unknown_prefix_ok() {
+        let entry =
+            EventLogEntry::new(1, 0, "unknown.v3_feature", json!({}), vec![]).unwrap();
+        assert!(entry.validate().is_ok());
+    }
+
+    // ── Serde round-trip for all known kinds ──────────────────────────────────
+
+    #[test]
+    fn serde_round_trip_for_all_known_kinds() {
+        for &kind in KnownKind::all() {
+            let entry = EventLogEntry::new(
+                1,
+                1_700_000_000_000,
+                kind.as_str(),
+                json!({"test": true}),
+                vec![],
+            )
+            .unwrap();
+
+            let serialized = serde_json::to_string(&entry)
+                .unwrap_or_else(|e| panic!("serialize failed for {}: {e}", kind.as_str()));
+            let back: EventLogEntry = serde_json::from_str(&serialized)
+                .unwrap_or_else(|e| panic!("deserialize failed for {}: {e}", kind.as_str()));
+
+            assert_eq!(back.id(), entry.id());
+            assert_eq!(back.kind(), entry.kind());
+            assert_eq!(back.payload(), entry.payload());
+            assert!(back.validate().is_ok());
+        }
+    }
+
+    // ── from_json (skip-unknown semantics) ────────────────────────────────────
+
+    #[test]
+    fn from_json_v1_entry_decodes_ok() {
+        let raw = json!({
+            "id": 1,
+            "timestamp_ms": 1_700_000_000_000u64,
+            "kind": "agent.spawn",
+            "payload": {"agent_id": 1},
+            "source_chain": []
+        });
+        let entry = EventLogEntry::from_json(raw).unwrap();
+        assert_eq!(entry.id(), 1);
+        assert_eq!(entry.kind(), "agent.spawn");
+    }
+
+    #[test]
+    fn from_json_ignores_unknown_fields() {
+        // Simulates a v2 entry being read by v1 code.
+        let raw = json!({
+            "id": 5,
+            "timestamp_ms": 9_000u64,
+            "kind": "tool.invoked",
+            "payload": {},
+            "source_chain": [1, 2],
+            // v2-only field — should be silently ignored
+            "correlation_id": "abc-123"
+        });
+        let entry = EventLogEntry::from_json(raw).unwrap();
+        assert_eq!(entry.id(), 5);
+        assert_eq!(entry.source_chain(), &[1, 2]);
+    }
+
+    // ── source_chain ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn source_chain_empty_for_root_events() {
+        let entry = EventLogEntry::new(1, 0, "user.command", json!({}), vec![]).unwrap();
+        assert!(entry.source_chain().is_empty());
+    }
+
+    #[test]
+    fn source_chain_preserves_causal_order() {
+        let chain = vec![1u64, 5, 9];
+        let entry =
+            EventLogEntry::new(10, 0, "agent.spawn", json!({}), chain.clone()).unwrap();
+        assert_eq!(entry.source_chain(), chain.as_slice());
+    }
+
+    // ── migrate ───────────────────────────────────────────────────────────────
+
+    #[test]
+    fn migrate_v1_is_identity() {
+        let raw = json!({
+            "id": 1,
+            "timestamp_ms": 0u64,
+            "kind": "agent.spawn",
+            "payload": {"x": 1},
+            "source_chain": []
+        });
+        let migrated = migrate(raw.clone(), 1).unwrap();
+        assert_eq!(migrated, raw);
+    }
+
+    #[test]
+    fn migrate_unsupported_version_returns_error() {
+        let raw = json!({});
+        let err = migrate(raw, 99).unwrap_err();
+        assert!(matches!(
+            err,
+            SchemaError::UnsupportedVersion { version: 99 }
+        ));
+    }
+
+    #[test]
+    fn migrate_then_decode_round_trips_v1() {
+        let original = json!({
+            "id": 7,
+            "timestamp_ms": 1_000_000u64,
+            "kind": "brain.observe",
+            "payload": {"score": 0.9},
+            "source_chain": [1, 2, 3]
+        });
+
+        let migrated = migrate(original, 1).unwrap();
+        let entry = EventLogEntry::from_json(migrated).unwrap();
+
+        assert_eq!(entry.id(), 7);
+        assert_eq!(entry.kind(), "brain.observe");
+        assert_eq!(entry.source_chain(), &[1, 2, 3]);
+    }
+
+    // ── kind validation edge cases ────────────────────────────────────────────
+
+    #[test]
+    fn kind_with_no_dot_and_no_unknown_prefix_rejected() {
+        let kinds = ["agentspawn", "AGENT.SPAWN", "agent", " agent.spawn", "agent.spawn "];
+        for bad in kinds {
+            let err = EventLogEntry::new(1, 0, bad, json!({}), vec![]).unwrap_err();
+            assert!(
+                matches!(err, SchemaError::InvalidKind { .. }),
+                "{bad:?} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_dot_prefix_accepted_with_any_suffix() {
+        let kinds = [
+            "unknown.v2_field",
+            "unknown.really.long.dotted.path",
+            "unknown.12345",
+        ];
+        for kind in kinds {
+            EventLogEntry::new(1, 0, kind, json!({}), vec![])
+                .unwrap_or_else(|e| panic!("{kind:?} should be accepted: {e}"));
+        }
+    }
+
+    // ── SchemaError display ────────────────────────────────────────────────────
+
+    #[test]
+    fn schema_error_display_is_human_readable() {
+        let err = SchemaError::InvalidKind {
+            kind: "bad".to_owned(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("bad"), "message: {msg}");
+        assert!(msg.contains("unknown."), "message: {msg}");
+
+        let err2 = SchemaError::UnsupportedVersion { version: 42 };
+        let msg2 = err2.to_string();
+        assert!(msg2.contains("42"), "message: {msg2}");
+    }
+}


### PR DESCRIPTION
Closes #62
Closes #78

## Summary

### Issue #62 — Durable notifications (`notifications.rs`)
- `NotificationKind` enum: all 6 variants from the spec (`PlanReady`, `AgentRunning`, `AgentSynced`, `AgentFlatlined`, `PipelineCompleted`, `PipelineBlocked`)
- `NotificationId` — opaque `u64` newtype with `Display` impl
- `Notification` — all fields private, exposed through getters (`id`, `kind`, `title`, `message`, `agent_id`, `is_read`, `created_at_ms`)
- `NotificationStore` — project-scoped, JSON-backed persistent store at `~/.config/phantom/notifications/<project-hash>.json`
  - `push` — append and persist, returns reference to the new notification
  - `mark_read(id)` — idempotent; returns `false` if already read or missing
  - `mark_all_read()` — returns count of newly-read notifications
  - `by_kind(kind)` — filter slice
  - `get(id)`, `all()`, `unread()`, `unread_count()`, `count()`, `remove(id)`
  - Atomic writes (write-tmp-then-rename)
  - `next_id` recovered correctly on reopen

### Issue #78 — Versioned EventLog schema (`schema.rs`)
- `SCHEMA_VERSION: u32 = 1`
- `KnownKind` enum — 13 dotted-path variants covering all current event kinds (`agent.*`, `tool.*`, `pipeline.*`, `brain.*`, `user.*`)
  - `as_str()`, `from_str()`, `all()`, `Display`
- `EventLogEntry` — all fields private, constructors and getters
  - `new()` validates kind on construction
  - `from_json()` uses skip-unknown semantics — v2 entries with extra optional fields decode cleanly under v1
  - `validate()` — kind must be a known path OR `unknown.*`-prefixed
  - `source_chain: Vec<u64>` for causal tracing
- `migrate(value, from_version)` — stub: v1→v1 is identity; unknown versions return `SchemaError::UnsupportedVersion`
- `SchemaError` — typed via `thiserror`

## Test plan

- [x] 83 unit tests + 2 doctests pass: `cargo test -p phantom-memory`
- [x] All 13 `KnownKind` variants round-trip through `from_str`/`as_str`
- [x] v1 entries decode under v2 reader (skip-unknown `from_json` with extra `correlation_id` field)
- [x] Validation rejects malformed kinds (no dot, wrong case, trailing spaces, empty string)
- [x] `unknown.*` prefix accepted with any suffix
- [x] Persistence survives reopen for both `NotificationStore` and `next_id` recovery
- [x] Different projects are isolated (separate hash-keyed files)
- [x] No `.unwrap()` in production paths — all errors surface through `Result<_, anyhow::Error>` or `Result<_, SchemaError>`
- [x] All struct fields private with constructors and getters

🤖 Generated with [Claude Code](https://claude.com/claude-code)