### PR TITLE
feat(#64): code DAG extraction + dag.json schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5386,6 +5386,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "phantom-dag"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "log",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
 name = "phantom-embeddings"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ members = [
     "crates/phantom-embeddings",
     # Voice synthesis (TTS) — OpenAI backend + mock.
     "crates/phantom-voice",
+    # Code dependency graph — DAG extraction + .planning/dag.json schema.
+    "crates/phantom-dag",
 ]
 resolver = "2"
 

--- a/crates/phantom-dag/Cargo.toml
+++ b/crates/phantom-dag/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "phantom-dag"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+log.workspace = true
+anyhow.workspace = true
+chrono.workspace = true
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]
+tempfile = "3"
+
+[lints]
+workspace = true

--- a/crates/phantom-dag/src/edge.rs
+++ b/crates/phantom-dag/src/edge.rs
@@ -1,0 +1,70 @@
+//! [`DagEdge`] and [`EdgeKind`] — dependency arcs.
+
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// EdgeKind
+// ---------------------------------------------------------------------------
+
+/// The relationship kind encoded by a directed edge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EdgeKind {
+    /// The source symbol calls the target (function call or method dispatch).
+    Calls,
+    /// The source type implements the target trait.
+    Implements,
+    /// The source symbol references the target type / value.
+    Uses,
+    /// The source module/struct contains the target symbol.
+    Contains,
+}
+
+// ---------------------------------------------------------------------------
+// DagEdge
+// ---------------------------------------------------------------------------
+
+/// A directed arc in the code dependency graph.
+///
+/// All fields are private; use the accessor methods to read them.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DagEdge {
+    /// Fully-qualified id of the source symbol.
+    from: String,
+    /// Fully-qualified id of the target symbol.
+    to: String,
+    /// The relationship kind.
+    kind: EdgeKind,
+}
+
+impl DagEdge {
+    /// Construct a new [`DagEdge`].
+    ///
+    /// # Arguments
+    ///
+    /// * `from` — Fully-qualified id of the source symbol.
+    /// * `to`   — Fully-qualified id of the target symbol.
+    /// * `kind` — The relationship kind.
+    #[must_use]
+    pub fn new(from: String, to: String, kind: EdgeKind) -> Self {
+        Self { from, to, kind }
+    }
+
+    /// Fully-qualified id of the source symbol.
+    #[must_use]
+    pub fn from(&self) -> &str {
+        &self.from
+    }
+
+    /// Fully-qualified id of the target symbol.
+    #[must_use]
+    pub fn to(&self) -> &str {
+        &self.to
+    }
+
+    /// The relationship kind.
+    #[must_use]
+    pub fn kind(&self) -> &EdgeKind {
+        &self.kind
+    }
+}

--- a/crates/phantom-dag/src/lib.rs
+++ b/crates/phantom-dag/src/lib.rs
@@ -1,0 +1,316 @@
+//! `phantom-dag` — code dependency graph extraction and persistence.
+//!
+//! Provides [`CodeDag`], a graph of [`DagNode`]s (code symbols) connected by
+//! [`DagEdge`]s (dependency relationships).  Graphs can be serialised to / from
+//! the `.planning/dag.json` format and queried for connected components via
+//! [`CodeDag::community_ids`].
+
+mod edge;
+mod node;
+mod persist;
+mod union_find;
+
+pub use edge::{DagEdge, EdgeKind};
+pub use node::{DagNode, NodeKind};
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// CodeDag
+// ---------------------------------------------------------------------------
+
+/// A directed code-dependency graph.
+///
+/// Nodes represent code symbols; edges represent relationships between them.
+/// The graph is keyed on the fully-qualified symbol id so duplicate insertions
+/// are handled gracefully (the later node overwrites the earlier one).
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct CodeDag {
+    nodes: HashMap<String, DagNode>,
+    edges: Vec<DagEdge>,
+}
+
+impl CodeDag {
+    /// Create an empty graph.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    // -----------------------------------------------------------------------
+    // Mutation
+    // -----------------------------------------------------------------------
+
+    /// Insert a node, replacing any existing node with the same id.
+    pub fn add_node(&mut self, node: DagNode) {
+        self.nodes.insert(node.id().to_owned(), node);
+    }
+
+    /// Append a directed edge.  The referenced node ids need not exist at the
+    /// time the edge is added; unknown ids are simply ignored during traversal.
+    pub fn add_edge(&mut self, edge: DagEdge) {
+        self.edges.push(edge);
+    }
+
+    // -----------------------------------------------------------------------
+    // Accessors
+    // -----------------------------------------------------------------------
+
+    /// Number of nodes in the graph.
+    #[must_use]
+    pub fn node_count(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Number of edges in the graph.
+    #[must_use]
+    pub fn edge_count(&self) -> usize {
+        self.edges.len()
+    }
+
+    /// Look up a node by its fully-qualified id.
+    #[must_use]
+    pub fn get_node(&self, id: &str) -> Option<&DagNode> {
+        self.nodes.get(id)
+    }
+
+    /// Iterate over all nodes.
+    pub fn nodes(&self) -> impl Iterator<Item = &DagNode> {
+        self.nodes.values()
+    }
+
+    /// Iterate over all edges.
+    pub fn edges(&self) -> impl Iterator<Item = &DagEdge> {
+        self.edges.iter()
+    }
+
+    // -----------------------------------------------------------------------
+    // Community detection
+    // -----------------------------------------------------------------------
+
+    /// Compute connected components using union-find (treating edges as
+    /// undirected for the purpose of clustering).
+    ///
+    /// Returns a `HashMap<node_id, component_id>` where `component_id` is the
+    /// canonical root id of the component.
+    #[must_use]
+    pub fn community_ids(&self) -> HashMap<String, String> {
+        let mut uf = union_find::UnionFind::new();
+
+        // Initialise every node as its own component.
+        for id in self.nodes.keys() {
+            uf.make_set(id);
+        }
+
+        // Union nodes connected by any edge.
+        for edge in &self.edges {
+            // Only union nodes that actually exist in the graph.
+            if self.nodes.contains_key(edge.from()) && self.nodes.contains_key(edge.to()) {
+                uf.union(edge.from(), edge.to());
+            }
+        }
+
+        self.nodes
+            .keys()
+            .map(|id| (id.clone(), uf.find(id)))
+            .collect()
+    }
+
+    // -----------------------------------------------------------------------
+    // Serialisation
+    // -----------------------------------------------------------------------
+
+    /// Serialise the graph to a JSON string in `.planning/dag.json` format.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if serialisation fails (practically unreachable for
+    /// well-formed data).
+    pub fn to_json(&self) -> Result<String> {
+        persist::to_json(self)
+    }
+
+    /// Deserialise a graph from a JSON string produced by [`to_json`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the JSON is malformed or the schema version is
+    /// unrecognised.
+    ///
+    /// [`to_json`]: CodeDag::to_json
+    pub fn from_json(json: &str) -> Result<Self> {
+        persist::from_json(json)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    fn node(id: &str) -> DagNode {
+        DagNode::new(id.to_owned(), NodeKind::Function, PathBuf::from("src/lib.rs"), 1)
+    }
+
+    fn edge(from: &str, to: &str) -> DagEdge {
+        DagEdge::new(from.to_owned(), to.to_owned(), EdgeKind::Calls)
+    }
+
+    // 1. Add a node and retrieve it.
+    #[test]
+    fn add_node_stores_and_retrieves() {
+        let mut dag = CodeDag::new();
+        dag.add_node(node("phantom_agents::dispatch::dispatch_tool"));
+
+        assert_eq!(dag.node_count(), 1);
+        let n = dag.get_node("phantom_agents::dispatch::dispatch_tool").unwrap();
+        assert_eq!(n.id(), "phantom_agents::dispatch::dispatch_tool");
+        assert_eq!(*n.kind(), NodeKind::Function);
+    }
+
+    // 2. Add an edge and verify counts.
+    #[test]
+    fn add_edge_increments_count() {
+        let mut dag = CodeDag::new();
+        dag.add_node(node("a"));
+        dag.add_node(node("b"));
+        dag.add_edge(edge("a", "b"));
+
+        assert_eq!(dag.edge_count(), 1);
+        let e = dag.edges().next().unwrap();
+        assert_eq!(e.from(), "a");
+        assert_eq!(e.to(), "b");
+        assert_eq!(*e.kind(), EdgeKind::Calls);
+    }
+
+    // 3. JSON round-trip preserves all data.
+    #[test]
+    fn json_round_trip() {
+        let mut dag = CodeDag::new();
+        dag.add_node(DagNode::new(
+            "mod::foo".to_owned(),
+            NodeKind::Function,
+            PathBuf::from("src/foo.rs"),
+            42,
+        ));
+        dag.add_node(DagNode::new(
+            "mod::Bar".to_owned(),
+            NodeKind::Struct,
+            PathBuf::from("src/bar.rs"),
+            10,
+        ));
+        dag.add_edge(DagEdge::new(
+            "mod::foo".to_owned(),
+            "mod::Bar".to_owned(),
+            EdgeKind::Uses,
+        ));
+
+        let json = dag.to_json().unwrap();
+        let restored = CodeDag::from_json(&json).unwrap();
+
+        assert_eq!(restored.node_count(), 2);
+        assert_eq!(restored.edge_count(), 1);
+
+        let foo = restored.get_node("mod::foo").unwrap();
+        assert_eq!(*foo.kind(), NodeKind::Function);
+        assert_eq!(foo.line(), 42);
+
+        let e = restored.edges().next().unwrap();
+        assert_eq!(e.from(), "mod::foo");
+        assert_eq!(e.to(), "mod::Bar");
+        assert_eq!(*e.kind(), EdgeKind::Uses);
+    }
+
+    // 4. Community detection on a disconnected graph.
+    #[test]
+    fn community_ids_disconnected_graph() {
+        let mut dag = CodeDag::new();
+        // Component A: a — b — c
+        dag.add_node(node("a"));
+        dag.add_node(node("b"));
+        dag.add_node(node("c"));
+        dag.add_edge(edge("a", "b"));
+        dag.add_edge(edge("b", "c"));
+        // Component B: x — y
+        dag.add_node(node("x"));
+        dag.add_node(node("y"));
+        dag.add_edge(edge("x", "y"));
+        // Isolated node
+        dag.add_node(node("z"));
+
+        let ids = dag.community_ids();
+
+        // All nodes in component A must share the same community id.
+        let ca = ids["a"].clone();
+        assert_eq!(ids["b"], ca);
+        assert_eq!(ids["c"], ca);
+
+        // Component B must share a different community id.
+        let cb = ids["x"].clone();
+        assert_eq!(ids["y"], cb);
+        assert_ne!(ca, cb);
+
+        // z is its own component.
+        let cz = ids["z"].clone();
+        assert_ne!(cz, ca);
+        assert_ne!(cz, cb);
+    }
+
+    // 5. Empty graph behaves correctly.
+    #[test]
+    fn empty_graph() {
+        let dag = CodeDag::new();
+        assert_eq!(dag.node_count(), 0);
+        assert_eq!(dag.edge_count(), 0);
+        assert!(dag.community_ids().is_empty());
+
+        // JSON round-trip of empty graph.
+        let json = dag.to_json().unwrap();
+        let restored = CodeDag::from_json(&json).unwrap();
+        assert_eq!(restored.node_count(), 0);
+        assert_eq!(restored.edge_count(), 0);
+    }
+
+    // 6. Duplicate node insertion — later node replaces earlier one.
+    #[test]
+    fn duplicate_node_replaces_earlier() {
+        let mut dag = CodeDag::new();
+        dag.add_node(DagNode::new(
+            "a".to_owned(),
+            NodeKind::Function,
+            PathBuf::from("old.rs"),
+            1,
+        ));
+        dag.add_node(DagNode::new(
+            "a".to_owned(),
+            NodeKind::Struct,
+            PathBuf::from("new.rs"),
+            99,
+        ));
+
+        // Still only one node.
+        assert_eq!(dag.node_count(), 1);
+        let n = dag.get_node("a").unwrap();
+        // The second insertion wins.
+        assert_eq!(*n.kind(), NodeKind::Struct);
+        assert_eq!(n.line(), 99);
+    }
+
+    // 7. JSON envelope contains expected schema version field.
+    #[test]
+    fn json_contains_schema_version() {
+        let dag = CodeDag::new();
+        let json = dag.to_json().unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["version"], 1);
+        assert!(v["generated_at"].is_string());
+    }
+}

--- a/crates/phantom-dag/src/node.rs
+++ b/crates/phantom-dag/src/node.rs
@@ -1,0 +1,83 @@
+//! [`DagNode`] and [`NodeKind`] — code symbol vertices.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// NodeKind
+// ---------------------------------------------------------------------------
+
+/// The syntactic category of a code symbol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NodeKind {
+    /// A free function or method.
+    Function,
+    /// A struct definition.
+    Struct,
+    /// A trait definition.
+    Trait,
+    /// A module.
+    Module,
+    /// A test function (annotated with `#[test]`).
+    Test,
+}
+
+// ---------------------------------------------------------------------------
+// DagNode
+// ---------------------------------------------------------------------------
+
+/// A vertex in the code dependency graph, representing a single code symbol.
+///
+/// All fields are private; use the accessor methods to read them.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DagNode {
+    /// Fully-qualified symbol path, e.g. `phantom_agents::dispatch::dispatch_tool`.
+    id: String,
+    /// The syntactic category of this symbol.
+    kind: NodeKind,
+    /// Source file in which the symbol is defined.
+    file: PathBuf,
+    /// 1-based line number of the symbol's definition.
+    line: u32,
+}
+
+impl DagNode {
+    /// Construct a new [`DagNode`].
+    ///
+    /// # Arguments
+    ///
+    /// * `id`   — Fully-qualified symbol id (e.g. `phantom_agents::dispatch::dispatch_tool`).
+    /// * `kind` — Syntactic category.
+    /// * `file` — Source file path.
+    /// * `line` — 1-based line number.
+    #[must_use]
+    pub fn new(id: String, kind: NodeKind, file: PathBuf, line: u32) -> Self {
+        Self { id, kind, file, line }
+    }
+
+    /// The fully-qualified symbol id.
+    #[must_use]
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// The syntactic category.
+    #[must_use]
+    pub fn kind(&self) -> &NodeKind {
+        &self.kind
+    }
+
+    /// Source file in which the symbol is defined.
+    #[must_use]
+    pub fn file(&self) -> &PathBuf {
+        &self.file
+    }
+
+    /// 1-based line number of the definition.
+    #[must_use]
+    pub fn line(&self) -> u32 {
+        self.line
+    }
+}

--- a/crates/phantom-dag/src/persist.rs
+++ b/crates/phantom-dag/src/persist.rs
@@ -1,0 +1,71 @@
+//! JSON persistence for [`CodeDag`] — the `.planning/dag.json` wire format.
+//!
+//! Schema (version 1):
+//! ```json
+//! {
+//!   "version": 1,
+//!   "generated_at": "<ISO 8601 UTC timestamp>",
+//!   "nodes": [ { "id": "...", "kind": "function", "file": "...", "line": 1 } ],
+//!   "edges": [ { "from": "...", "to": "...", "kind": "calls" } ]
+//! }
+//! ```
+
+use anyhow::{Context, Result, bail};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+
+use crate::{CodeDag, DagEdge, DagNode};
+
+/// Current schema version written to `dag.json`.
+const SCHEMA_VERSION: u32 = 1;
+
+// ---------------------------------------------------------------------------
+// Wire types
+// ---------------------------------------------------------------------------
+
+/// Top-level JSON envelope for `.planning/dag.json`.
+#[derive(Serialize, Deserialize)]
+struct DagFile {
+    version: u32,
+    generated_at: String,
+    nodes: Vec<DagNode>,
+    edges: Vec<DagEdge>,
+}
+
+// ---------------------------------------------------------------------------
+// Public helpers (crate-private)
+// ---------------------------------------------------------------------------
+
+/// Serialise a [`CodeDag`] into the `.planning/dag.json` JSON format.
+pub(crate) fn to_json(dag: &CodeDag) -> Result<String> {
+    let file = DagFile {
+        version: SCHEMA_VERSION,
+        generated_at: Utc::now().to_rfc3339(),
+        nodes: dag.nodes().cloned().collect(),
+        edges: dag.edges().cloned().collect(),
+    };
+    serde_json::to_string_pretty(&file).context("failed to serialise CodeDag to JSON")
+}
+
+/// Deserialise a [`CodeDag`] from the `.planning/dag.json` JSON format.
+pub(crate) fn from_json(json: &str) -> Result<CodeDag> {
+    let file: DagFile =
+        serde_json::from_str(json).context("failed to parse dag.json — invalid JSON or schema")?;
+
+    if file.version != SCHEMA_VERSION {
+        bail!(
+            "unsupported dag.json schema version {} (expected {})",
+            file.version,
+            SCHEMA_VERSION
+        );
+    }
+
+    let mut dag = CodeDag::new();
+    for node in file.nodes {
+        dag.add_node(node);
+    }
+    for edge in file.edges {
+        dag.add_edge(edge);
+    }
+    Ok(dag)
+}

--- a/crates/phantom-dag/src/union_find.rs
+++ b/crates/phantom-dag/src/union_find.rs
@@ -1,0 +1,119 @@
+//! Weighted union-find (disjoint-set) for connected-component computation.
+//!
+//! Node ids are arbitrary `String`s.  Rank-based union with path-compression
+//! find gives amortised near-linear performance.
+
+use std::collections::HashMap;
+
+/// A union-find data structure keyed on `String` node ids.
+pub(crate) struct UnionFind {
+    parent: HashMap<String, String>,
+    rank: HashMap<String, u32>,
+}
+
+impl UnionFind {
+    pub(crate) fn new() -> Self {
+        Self { parent: HashMap::new(), rank: HashMap::new() }
+    }
+
+    /// Register a new singleton set for `id`.  A no-op if `id` is already
+    /// present.
+    pub(crate) fn make_set(&mut self, id: &str) {
+        if !self.parent.contains_key(id) {
+            self.parent.insert(id.to_owned(), id.to_owned());
+            self.rank.insert(id.to_owned(), 0);
+        }
+    }
+
+    /// Find the canonical root of the set containing `id`, with path
+    /// compression.  Returns the root id as an owned `String`.
+    /// Panics if `id` was never registered via [`make_set`].
+    pub(crate) fn find(&mut self, id: &str) -> String {
+        // Iterative path-compression.
+        let mut current = id.to_owned();
+        loop {
+            let parent = self.parent[&current].clone();
+            if parent == current {
+                break;
+            }
+            // Path compression: point directly to grandparent.
+            let grandparent = self.parent[&parent].clone();
+            self.parent.insert(current.clone(), grandparent.clone());
+            current = grandparent;
+        }
+        current
+    }
+
+    /// Merge the sets containing `a` and `b` using union-by-rank.
+    pub(crate) fn union(&mut self, a: &str, b: &str) {
+        let root_a = self.find(a);
+        let root_b = self.find(b);
+
+        if root_a == root_b {
+            return;
+        }
+
+        let rank_a = self.rank[&root_a];
+        let rank_b = self.rank[&root_b];
+
+        // Lower-rank root becomes a child of the higher-rank root.
+        match rank_a.cmp(&rank_b) {
+            std::cmp::Ordering::Less => {
+                self.parent.insert(root_a, root_b);
+            }
+            std::cmp::Ordering::Greater => {
+                self.parent.insert(root_b, root_a);
+            }
+            std::cmp::Ordering::Equal => {
+                self.parent.insert(root_b, root_a.clone());
+                *self.rank.entry(root_a).or_insert(0) += 1;
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn singleton_is_own_root() {
+        let mut uf = UnionFind::new();
+        uf.make_set("a");
+        assert_eq!(uf.find("a"), "a");
+    }
+
+    #[test]
+    fn union_merges_components() {
+        let mut uf = UnionFind::new();
+        for id in ["a", "b", "c"] {
+            uf.make_set(id);
+        }
+        uf.union("a", "b");
+        uf.union("b", "c");
+
+        let ra = uf.find("a");
+        let rb = uf.find("b");
+        let rc = uf.find("c");
+        assert_eq!(ra, rb);
+        assert_eq!(rb, rc);
+    }
+
+    #[test]
+    fn disconnected_sets_have_different_roots() {
+        let mut uf = UnionFind::new();
+        for id in ["a", "b", "x", "y"] {
+            uf.make_set(id);
+        }
+        uf.union("a", "b");
+        uf.union("x", "y");
+
+        let rab = uf.find("a");
+        let rxy = uf.find("x");
+        assert_ne!(rab, rxy);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #64

- Introduces `crates/phantom-dag` (new workspace member) with the full code dependency graph foundation required by the Inspector DAG visualizer (#66) and ticket overlay (#65)
- `DagNode` — fully-qualified symbol id, `NodeKind` (Function/Struct/Trait/Module/Test), file path, line number; all fields private with accessors
- `DagEdge` — from/to ids, `EdgeKind` (Calls/Implements/Uses/Contains); all fields private with accessors
- `CodeDag` — `HashMap<String, DagNode>` + `Vec<DagEdge>`, with `add_node`/`add_edge`, counts, iterators, `to_json`/`from_json`, and `community_ids` (union-find connected components)
- `.planning/dag.json` schema: `{ "version": 1, "generated_at": "<ISO8601>", "nodes": [...], "edges": [...] }`
- 10 tests passing: add_node, add_edge, JSON round-trip, disconnected community detection, empty graph, duplicate node replacement, schema version assertion, and 3 union-find unit tests
- No bare `pub` fields; no `.unwrap()` outside `#[cfg(test)]`

## Test plan

- [ ] `cargo test -p phantom-dag` — all 10 tests green
- [ ] `cargo check -p phantom-dag` — clean
- [ ] Verify JSON output from `to_json()` has `"version": 1` and `"generated_at"` fields
- [ ] Verify `community_ids()` groups connected nodes and isolates disconnected ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)