### PR TITLE
fix(#98,#99): remove stale reconciler deferral comment + Replan user notification

### DIFF
--- a/crates/phantom-brain/src/reconciler.rs
+++ b/crates/phantom-brain/src/reconciler.rs
@@ -112,10 +112,17 @@ impl ReconcilerState {
                 // stall counter and recent-output loop detection.
                 let _assessment = ledger.assess_progress();
                 log::info!("Reconciler: re-plan triggered — {reason}");
-                // Deferred to #32 (Reconciler: should_replan + dispatch_next_step).
-                // When that lands, spawn a Composer agent here to generate a revised
-                // plan and call ledger.replan(new_steps). For now, log and keep the
-                // ledger alive — the next tick will re-evaluate.
+                // Notify the user that the goal is being re-evaluated.
+                let _ = action_tx.send(AiAction::ShowNotification(format!(
+                    "Re-planning goal '{}': {reason}",
+                    ledger.goal
+                )));
+                // Automated re-planning (spawning a Composer agent to generate
+                // revised steps via LLM and calling `ledger.replan(new_steps)`)
+                // is a Phase 2 feature that requires the brain to hold an async
+                // LLM client. For now the ledger stays alive and the next tick
+                // will re-evaluate — stall detection or GiveUp will escalate
+                // if progress never resumes.
                 true
             }
 
@@ -551,6 +558,38 @@ mod tests {
             "step must remain Active when spawn_tag is unknown"
         );
     }
+    // -- Replan notification test (Issue #98 comment cleanup) -----------------
+
+    /// When `should_replan()` returns `Replan`, the reconciler must emit a
+    /// `ShowNotification` to the user so they can see that the goal hit a
+    /// re-plan decision point. The ledger must remain alive (`tick` returns
+    /// `true`) so subsequent ticks can re-evaluate.
+    #[test]
+    fn replan_decision_emits_notification_and_keeps_ledger_alive() {
+        let (tx, rx) = mpsc::channel();
+        let mut state = ReconcilerState::new();
+        let mut ledger = make_ledger(&["step one"]);
+
+        // Force a stall: set stall_counter above the default threshold (2).
+        ledger.stall_counter = 3;
+
+        // Tick: should_replan() → Replan, must emit ShowNotification.
+        let still_active = state.tick(&mut ledger, &tx);
+        assert!(still_active, "ledger must remain active on Replan");
+
+        // Drain all actions emitted; the notification should be one of them.
+        let mut got_notification = false;
+        while let Ok(action) = rx.try_recv() {
+            if matches!(action, AiAction::ShowNotification(_)) {
+                got_notification = true;
+            }
+        }
+        assert!(
+            got_notification,
+            "reconciler must emit ShowNotification when Replan is triggered"
+        );
+    }
+
     // -- Issue #111: AgentError exit-path spawn_tag coverage -----------------
 
     /// When `drain_bus_to_brain` translates `Event::AgentError` it hard-codes


### PR DESCRIPTION
## Summary

- **Issue #98** (brain.rs tech debt): Removes the last stale `// Deferred to #32` marker in `reconciler.rs`. This comment predated the `should_replan()` + `dispatch_next_step()` implementation from #32 and was no longer accurate.
- **Issue #99** (spawn ID feedback loop): The spawn_tag fix was already implemented in commit `30fe072`. This PR documents the completion and adds one additional test to verify the `Replan` notification behavior.

**Changes to `crates/phantom-brain/src/reconciler.rs`:**

1. Replace the stale deferral comment in `ReplanDecision::Replan` arm with a `ShowNotification` action — users now see re-plan events inline instead of only in the logs
2. Replace inaccurate "waiting for #32 to land" comment with an accurate Phase 2 deferral note (the missing piece is an async LLM client in the brain loop, not the orchestrator API — `ledger.replan()` already exists)
3. Add `replan_decision_emits_notification_and_keeps_ledger_alive` test (TDD)

## Test plan

- [x] `cargo test -p phantom-brain` — 263 passed (262 before + 1 new), 0 failed
- [x] No bare `pub` fields in changed files
- [x] No `.unwrap()` outside `#[cfg(test)]` blocks in changed files
- [x] `cargo check -p phantom-brain` — clean

## Context

- Issue #98 (standalone brain.rs TODOs) was resolved by commit `1fcddc9` (PR #120)
- Issue #99 (spawn_tag feedback loop) was resolved by commit `30fe072` (branch `fix/issue-99-spawn-tag`)
- This PR closes out the one stale comment that outlived both of those fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)