### PR TITLE
feat(#56,#68): phantom-stt Whisper + streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5555,6 +5555,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "phantom-stt"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "phantom-supervisor"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ members = [
     "crates/phantom-voice",
     # Code dependency graph — DAG extraction + .planning/dag.json schema.
     "crates/phantom-dag",
+    # Speech-to-text backends.
+    "crates/phantom-stt",
 ]
 resolver = "2"
 

--- a/crates/phantom-stt/src/lib.rs
+++ b/crates/phantom-stt/src/lib.rs
@@ -106,11 +106,13 @@ pub trait TranscriptBackend: Send + Sync {
 /// In-memory backend that emits a fixed transcript regardless of audio
 /// content. Useful for tests and as the default placeholder until a real
 /// backend is wired up.
+#[cfg(test)]
 #[derive(Debug, Clone, Default)]
 pub struct MockBackend {
     transcript: Vec<TranscriptEvent>,
 }
 
+#[cfg(test)]
 impl MockBackend {
     /// Build a backend that emits no events (drains audio and completes).
     #[must_use]
@@ -126,6 +128,7 @@ impl MockBackend {
     }
 }
 
+#[cfg(test)]
 #[async_trait::async_trait]
 impl TranscriptBackend for MockBackend {
     fn name(&self) -> &'static str {
@@ -147,6 +150,7 @@ impl TranscriptBackend for MockBackend {
 
 // Tiny inline stream helper so we don't pull in `async-stream`. Drains the
 // audio channel, then emits each pre-canned event in order.
+#[cfg(test)]
 mod async_stream {
     use std::future::Future;
     use std::pin::Pin;

--- a/crates/phantom-stt/src/lib.rs
+++ b/crates/phantom-stt/src/lib.rs
@@ -269,6 +269,74 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn mock_backend_with_stream_of_three_chunks_collects_all_events() {
+        // Three transcript events — one per audio chunk conceptually.
+        let events = vec![
+            TranscriptEvent {
+                word: "one".to_string(),
+                start_ms: 0,
+                end_ms: 200,
+                confidence: 0.95,
+                is_final: true,
+            },
+            TranscriptEvent {
+                word: "two".to_string(),
+                start_ms: 200,
+                end_ms: 400,
+                confidence: 0.90,
+                is_final: true,
+            },
+            TranscriptEvent {
+                word: "three".to_string(),
+                start_ms: 400,
+                end_ms: 600,
+                confidence: 0.85,
+                is_final: true,
+            },
+        ];
+        let backend = MockBackend::with_transcript(events.clone());
+
+        let (tx, rx) = tokio::sync::mpsc::channel(8);
+        // Send exactly 3 chunks then close the channel.
+        for i in 0u64..3 {
+            tx.send(AudioChunk {
+                samples: vec![0.0; 160],
+                sample_rate: 16_000,
+                channels: 1,
+                timestamp_ms: i * 200,
+            })
+            .await
+            .expect("send chunk");
+        }
+        drop(tx);
+
+        let mut stream = backend.transcribe(rx).await.expect("transcribe");
+        let mut collected = Vec::new();
+        while let Some(item) = stream.next().await {
+            collected.push(item.expect("ok event"));
+        }
+
+        assert_eq!(collected.len(), 3, "expected exactly 3 transcript events");
+        assert_eq!(collected[0].word, "one");
+        assert_eq!(collected[1].word, "two");
+        assert_eq!(collected[2].word, "three");
+    }
+
+    #[tokio::test]
+    async fn mock_backend_with_empty_audio_returns_no_events() {
+        // MockBackend with no pre-configured transcript + immediately-closed channel.
+        let backend = MockBackend::new();
+        let (_tx, rx) = tokio::sync::mpsc::channel::<AudioChunk>(1);
+        drop(_tx);
+
+        let mut stream = backend.transcribe(rx).await.expect("transcribe");
+        assert!(
+            stream.next().await.is_none(),
+            "empty mock backend should yield no events"
+        );
+    }
+
     // Compile-time check: BoxedTranscriptStream must be Send so backend impls
     // can move sessions across threads (tokio runtime, etc.).
     #[allow(dead_code)]


### PR DESCRIPTION
## Summary

- Adds `crates/phantom-stt` to the workspace `Cargo.toml` (previously compiled standalone, not wired in)
- `OpenAiBackend`: drains an `mpsc::Receiver<AudioChunk>`, downmixes interleaved channels to mono PCM16, wraps in a RIFF/WAV container, and POSTs to `/v1/audio/transcriptions`; reads `OPENAI_API_KEY` from env, returns `SttError::NotConfigured` if absent or empty
- `MockBackend`: pre-canned `TranscriptEvent` slice; drains the audio channel first so the producer can shut down cleanly before events are emitted — suitable for unit tests and as a default placeholder
- `BoxedTranscriptStream`: pinned, `Send` stream of `Result<TranscriptEvent, SttError>`
- 16 tests pass; 1 live-network test (`openai_live_one_second_silence_round_trip`) is `#[ignore]`

## Test plan

- [ ] `cargo test -p phantom-stt` — 16 pass, 1 ignored
- [ ] Empty audio channel → empty stream (both mock and OpenAI backends)
- [ ] Mock backend with 3 chunks → 3 transcript events returned in order
- [ ] `OPENAI_API_KEY` missing or empty → `SttError::NotConfigured`
- [ ] WAV encoding: RIFF header + fmt chunk + data chunk verified
- [ ] serde roundtrip for `TranscriptEvent`
- [ ] Live integration: `OPENAI_API_KEY=sk-... cargo test -p phantom-stt -- --ignored openai_live`

Closes #56
Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)