### PR TITLE
feat(#71): GPT-4V visual analysis backend in phantom-vision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5567,7 +5567,14 @@ dependencies = [
 name = "phantom-vision"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
+ "base64",
+ "png 0.17.16",
+ "reqwest",
+ "serde",
+ "serde_json",
  "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/phantom-vision/Cargo.toml
+++ b/crates/phantom-vision/Cargo.toml
@@ -13,6 +13,9 @@ base64 = "0.22"
 png = "0.17"
 reqwest = { version = "0.12", features = ["json"] }
 
+[features]
+test-utils = []
+
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 

--- a/crates/phantom-vision/Cargo.toml
+++ b/crates/phantom-vision/Cargo.toml
@@ -6,6 +6,15 @@ license.workspace = true
 
 [dependencies]
 thiserror = "2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+async-trait = "0.1"
+base64 = "0.22"
+png = "0.17"
+reqwest = { version = "0.12", features = ["json"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 
 [lints]
 workspace = true

--- a/crates/phantom-vision/src/analysis.rs
+++ b/crates/phantom-vision/src/analysis.rs
@@ -34,24 +34,91 @@ pub const MAX_IMAGE_BYTES: usize = 100 * 1024; // 100 KB
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct UiElement {
     /// Human-readable label, e.g. `"Submit button"`, `"Terminal pane"`.
-    pub label: String,
+    label: String,
     /// Confidence in `[0.0, 1.0]`.
-    pub confidence: f32,
+    confidence: f32,
     /// Optional bounding-box in pixels `(x, y, width, height)`.
-    pub bounding_box: Option<(u32, u32, u32, u32)>,
+    bounding_box: Option<(u32, u32, u32, u32)>,
+}
+
+impl UiElement {
+    /// Build a new [`UiElement`].
+    #[must_use]
+    pub fn new(
+        label: String,
+        confidence: f32,
+        bounding_box: Option<(u32, u32, u32, u32)>,
+    ) -> Self {
+        Self { label, confidence, bounding_box }
+    }
+
+    /// Human-readable label, e.g. `"Submit button"` or `"Terminal pane"`.
+    #[must_use]
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    /// Confidence score in `[0.0, 1.0]`.
+    #[must_use]
+    pub fn confidence(&self) -> f32 {
+        self.confidence
+    }
+
+    /// Optional bounding-box in pixels `(x, y, width, height)`.
+    #[must_use]
+    pub fn bounding_box(&self) -> Option<(u32, u32, u32, u32)> {
+        self.bounding_box
+    }
 }
 
 /// Structured output produced by a [`VisionBackend`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Analysis {
     /// All readable text extracted from the frame.
-    pub text_content: String,
+    text_content: String,
     /// UI elements detected (may be empty when the prompt is not UI-oriented).
-    pub ui_elements: Vec<UiElement>,
+    ui_elements: Vec<UiElement>,
     /// One-sentence summary of the frame.
-    pub summary: String,
+    summary: String,
     /// Optional embedding vector for downstream vector search.
-    pub embedding: Vec<f32>,
+    embedding: Vec<f32>,
+}
+
+impl Analysis {
+    /// Build a new [`Analysis`].
+    #[must_use]
+    pub fn new(
+        text_content: String,
+        ui_elements: Vec<UiElement>,
+        summary: String,
+        embedding: Vec<f32>,
+    ) -> Self {
+        Self { text_content, ui_elements, summary, embedding }
+    }
+
+    /// All readable text extracted from the frame.
+    #[must_use]
+    pub fn text_content(&self) -> &str {
+        &self.text_content
+    }
+
+    /// UI elements detected (may be empty when the prompt is not UI-oriented).
+    #[must_use]
+    pub fn ui_elements(&self) -> &[UiElement] {
+        &self.ui_elements
+    }
+
+    /// One-sentence summary of the frame.
+    #[must_use]
+    pub fn summary(&self) -> &str {
+        &self.summary
+    }
+
+    /// Optional embedding vector for downstream vector search.
+    #[must_use]
+    pub fn embedding(&self) -> &[f32] {
+        &self.embedding
+    }
 }
 
 /// Canned prompt templates understood by all backends.
@@ -318,12 +385,7 @@ impl VisionBackend for OpenAiVisionBackend {
             .and_then(|c| c.message.content)
             .unwrap_or_default();
 
-        Ok(Analysis {
-            text_content: content.clone(),
-            ui_elements: Vec::new(),
-            summary: content,
-            embedding: Vec::new(),
-        })
+        Ok(Analysis::new(content.clone(), Vec::new(), content, Vec::new()))
     }
 }
 
@@ -333,8 +395,13 @@ impl VisionBackend for OpenAiVisionBackend {
 ///
 /// Always returns a fixed [`Analysis`] derived from the prompt string and the
 /// screenshot dimensions. Never makes network calls.
+///
+/// Only compiled when the `test-utils` feature is enabled or in `#[cfg(test)]`
+/// contexts — never compiled into a production binary.
+#[cfg(any(test, feature = "test-utils"))]
 pub struct MockVisionBackend;
 
+#[cfg(any(test, feature = "test-utils"))]
 #[async_trait]
 impl VisionBackend for MockVisionBackend {
     fn name(&self) -> &'static str {
@@ -356,16 +423,12 @@ impl VisionBackend for MockVisionBackend {
         }
 
         let summary = format!("Mock analysis of {w}x{h} frame: {prompt}");
-        Ok(Analysis {
-            text_content: format!("Text from mock {w}x{h}"),
-            ui_elements: vec![UiElement {
-                label: "mock element".to_string(),
-                confidence: 1.0,
-                bounding_box: Some((0, 0, w, h)),
-            }],
+        Ok(Analysis::new(
+            format!("Text from mock {w}x{h}"),
+            vec![UiElement::new("mock element".to_string(), 1.0, Some((0, 0, w, h)))],
             summary,
-            embedding: vec![0.0_f32; 16],
-        })
+            vec![0.0_f32; 16],
+        ))
     }
 }
 
@@ -401,9 +464,9 @@ mod tests {
         let s = small_screenshot();
         let backend = MockVisionBackend;
         let result = backend.analyze(&s, "summarize this").await.unwrap();
-        assert!(!result.summary.is_empty());
-        assert!(!result.text_content.is_empty());
-        assert_eq!(result.embedding.len(), 16);
+        assert!(!result.summary().is_empty());
+        assert!(!result.text_content().is_empty());
+        assert_eq!(result.embedding().len(), 16);
     }
 
     #[tokio::test]
@@ -412,9 +475,9 @@ mod tests {
         let backend = MockVisionBackend;
         let result = backend.analyze(&s, "summarize").await.unwrap();
         assert!(
-            result.summary.contains("8x8"),
+            result.summary().contains("8x8"),
             "summary should mention dimensions: {}",
-            result.summary
+            result.summary()
         );
     }
 
@@ -426,8 +489,8 @@ mod tests {
             .analyze_with_template(&s, PromptTemplate::IdentifyUiElements)
             .await
             .unwrap();
-        assert_eq!(result.ui_elements.len(), 1);
-        assert_eq!(result.ui_elements[0].label, "mock element");
+        assert_eq!(result.ui_elements().len(), 1);
+        assert_eq!(result.ui_elements()[0].label(), "mock element");
     }
 
     #[tokio::test]
@@ -458,9 +521,9 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            result.summary.contains("anomal"),
+            result.summary().contains("anomal"),
             "terminal anomalies template should surface in mock summary: {}",
-            result.summary
+            result.summary()
         );
     }
 
@@ -553,28 +616,24 @@ mod tests {
 
     #[test]
     fn ui_element_serde_round_trips() {
-        let el = UiElement {
-            label: "Terminal pane".into(),
-            confidence: 0.95,
-            bounding_box: Some((10, 20, 640, 480)),
-        };
+        let el = UiElement::new("Terminal pane".into(), 0.95, Some((10, 20, 640, 480)));
         let json = serde_json::to_string(&el).unwrap();
         let back: UiElement = serde_json::from_str(&json).unwrap();
-        assert_eq!(back.label, el.label);
-        assert!((back.confidence - el.confidence).abs() < 1e-6);
-        assert_eq!(back.bounding_box, el.bounding_box);
+        assert_eq!(back.label(), el.label());
+        assert!((back.confidence() - el.confidence()).abs() < 1e-6);
+        assert_eq!(back.bounding_box(), el.bounding_box());
     }
 
     #[test]
     fn analysis_embedding_storable_as_vec_f32() {
-        let a = Analysis {
-            text_content: "hello".into(),
-            ui_elements: Vec::new(),
-            summary: "a frame".into(),
-            embedding: vec![0.1, 0.2, 0.3],
-        };
+        let a = Analysis::new(
+            "hello".into(),
+            Vec::new(),
+            "a frame".into(),
+            vec![0.1, 0.2, 0.3],
+        );
         let json = serde_json::to_string(&a).unwrap();
         let back: Analysis = serde_json::from_str(&json).unwrap();
-        assert_eq!(back.embedding.len(), 3);
+        assert_eq!(back.embedding().len(), 3);
     }
 }

--- a/crates/phantom-vision/src/analysis.rs
+++ b/crates/phantom-vision/src/analysis.rs
@@ -1,0 +1,580 @@
+//! GPT-4V analysis pipeline for phantom-vision.
+//!
+//! The [`VisionBackend`] trait is the sole public surface for callers. Pass a
+//! [`Screenshot`] and a plain-English `prompt`; receive an [`Analysis`] in
+//! return. Concrete implementations ([`OpenAiVisionBackend`] and
+//! [`MockVisionBackend`]) are wired at the call site so the trait can be
+//! swapped for local vision models without touching callers.
+//!
+//! # Cost guard
+//!
+//! [`OpenAiVisionBackend`] refuses any screenshot whose PNG byte length exceeds
+//! [`MAX_IMAGE_BYTES`] (100 KB). The image is sent as an inline `data:` URI in
+//! the GPT-4V `image_url` message part.
+//!
+//! # Prompt templates
+//!
+//! Three stock prompts are exposed via [`PromptTemplate`]:
+//! - [`PromptTemplate::Summarize`] — one-sentence summary of what is visible.
+//! - [`PromptTemplate::ExtractText`] — all readable text, preserving layout.
+//! - [`PromptTemplate::IdentifyUiElements`] — structured list of UI elements.
+//! - [`PromptTemplate::TerminalAnomalies`] — terminal-optimised: flags errors and crashes.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::{format::Screenshot, VisionError};
+
+/// Maximum PNG byte size accepted by [`OpenAiVisionBackend`].
+pub const MAX_IMAGE_BYTES: usize = 100 * 1024; // 100 KB
+
+// ── Domain types ──────────────────────────────────────────────────────────────
+
+/// A detected UI element inside the screenshot.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UiElement {
+    /// Human-readable label, e.g. `"Submit button"`, `"Terminal pane"`.
+    pub label: String,
+    /// Confidence in `[0.0, 1.0]`.
+    pub confidence: f32,
+    /// Optional bounding-box in pixels `(x, y, width, height)`.
+    pub bounding_box: Option<(u32, u32, u32, u32)>,
+}
+
+/// Structured output produced by a [`VisionBackend`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Analysis {
+    /// All readable text extracted from the frame.
+    pub text_content: String,
+    /// UI elements detected (may be empty when the prompt is not UI-oriented).
+    pub ui_elements: Vec<UiElement>,
+    /// One-sentence summary of the frame.
+    pub summary: String,
+    /// Optional embedding vector for downstream vector search.
+    pub embedding: Vec<f32>,
+}
+
+/// Canned prompt templates understood by all backends.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PromptTemplate {
+    /// Produce a one-sentence summary of what is visible.
+    Summarize,
+    /// Extract all readable text, preserving approximate spatial layout.
+    ExtractText,
+    /// Return a structured list of UI elements with labels and positions.
+    IdentifyUiElements,
+    /// Terminal screenshot optimised: describe content and flag errors/crashes.
+    TerminalAnomalies,
+}
+
+impl PromptTemplate {
+    /// Resolve the template to a concrete prompt string.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Summarize => {
+                "Provide a single concise sentence summarising what is visible in this screenshot."
+            }
+            Self::ExtractText => {
+                "Extract all readable text from this screenshot, preserving the approximate \
+                 spatial layout using newlines and indentation where helpful."
+            }
+            Self::IdentifyUiElements => {
+                "List every UI element visible in this screenshot. For each element provide: \
+                 a short label, its approximate location (top-left quadrant, centre, etc.), \
+                 and whether it appears interactive."
+            }
+            Self::TerminalAnomalies => {
+                "Describe what you see in this terminal screenshot. Be concise. \
+                 Flag any errors, crashes, or anomalies."
+            }
+        }
+    }
+}
+
+// ── Trait ─────────────────────────────────────────────────────────────────────
+
+/// Implemented by concrete vision providers (OpenAI GPT-4V, local models, mocks).
+#[async_trait]
+pub trait VisionBackend: Send + Sync {
+    /// Stable identifier for this backend, e.g. `"openai-gpt4v"` or `"mock"`.
+    fn name(&self) -> &'static str;
+
+    /// Analyse `screenshot` using the given free-form `prompt`.
+    ///
+    /// # Errors
+    ///
+    /// Implementations must return [`VisionError::ImageTooLarge`] when the PNG
+    /// payload exceeds [`MAX_IMAGE_BYTES`], and [`VisionError::Backend`] for
+    /// provider-specific failures.
+    async fn analyze(
+        &self,
+        screenshot: &Screenshot,
+        prompt: &str,
+    ) -> Result<Analysis, VisionError>;
+
+    /// Convenience wrapper that resolves a [`PromptTemplate`] and delegates to
+    /// [`Self::analyze`].
+    async fn analyze_with_template(
+        &self,
+        screenshot: &Screenshot,
+        template: PromptTemplate,
+    ) -> Result<Analysis, VisionError> {
+        self.analyze(screenshot, template.as_str()).await
+    }
+}
+
+// ── OpenAI GPT-4V backend ─────────────────────────────────────────────────────
+
+/// OpenAI GPT-4V vision backend.
+///
+/// Construct via [`OpenAiVisionBackend::from_env`] (reads `OPENAI_API_KEY`) or
+/// [`OpenAiVisionBackend::new`]. Calls the `/chat/completions` endpoint with the
+/// `gpt-4o` model, which supports inline image data URIs.
+pub struct OpenAiVisionBackend {
+    api_key: String,
+    base_url: String,
+    model: String,
+}
+
+impl std::fmt::Debug for OpenAiVisionBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OpenAiVisionBackend")
+            .field("api_key", &"<redacted>")
+            .field("base_url", &self.base_url)
+            .field("model", &self.model)
+            .finish()
+    }
+}
+
+/// Default model — `gpt-4o` supports the vision (image_url) message part.
+const DEFAULT_MODEL: &str = "gpt-4o";
+/// Default OpenAI API base URL.
+const DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
+
+impl OpenAiVisionBackend {
+    /// Build from `OPENAI_API_KEY` environment variable.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VisionError::Backend`] if the variable is absent or empty.
+    pub fn from_env() -> Result<Self, VisionError> {
+        let key = std::env::var("OPENAI_API_KEY").map_err(|_| {
+            VisionError::Backend("OPENAI_API_KEY environment variable not set".to_string())
+        })?;
+        if key.is_empty() {
+            return Err(VisionError::Backend(
+                "OPENAI_API_KEY environment variable is empty".to_string(),
+            ));
+        }
+        Ok(Self::new(key))
+    }
+
+    /// Build with an explicit API key.
+    #[must_use]
+    pub fn new(api_key: String) -> Self {
+        Self {
+            api_key,
+            base_url: DEFAULT_BASE_URL.to_string(),
+            model: DEFAULT_MODEL.to_string(),
+        }
+    }
+
+    /// Override the base URL — used for tests against a local mock server.
+    #[must_use]
+    pub fn with_base_url(mut self, base_url: String) -> Self {
+        self.base_url = base_url;
+        self
+    }
+
+    /// Override the model identifier.
+    #[must_use]
+    pub fn with_model(mut self, model: String) -> Self {
+        self.model = model;
+        self
+    }
+}
+
+// ── OpenAI wire types ─────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct ChatRequest<'a> {
+    model: &'a str,
+    messages: Vec<Message<'a>>,
+    max_tokens: u32,
+}
+
+#[derive(Serialize)]
+struct Message<'a> {
+    role: &'a str,
+    content: Vec<ContentPart<'a>>,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ContentPart<'a> {
+    Text { text: &'a str },
+    ImageUrl { image_url: ImageUrl<'a> },
+}
+
+#[derive(Serialize)]
+struct ImageUrl<'a> {
+    url: &'a str,
+}
+
+#[derive(Deserialize)]
+struct ChatResponse {
+    choices: Vec<Choice>,
+}
+
+#[derive(Deserialize)]
+struct Choice {
+    message: ResponseMessage,
+}
+
+#[derive(Deserialize)]
+struct ResponseMessage {
+    content: Option<String>,
+}
+
+#[async_trait]
+impl VisionBackend for OpenAiVisionBackend {
+    fn name(&self) -> &'static str {
+        "openai-gpt4v"
+    }
+
+    async fn analyze(
+        &self,
+        screenshot: &Screenshot,
+        prompt: &str,
+    ) -> Result<Analysis, VisionError> {
+        let png = screenshot.png_bytes();
+
+        if png.len() > MAX_IMAGE_BYTES {
+            return Err(VisionError::ImageTooLarge {
+                size: png.len(),
+                limit: MAX_IMAGE_BYTES,
+            });
+        }
+
+        let b64 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, png);
+        let data_uri = format!("data:image/png;base64,{b64}");
+
+        let system_prompt =
+            "Describe what you see in this terminal screenshot. Be concise. \
+             Flag any errors, crashes, or anomalies.";
+
+        let body = ChatRequest {
+            model: &self.model,
+            messages: vec![
+                Message {
+                    role: "system",
+                    content: vec![ContentPart::Text { text: system_prompt }],
+                },
+                Message {
+                    role: "user",
+                    content: vec![
+                        ContentPart::ImageUrl {
+                            image_url: ImageUrl { url: &data_uri },
+                        },
+                        ContentPart::Text { text: prompt },
+                    ],
+                },
+            ],
+            max_tokens: 1024,
+        };
+
+        let url = format!("{}/chat/completions", self.base_url);
+        let client = reqwest::Client::new();
+
+        let resp = client
+            .post(&url)
+            .bearer_auth(&self.api_key)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| VisionError::Backend(format!("request failed: {e}")))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp
+                .text()
+                .await
+                .unwrap_or_else(|_| "<unreadable>".to_string());
+            return Err(VisionError::Backend(format!(
+                "OpenAI returned {status}: {text}"
+            )));
+        }
+
+        let parsed: ChatResponse = resp
+            .json()
+            .await
+            .map_err(|e| VisionError::Backend(format!("decode failed: {e}")))?;
+
+        let content = parsed
+            .choices
+            .into_iter()
+            .next()
+            .and_then(|c| c.message.content)
+            .unwrap_or_default();
+
+        Ok(Analysis {
+            text_content: content.clone(),
+            ui_elements: Vec::new(),
+            summary: content,
+            embedding: Vec::new(),
+        })
+    }
+}
+
+// ── Mock backend ──────────────────────────────────────────────────────────────
+
+/// Deterministic in-memory backend for tests and offline development.
+///
+/// Always returns a fixed [`Analysis`] derived from the prompt string and the
+/// screenshot dimensions. Never makes network calls.
+pub struct MockVisionBackend;
+
+#[async_trait]
+impl VisionBackend for MockVisionBackend {
+    fn name(&self) -> &'static str {
+        "mock"
+    }
+
+    async fn analyze(
+        &self,
+        screenshot: &Screenshot,
+        prompt: &str,
+    ) -> Result<Analysis, VisionError> {
+        let (w, h) = screenshot.dimensions();
+
+        if screenshot.png_bytes().len() > MAX_IMAGE_BYTES {
+            return Err(VisionError::ImageTooLarge {
+                size: screenshot.png_bytes().len(),
+                limit: MAX_IMAGE_BYTES,
+            });
+        }
+
+        let summary = format!("Mock analysis of {w}x{h} frame: {prompt}");
+        Ok(Analysis {
+            text_content: format!("Text from mock {w}x{h}"),
+            ui_elements: vec![UiElement {
+                label: "mock element".to_string(),
+                confidence: 1.0,
+                bounding_box: Some((0, 0, w, h)),
+            }],
+            summary,
+            embedding: vec![0.0_f32; 16],
+        })
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::format::ScreenshotSource;
+
+    fn small_screenshot() -> Screenshot {
+        // 8x8 solid grey — tiny PNG, well under 100 KB.
+        let rgba: Vec<u8> = vec![128u8; 8 * 8 * 4];
+        Screenshot::new(&rgba, 8, 8, 0, ScreenshotSource::FullDesktop).unwrap()
+    }
+
+    fn oversized_screenshot() -> Screenshot {
+        // 300x300 pseudo-random pixels — hard to compress below 100 KB.
+        let side = 300u32;
+        let mut rgba = Vec::with_capacity((side as usize) * (side as usize) * 4);
+        for i in 0..(side * side) {
+            let v = (i % 251) as u8;
+            let w = ((i * 7 + 13) % 251) as u8;
+            rgba.extend_from_slice(&[v, w, v ^ w, 255]);
+        }
+        Screenshot::new(&rgba, side, side, 0, ScreenshotSource::FullDesktop).unwrap()
+    }
+
+    // ── Mock backend ──────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn mock_analyze_returns_analysis() {
+        let s = small_screenshot();
+        let backend = MockVisionBackend;
+        let result = backend.analyze(&s, "summarize this").await.unwrap();
+        assert!(!result.summary.is_empty());
+        assert!(!result.text_content.is_empty());
+        assert_eq!(result.embedding.len(), 16);
+    }
+
+    #[tokio::test]
+    async fn mock_analyze_includes_dimensions_in_summary() {
+        let s = small_screenshot();
+        let backend = MockVisionBackend;
+        let result = backend.analyze(&s, "summarize").await.unwrap();
+        assert!(
+            result.summary.contains("8x8"),
+            "summary should mention dimensions: {}",
+            result.summary
+        );
+    }
+
+    #[tokio::test]
+    async fn mock_analyze_returns_one_ui_element() {
+        let s = small_screenshot();
+        let backend = MockVisionBackend;
+        let result = backend
+            .analyze_with_template(&s, PromptTemplate::IdentifyUiElements)
+            .await
+            .unwrap();
+        assert_eq!(result.ui_elements.len(), 1);
+        assert_eq!(result.ui_elements[0].label, "mock element");
+    }
+
+    #[tokio::test]
+    async fn mock_cost_guard_rejects_oversized_image() {
+        let s = oversized_screenshot();
+        if s.png_bytes().len() <= MAX_IMAGE_BYTES {
+            return; // PNG compressed it below limit — skip
+        }
+        let backend = MockVisionBackend;
+        let err = backend
+            .analyze(&s, "anything")
+            .await
+            .expect_err("oversized image should be rejected");
+        assert!(
+            matches!(err, VisionError::ImageTooLarge { .. }),
+            "expected ImageTooLarge, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn mock_anomaly_detection_flag() {
+        // Confirm that the TerminalAnomalies template prompt string is forwarded
+        // and appears in the mock summary (which echoes the prompt).
+        let s = small_screenshot();
+        let backend = MockVisionBackend;
+        let result = backend
+            .analyze_with_template(&s, PromptTemplate::TerminalAnomalies)
+            .await
+            .unwrap();
+        assert!(
+            result.summary.contains("anomal"),
+            "terminal anomalies template should surface in mock summary: {}",
+            result.summary
+        );
+    }
+
+    // ── Prompt templates ──────────────────────────────────────────────────────
+
+    #[test]
+    fn summarize_template_is_non_empty() {
+        assert!(!PromptTemplate::Summarize.as_str().is_empty());
+    }
+
+    #[test]
+    fn extract_text_template_is_non_empty() {
+        assert!(!PromptTemplate::ExtractText.as_str().is_empty());
+    }
+
+    #[test]
+    fn identify_ui_elements_template_is_non_empty() {
+        assert!(!PromptTemplate::IdentifyUiElements.as_str().is_empty());
+    }
+
+    #[test]
+    fn terminal_anomalies_template_is_non_empty() {
+        assert!(!PromptTemplate::TerminalAnomalies.as_str().is_empty());
+    }
+
+    #[test]
+    fn all_templates_are_distinct() {
+        let s = PromptTemplate::Summarize.as_str();
+        let e = PromptTemplate::ExtractText.as_str();
+        let u = PromptTemplate::IdentifyUiElements.as_str();
+        let t = PromptTemplate::TerminalAnomalies.as_str();
+        assert_ne!(s, e);
+        assert_ne!(s, u);
+        assert_ne!(e, u);
+        assert_ne!(s, t);
+        assert_ne!(e, t);
+        assert_ne!(u, t);
+    }
+
+    // ── OpenAI backend unit tests (no network) ────────────────────────────────
+
+    #[test]
+    fn openai_backend_name_is_correct() {
+        let b = OpenAiVisionBackend::new("sk-x".into());
+        assert_eq!(b.name(), "openai-gpt4v");
+    }
+
+    #[test]
+    fn openai_from_env_fails_when_missing() {
+        if std::env::var("OPENAI_API_KEY").is_ok() {
+            return;
+        }
+        let err = OpenAiVisionBackend::from_env()
+            .expect_err("should fail without OPENAI_API_KEY");
+        assert!(matches!(err, VisionError::Backend(_)));
+    }
+
+    #[tokio::test]
+    async fn openai_cost_guard_rejects_oversized_image() {
+        let s = oversized_screenshot();
+        if s.png_bytes().len() <= MAX_IMAGE_BYTES {
+            return; // PNG too compressible to trigger guard — skip
+        }
+        let backend = OpenAiVisionBackend::new("sk-fake".into());
+        let err = backend
+            .analyze(&s, "any prompt")
+            .await
+            .expect_err("oversized image must be rejected before network call");
+        assert!(
+            matches!(err, VisionError::ImageTooLarge { .. }),
+            "expected ImageTooLarge, got {err:?}"
+        );
+    }
+
+    /// Live integration test — skipped in CI, run manually with a real key.
+    #[tokio::test]
+    #[ignore = "requires live OPENAI_API_KEY + network"]
+    async fn openai_analyze_small_screenshot_returns_sensible_analysis() {
+        let backend = OpenAiVisionBackend::from_env()
+            .expect("set OPENAI_API_KEY for live test");
+        let s = small_screenshot();
+        let result = backend
+            .analyze_with_template(&s, PromptTemplate::TerminalAnomalies)
+            .await
+            .expect("live call should succeed");
+        assert!(!result.summary.is_empty(), "summary must not be empty");
+    }
+
+    // ── UiElement serde ───────────────────────────────────────────────────────
+
+    #[test]
+    fn ui_element_serde_round_trips() {
+        let el = UiElement {
+            label: "Terminal pane".into(),
+            confidence: 0.95,
+            bounding_box: Some((10, 20, 640, 480)),
+        };
+        let json = serde_json::to_string(&el).unwrap();
+        let back: UiElement = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.label, el.label);
+        assert!((back.confidence - el.confidence).abs() < 1e-6);
+        assert_eq!(back.bounding_box, el.bounding_box);
+    }
+
+    #[test]
+    fn analysis_embedding_storable_as_vec_f32() {
+        let a = Analysis {
+            text_content: "hello".into(),
+            ui_elements: Vec::new(),
+            summary: "a frame".into(),
+            embedding: vec![0.1, 0.2, 0.3],
+        };
+        let json = serde_json::to_string(&a).unwrap();
+        let back: Analysis = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.embedding.len(), 3);
+    }
+}

--- a/crates/phantom-vision/src/format.rs
+++ b/crates/phantom-vision/src/format.rs
@@ -1,0 +1,390 @@
+//! Canonical screenshot format for phantom-vision.
+//!
+//! A [`Screenshot`] carries raw PNG bytes plus structured metadata sidecar. The
+//! sidecar is stored as a JSON string in a `tEXt` chunk keyed `"phantom-meta"`
+//! so it travels with the file and survives round-trips through any PNG-aware
+//! tool.
+//!
+//! # Wire schema
+//!
+//! ```json
+//! {
+//!   "schema_version": 1,
+//!   "width": 1920,
+//!   "height": 1080,
+//!   "captured_at_ms": 1714300800000,
+//!   "source": { "type": "FullDesktop" },
+//!   "dhash": 12345678901234567890
+//! }
+//! ```
+//!
+//! # Round-trip guarantee
+//!
+//! `Screenshot::encode` → `Screenshot::decode` preserves all fields exactly.
+//! The `dhash` field is computed from the raw pixel buffer at construction time
+//! so it is always consistent with the image content.
+
+use serde::{Deserialize, Serialize};
+
+use crate::VisionError;
+
+/// Bump this whenever the JSON sidecar schema changes in a breaking way.
+pub const SCHEMA_VERSION: u8 = 1;
+
+/// PNG `tEXt` chunk keyword that holds the JSON metadata sidecar.
+const META_KEYWORD: &str = "phantom-meta";
+
+/// Where a screenshot was captured from.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ScreenshotSource {
+    /// The full desktop / primary display.
+    FullDesktop,
+    /// A specific application window identified by the adapter registry.
+    Window { app_id: String },
+    /// A single pane inside the Phantom UI.
+    Pane { adapter_id: String, pane_kind: String },
+}
+
+/// A captured screenshot with all associated metadata.
+///
+/// Construct via [`Screenshot::new`]. Encode to PNG bytes (with embedded
+/// metadata sidecar) via [`Screenshot::encode`]. Recover from those bytes
+/// via [`Screenshot::decode`].
+#[derive(Debug, Clone)]
+pub struct Screenshot {
+    /// Raw PNG bytes. Always valid PNG — guaranteed at construction.
+    png_bytes: Vec<u8>,
+    /// Width and height in pixels.
+    dimensions: (u32, u32),
+    /// Milliseconds since the Unix epoch when the frame was captured.
+    captured_at_ms: u64,
+    /// Origin of the screenshot.
+    source: ScreenshotSource,
+    /// Perceptual difference hash (dHash) of the original RGBA buffer.
+    dhash: u64,
+}
+
+impl Screenshot {
+    /// Raw PNG bytes (always valid, guaranteed at construction).
+    #[must_use]
+    pub fn png_bytes(&self) -> &[u8] {
+        &self.png_bytes
+    }
+
+    /// Width and height in pixels as `(width, height)`.
+    #[must_use]
+    pub fn dimensions(&self) -> (u32, u32) {
+        self.dimensions
+    }
+
+    /// Milliseconds since the Unix epoch when the frame was captured.
+    #[must_use]
+    pub fn captured_at_ms(&self) -> u64 {
+        self.captured_at_ms
+    }
+
+    /// Origin of the screenshot.
+    #[must_use]
+    pub fn source(&self) -> &ScreenshotSource {
+        &self.source
+    }
+
+    /// Perceptual difference hash (dHash) of the original RGBA buffer.
+    #[must_use]
+    pub fn dhash(&self) -> u64 {
+        self.dhash
+    }
+
+    /// Build a [`Screenshot`] from a raw RGBA pixel buffer.
+    ///
+    /// The buffer must be exactly `width * height * 4` bytes. The dHash is
+    /// computed here so it is always consistent with `png_bytes`.
+    ///
+    /// # Errors
+    ///
+    /// - [`VisionError::ZeroDim`] if `width` or `height` is zero.
+    /// - [`VisionError::SizeMismatch`] if the buffer length is wrong.
+    /// - [`VisionError::Encode`] if PNG encoding fails.
+    pub fn new(
+        rgba: &[u8],
+        width: u32,
+        height: u32,
+        captured_at_ms: u64,
+        source: ScreenshotSource,
+    ) -> Result<Self, VisionError> {
+        let dhash = crate::dhash(rgba, width, height)?;
+        let png_bytes = encode_rgba_to_png(rgba, width, height, captured_at_ms, &source, dhash)?;
+        Ok(Self {
+            png_bytes,
+            dimensions: (width, height),
+            captured_at_ms,
+            source,
+            dhash,
+        })
+    }
+
+    /// Encode this screenshot as PNG bytes with a `tEXt` sidecar chunk.
+    ///
+    /// The returned bytes are self-contained: `Screenshot::decode` can recover
+    /// all fields from them without any external state.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VisionError::Encode`] if the PNG encoder fails.
+    pub fn encode(&self) -> Result<Vec<u8>, VisionError> {
+        // Our png_bytes already carry the sidecar from `new`. Return a clone.
+        Ok(self.png_bytes.clone())
+    }
+
+    /// Recover a [`Screenshot`] from PNG bytes produced by [`Self::encode`].
+    ///
+    /// # Errors
+    ///
+    /// - [`VisionError::Decode`] if the bytes are not valid PNG or the sidecar
+    ///   is missing / malformed.
+    pub fn decode(png_bytes: &[u8]) -> Result<Self, VisionError> {
+        let (meta, _rgba, width, height) = decode_png_with_meta(png_bytes)?;
+        Ok(Self {
+            png_bytes: png_bytes.to_vec(),
+            dimensions: (width, height),
+            captured_at_ms: meta.captured_at_ms,
+            source: meta.source,
+            dhash: meta.dhash,
+        })
+    }
+}
+
+// ── Internal PNG helpers ──────────────────────────────────────────────────────
+
+/// JSON sidecar that lives in the PNG `tEXt` chunk.
+#[derive(Serialize, Deserialize)]
+struct ScreenshotMeta {
+    schema_version: u8,
+    width: u32,
+    height: u32,
+    captured_at_ms: u64,
+    source: ScreenshotSource,
+    dhash: u64,
+}
+
+/// Encode RGBA pixel data to PNG bytes and embed the metadata sidecar.
+fn encode_rgba_to_png(
+    rgba: &[u8],
+    width: u32,
+    height: u32,
+    captured_at_ms: u64,
+    source: &ScreenshotSource,
+    dhash: u64,
+) -> Result<Vec<u8>, VisionError> {
+    let meta = ScreenshotMeta {
+        schema_version: SCHEMA_VERSION,
+        width,
+        height,
+        captured_at_ms,
+        source: source.clone(),
+        dhash,
+    };
+    let meta_json =
+        serde_json::to_string(&meta).map_err(|e| VisionError::Encode(e.to_string()))?;
+
+    let mut out = Vec::new();
+    {
+        let mut encoder = png::Encoder::new(&mut out, width, height);
+        encoder.set_color(png::ColorType::Rgba);
+        encoder.set_depth(png::BitDepth::Eight);
+
+        // Embed the JSON sidecar as a tEXt chunk before the image data.
+        encoder
+            .add_text_chunk(META_KEYWORD.to_string(), meta_json)
+            .map_err(|e| VisionError::Encode(e.to_string()))?;
+
+        let mut writer = encoder
+            .write_header()
+            .map_err(|e| VisionError::Encode(e.to_string()))?;
+        writer
+            .write_image_data(rgba)
+            .map_err(|e| VisionError::Encode(e.to_string()))?;
+    }
+    Ok(out)
+}
+
+/// Decode PNG bytes produced by [`encode_rgba_to_png`].
+///
+/// Returns `(meta, rgba_pixels, width, height)`.
+fn decode_png_with_meta(
+    png_bytes: &[u8],
+) -> Result<(ScreenshotMeta, Vec<u8>, u32, u32), VisionError> {
+    let decoder = png::Decoder::new(png_bytes);
+    let mut reader = decoder
+        .read_info()
+        .map_err(|e| VisionError::Decode(e.to_string()))?;
+
+    // Pull the tEXt sidecar out of the ancillary chunks collected during
+    // header parsing.
+    let meta_json = reader
+        .info()
+        .uncompressed_latin1_text
+        .iter()
+        .find(|chunk| chunk.keyword == META_KEYWORD)
+        .map(|chunk| chunk.text.clone())
+        .ok_or_else(|| VisionError::Decode("missing phantom-meta tEXt chunk".to_string()))?;
+
+    let meta: ScreenshotMeta = serde_json::from_str(&meta_json)
+        .map_err(|e| VisionError::Decode(format!("malformed sidecar JSON: {e}")))?;
+
+    let info = reader.info();
+    let width = info.width;
+    let height = info.height;
+    let buf_size = reader.output_buffer_size();
+
+    let mut rgba = vec![0u8; buf_size];
+    let frame = reader
+        .next_frame(&mut rgba)
+        .map_err(|e| VisionError::Decode(e.to_string()))?;
+    rgba.truncate(frame.buffer_size());
+
+    Ok((meta, rgba, width, height))
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn solid_rgba(width: u32, height: u32, colour: [u8; 4]) -> Vec<u8> {
+        let n = (width as usize) * (height as usize);
+        let mut buf = Vec::with_capacity(n * 4);
+        for _ in 0..n {
+            buf.extend_from_slice(&colour);
+        }
+        buf
+    }
+
+    fn gradient_rgba(width: u32, height: u32) -> Vec<u8> {
+        let mut buf = Vec::with_capacity((width as usize) * (height as usize) * 4);
+        for y in 0..height {
+            for x in 0..width {
+                let v = ((x + y) % 256) as u8;
+                buf.extend_from_slice(&[v, v.wrapping_add(30), v.wrapping_add(60), 255]);
+            }
+        }
+        buf
+    }
+
+    #[test]
+    fn round_trip_preserves_dimensions() {
+        let rgba = solid_rgba(64, 48, [200, 100, 50, 255]);
+        let s = Screenshot::new(&rgba, 64, 48, 1_000_000, ScreenshotSource::FullDesktop).unwrap();
+        let encoded = s.encode().unwrap();
+        let decoded = Screenshot::decode(&encoded).unwrap();
+        assert_eq!(decoded.dimensions(), (64, 48));
+    }
+
+    #[test]
+    fn round_trip_preserves_captured_at_ms() {
+        let rgba = solid_rgba(32, 32, [10, 20, 30, 255]);
+        let ts = 1_714_300_800_000u64;
+        let s = Screenshot::new(&rgba, 32, 32, ts, ScreenshotSource::FullDesktop).unwrap();
+        let decoded = Screenshot::decode(&s.encode().unwrap()).unwrap();
+        assert_eq!(decoded.captured_at_ms(), ts);
+    }
+
+    #[test]
+    fn round_trip_preserves_source_full_desktop() {
+        let rgba = solid_rgba(16, 16, [255, 0, 0, 255]);
+        let s = Screenshot::new(&rgba, 16, 16, 42, ScreenshotSource::FullDesktop).unwrap();
+        let decoded = Screenshot::decode(&s.encode().unwrap()).unwrap();
+        assert_eq!(*decoded.source(), ScreenshotSource::FullDesktop);
+    }
+
+    #[test]
+    fn round_trip_preserves_source_window() {
+        let rgba = solid_rgba(16, 16, [0, 255, 0, 255]);
+        let src = ScreenshotSource::Window {
+            app_id: "com.example.app".to_string(),
+        };
+        let s = Screenshot::new(&rgba, 16, 16, 99, src.clone()).unwrap();
+        let decoded = Screenshot::decode(&s.encode().unwrap()).unwrap();
+        assert_eq!(*decoded.source(), src);
+    }
+
+    #[test]
+    fn round_trip_preserves_source_pane() {
+        let rgba = solid_rgba(16, 16, [0, 0, 255, 255]);
+        let src = ScreenshotSource::Pane {
+            adapter_id: "uuid-1234".to_string(),
+            pane_kind: "terminal".to_string(),
+        };
+        let s = Screenshot::new(&rgba, 16, 16, 7, src.clone()).unwrap();
+        let decoded = Screenshot::decode(&s.encode().unwrap()).unwrap();
+        assert_eq!(*decoded.source(), src);
+    }
+
+    #[test]
+    fn round_trip_preserves_dhash() {
+        let rgba = gradient_rgba(64, 64);
+        let s = Screenshot::new(&rgba, 64, 64, 0, ScreenshotSource::FullDesktop).unwrap();
+        let h_before = s.dhash();
+        let decoded = Screenshot::decode(&s.encode().unwrap()).unwrap();
+        assert_eq!(decoded.dhash(), h_before);
+    }
+
+    #[test]
+    fn dhash_collision_similar_frames_within_hamming_4() {
+        let mut a = gradient_rgba(64, 64);
+        let b = a.clone();
+        a[0] = a[0].saturating_add(10);
+        a[1] = a[1].saturating_add(10);
+        a[2] = a[2].saturating_add(10);
+        let sa = Screenshot::new(&a, 64, 64, 0, ScreenshotSource::FullDesktop).unwrap();
+        let sb = Screenshot::new(&b, 64, 64, 0, ScreenshotSource::FullDesktop).unwrap();
+        let dist = crate::hamming_distance(sa.dhash(), sb.dhash());
+        assert!(dist <= 4, "similar frames: hamming distance {dist}, expected <= 4");
+    }
+
+    #[test]
+    fn dhash_very_different_frames_exceed_hamming_4() {
+        let mut a = Vec::with_capacity(64 * 64 * 4);
+        let mut b = Vec::with_capacity(64 * 64 * 4);
+        for _y in 0..64u32 {
+            for x in 0..64u32 {
+                let v = (x * 4).min(255) as u8;
+                a.extend_from_slice(&[v, v, v, 255]);
+                let inv = 255 - v;
+                b.extend_from_slice(&[inv, inv, inv, 255]);
+            }
+        }
+        let sa = Screenshot::new(&a, 64, 64, 0, ScreenshotSource::FullDesktop).unwrap();
+        let sb = Screenshot::new(&b, 64, 64, 0, ScreenshotSource::FullDesktop).unwrap();
+        let dist = crate::hamming_distance(sa.dhash(), sb.dhash());
+        assert!(dist > 4, "mirrored gradient should exceed hamming 4, got {dist}");
+    }
+
+    #[test]
+    fn new_rejects_zero_dimensions() {
+        let err =
+            Screenshot::new(&[], 0, 0, 0, ScreenshotSource::FullDesktop).unwrap_err();
+        assert!(matches!(err, VisionError::ZeroDim));
+    }
+
+    #[test]
+    fn new_rejects_size_mismatch() {
+        let bad = vec![0u8; 10];
+        let err =
+            Screenshot::new(&bad, 4, 4, 0, ScreenshotSource::FullDesktop).unwrap_err();
+        assert!(matches!(err, VisionError::SizeMismatch { .. }));
+    }
+
+    #[test]
+    fn decode_rejects_non_png() {
+        let err = Screenshot::decode(b"not a png").unwrap_err();
+        assert!(matches!(err, VisionError::Decode(_)));
+    }
+
+    #[test]
+    fn schema_version_is_one() {
+        assert_eq!(SCHEMA_VERSION, 1);
+    }
+}

--- a/crates/phantom-vision/src/lib.rs
+++ b/crates/phantom-vision/src/lib.rs
@@ -23,9 +23,10 @@ pub mod format;
 
 // Re-export commonly used types.
 pub use analysis::{
-    Analysis, MockVisionBackend, OpenAiVisionBackend, PromptTemplate, UiElement, VisionBackend,
-    MAX_IMAGE_BYTES,
+    Analysis, OpenAiVisionBackend, PromptTemplate, UiElement, VisionBackend, MAX_IMAGE_BYTES,
 };
+#[cfg(any(test, feature = "test-utils"))]
+pub use analysis::MockVisionBackend;
 pub use format::{Screenshot, ScreenshotSource};
 
 /// Type alias matching the issue #71 spec name for the OpenAI backend.

--- a/crates/phantom-vision/src/lib.rs
+++ b/crates/phantom-vision/src/lib.rs
@@ -1,21 +1,211 @@
-//! Perceptual-hash dedup for frame storage.
+//! Phantom vision: perceptual-hash dedup + GPT-4V analysis pipeline.
 //!
-//! Self-contained dHash + cheap pixel-difference gate. No image-decoding deps;
-//! callers pass an 8-bit RGBA buffer of known dimensions.
+//! # Modules
 //!
-//! Pipeline: `fast_diff_gate` (cheap SAD on 64x64 luma) rejects near-identical
-//! frames before the more expensive `dhash` is computed.
+//! - [`format`] — [`Screenshot`] canonical capture format with PNG sidecar metadata.
+//! - [`analysis`] — [`VisionBackend`] trait, [`OpenAiVisionBackend`] (GPT-4V), [`MockVisionBackend`].
+//!
+//! # Frame types
+//!
+//! [`VisionFrame`] is a lightweight, allocation-friendly capture buffer used by
+//! the analysis pipeline. [`format::Screenshot`] is the richer, PNG-encoded
+//! format used for storage and dedup.
+//!
+//! # Dedup pipeline
+//!
+//! `fast_diff_gate` (cheap SAD on 64×64 luma) rejects near-identical frames
+//! before the more expensive `dhash` is computed.
 
 #![forbid(unsafe_code)]
 
-/// Errors returned by the vision module.
+pub mod analysis;
+pub mod format;
+
+// Re-export commonly used types.
+pub use analysis::{
+    Analysis, MockVisionBackend, OpenAiVisionBackend, PromptTemplate, UiElement, VisionBackend,
+    MAX_IMAGE_BYTES,
+};
+pub use format::{Screenshot, ScreenshotSource};
+
+/// Type alias matching the issue #71 spec name for the OpenAI backend.
+pub type Gpt4VBackend = OpenAiVisionBackend;
+
+// ── Errors ────────────────────────────────────────────────────────────────────
+
+/// All errors returned by the phantom-vision module.
 #[derive(Debug, thiserror::Error)]
 pub enum VisionError {
+    /// Image dimensions are zero.
     #[error("image dimensions zero")]
     ZeroDim,
+    /// Buffer size does not match the declared dimensions.
     #[error("buffer size mismatch: expected {expected}, got {got}")]
     SizeMismatch { expected: usize, got: usize },
+    /// PNG image byte length exceeds the backend cost-guard limit.
+    #[error("image too large: {size} bytes exceeds limit of {limit} bytes")]
+    ImageTooLarge { size: usize, limit: usize },
+    /// PNG encoding failure.
+    #[error("PNG encode error: {0}")]
+    Encode(String),
+    /// PNG decoding failure.
+    #[error("PNG decode error: {0}")]
+    Decode(String),
+    /// Vision backend (network / API) failure.
+    #[error("vision backend error: {0}")]
+    Backend(String),
 }
+
+// ── VisionFrame ───────────────────────────────────────────────────────────────
+
+/// Lightweight raw frame buffer for the analysis pipeline.
+///
+/// Prefer this over [`Screenshot`] when PNG encoding or the dHash sidecar are
+/// not needed — it avoids unnecessary allocations in hot paths.
+///
+/// # Construction
+///
+/// ```
+/// use phantom_vision::VisionFrame;
+///
+/// let rgba = vec![0u8; 4 * 4 * 4]; // 4×4 solid black
+/// let frame = VisionFrame::new(4, 4, rgba, 0).unwrap();
+/// assert_eq!(frame.width(), 4);
+/// assert_eq!(frame.height(), 4);
+/// assert_eq!(frame.pixels().len(), 64);
+/// assert_eq!(frame.timestamp_ms(), 0);
+/// ```
+#[derive(Debug, Clone)]
+pub struct VisionFrame {
+    width: u32,
+    height: u32,
+    /// Raw RGBA pixel data, row-major.
+    pixels: Vec<u8>,
+    timestamp_ms: u64,
+}
+
+impl VisionFrame {
+    /// Build a new frame, validating that `pixels.len() == width * height * 4`.
+    ///
+    /// # Errors
+    ///
+    /// - [`VisionError::ZeroDim`] if `width` or `height` is zero.
+    /// - [`VisionError::SizeMismatch`] if the buffer length is wrong.
+    pub fn new(
+        width: u32,
+        height: u32,
+        pixels: Vec<u8>,
+        timestamp_ms: u64,
+    ) -> Result<Self, VisionError> {
+        if width == 0 || height == 0 {
+            return Err(VisionError::ZeroDim);
+        }
+        let expected = (width as usize)
+            .checked_mul(height as usize)
+            .and_then(|n| n.checked_mul(4))
+            .ok_or(VisionError::SizeMismatch {
+                expected: usize::MAX,
+                got: pixels.len(),
+            })?;
+        if pixels.len() != expected {
+            return Err(VisionError::SizeMismatch {
+                expected,
+                got: pixels.len(),
+            });
+        }
+        Ok(Self {
+            width,
+            height,
+            pixels,
+            timestamp_ms,
+        })
+    }
+
+    /// Frame width in pixels.
+    #[must_use]
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    /// Frame height in pixels.
+    #[must_use]
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+
+    /// Raw RGBA pixel data, row-major.
+    #[must_use]
+    pub fn pixels(&self) -> &[u8] {
+        &self.pixels
+    }
+
+    /// Milliseconds since the Unix epoch when the frame was captured.
+    #[must_use]
+    pub fn timestamp_ms(&self) -> u64 {
+        self.timestamp_ms
+    }
+
+    /// Convert to a [`Screenshot`] (PNG-encodes the pixel data with dHash sidecar).
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`VisionError::Encode`] if PNG encoding fails.
+    pub fn to_screenshot(&self) -> Result<Screenshot, VisionError> {
+        Screenshot::new(
+            &self.pixels,
+            self.width,
+            self.height,
+            self.timestamp_ms,
+            ScreenshotSource::FullDesktop,
+        )
+    }
+}
+
+// ── VisionAnalysis ────────────────────────────────────────────────────────────
+
+/// Compact result returned after analysing a [`VisionFrame`].
+///
+/// Matches the field names specified in issue #71 (`description`, `anomalies`,
+/// `confidence`). Use [`Analysis`] from [`analysis`] for the richer format
+/// produced by the full [`VisionBackend`] trait.
+#[derive(Debug, Clone)]
+pub struct VisionAnalysis {
+    description: String,
+    anomalies: Vec<String>,
+    confidence: f32,
+}
+
+impl VisionAnalysis {
+    /// Build a new analysis result.
+    #[must_use]
+    pub fn new(description: String, anomalies: Vec<String>, confidence: f32) -> Self {
+        Self {
+            description,
+            anomalies,
+            confidence,
+        }
+    }
+
+    /// Human-readable description of what is visible in the frame.
+    #[must_use]
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    /// Detected anomalies (errors, crashes, unexpected output).
+    #[must_use]
+    pub fn anomalies(&self) -> &[String] {
+        &self.anomalies
+    }
+
+    /// Overall confidence in the analysis, in `[0.0, 1.0]`.
+    #[must_use]
+    pub fn confidence(&self) -> f32 {
+        self.confidence
+    }
+}
+
+// ── BT.601 luma / dedup helpers ───────────────────────────────────────────────
 
 /// BT.601 luma weights, scaled to integer math (sum = 1024).
 const LUMA_R: u32 = 306; // ~0.299 * 1024
@@ -51,9 +241,6 @@ fn check_rgba(rgba: &[u8], width: u32, height: u32) -> Result<(), VisionError> {
 }
 
 /// Box-filter downsample an RGBA image to a `target_w x target_h` grayscale buffer.
-///
-/// Each target cell averages the luma of all source pixels whose coordinates
-/// fall into that cell. Cheap, branch-free, and stable under sub-pixel shifts.
 fn box_downsample_gray(
     rgba: &[u8],
     width: u32,
@@ -100,6 +287,7 @@ fn box_downsample_gray(
 /// adjacent horizontal pixels, set bit if left > right.
 ///
 /// # Errors
+///
 /// - [`VisionError::ZeroDim`] if `width` or `height` is zero.
 /// - [`VisionError::SizeMismatch`] if `rgba.len()` is not `width * height * 4`.
 pub fn dhash(rgba: &[u8], width: u32, height: u32) -> Result<u64, VisionError> {
@@ -119,16 +307,18 @@ pub fn dhash(rgba: &[u8], width: u32, height: u32) -> Result<u64, VisionError> {
     Ok(hash)
 }
 
-/// Hamming distance between two dhashes. <= 5 typically means duplicate.
+/// Hamming distance between two dhashes. A distance of <= 5 typically means duplicate.
 #[must_use]
 pub fn hamming_distance(a: u64, b: u64) -> u32 {
     (a ^ b).count_ones()
 }
 
-/// Downsample RGBA to a 64x64 grayscale buffer (4096 bytes). Used as the
-/// reference in [`fast_diff_gate`].
+/// Downsample RGBA to a 64x64 grayscale buffer (4096 bytes).
+///
+/// Used as the reference in [`fast_diff_gate`].
 ///
 /// # Errors
+///
 /// - [`VisionError::ZeroDim`] if `width` or `height` is zero.
 /// - [`VisionError::SizeMismatch`] if `rgba.len()` is not `width * height * 4`.
 pub fn downsample_to_64x64_gray(
@@ -140,13 +330,13 @@ pub fn downsample_to_64x64_gray(
     Ok(box_downsample_gray(rgba, width, height, 64, 64))
 }
 
-/// Cheap pixel-difference gate: downsample to 64x64 grayscale, compute
-/// sum-of-absolute-differences against the reference. Returns the SAD.
+/// Cheap pixel-difference gate: SAD on 64x64 luma vs a reference buffer.
 ///
-/// Used as a fast first-pass before computing the full dhash. Max SAD for
-/// fully inverted 64x64 gray = 4096 * 255 = 1_044_480.
+/// Used as a fast first-pass before computing the full dhash.
+/// Max SAD for fully inverted 64x64 gray = 4096 * 255 = 1_044_480.
 ///
 /// # Errors
+///
 /// - [`VisionError::ZeroDim`] if `width` or `height` is zero.
 /// - [`VisionError::SizeMismatch`] if `rgba.len()` is not `width * height * 4`,
 ///   or `reference_64x64.len() != 4096`.
@@ -171,11 +361,12 @@ pub fn fast_diff_gate(
     Ok(sad)
 }
 
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// Build a `width x height` RGBA buffer filled with one color.
     fn solid(width: u32, height: u32, rgba: [u8; 4]) -> Vec<u8> {
         let n = (width as usize) * (height as usize);
         let mut buf = Vec::with_capacity(n * 4);
@@ -185,19 +376,18 @@ mod tests {
         buf
     }
 
-    /// Build a 9x8 RGBA buffer with varied (non-monotonic) pixels so some
-    /// horizontal diffs go negative and the dhash sets at least one bit.
     fn gradient_9x8() -> Vec<u8> {
         let mut buf = Vec::with_capacity(9 * 8 * 4);
         for y in 0..8u32 {
             for x in 0..9u32 {
-                // Checkerboard-ish: alternates high/low across the row.
                 let v = if (x + y) % 2 == 0 { 200u8 } else { 50 };
                 buf.extend_from_slice(&[v, v, v, 255]);
             }
         }
         buf
     }
+
+    // ── dHash / dedup ─────────────────────────────────────────────────────────
 
     #[test]
     fn dhash_returns_nonzero_for_real_image() {
@@ -208,7 +398,6 @@ mod tests {
 
     #[test]
     fn dhash_zero_for_uniform_image() {
-        // All pixels equal -> every diff is 0 -> no bit ever set -> hash = 0.
         let img = solid(16, 16, [128, 128, 128, 255]);
         let h = dhash(&img, 16, 16).unwrap();
         assert_eq!(h, 0, "uniform image must hash to zero");
@@ -216,7 +405,6 @@ mod tests {
 
     #[test]
     fn dhash_stable_under_minor_changes() {
-        // Two near-identical 64x64 gradients, one pixel nudged.
         let mut a = Vec::with_capacity(64 * 64 * 4);
         for y in 0..64u32 {
             for x in 0..64u32 {
@@ -225,7 +413,6 @@ mod tests {
             }
         }
         let mut b = a.clone();
-        // Flip one pixel hard.
         let i = (32 * 64 + 32) * 4;
         b[i] = 0;
         b[i + 1] = 0;
@@ -238,7 +425,6 @@ mod tests {
 
     #[test]
     fn dhash_changes_for_inverted_image() {
-        // Black-to-white gradient vs white-to-black gradient: every diff flips.
         let mut a = Vec::with_capacity(64 * 64 * 4);
         let mut b = Vec::with_capacity(64 * 64 * 4);
         for y in 0..64u32 {
@@ -307,5 +493,64 @@ mod tests {
         let bad = vec![0u8; 10];
         let err = dhash(&bad, 4, 4).unwrap_err();
         assert!(matches!(err, VisionError::SizeMismatch { expected: 64, got: 10 }));
+    }
+
+    // ── VisionFrame ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn vision_frame_accessors_round_trip() {
+        let pixels = vec![128u8; 8 * 8 * 4];
+        let frame = VisionFrame::new(8, 8, pixels.clone(), 42_000).unwrap();
+        assert_eq!(frame.width(), 8);
+        assert_eq!(frame.height(), 8);
+        assert_eq!(frame.pixels(), pixels.as_slice());
+        assert_eq!(frame.timestamp_ms(), 42_000);
+    }
+
+    #[test]
+    fn vision_frame_rejects_zero_width() {
+        let err = VisionFrame::new(0, 8, vec![], 0).unwrap_err();
+        assert!(matches!(err, VisionError::ZeroDim));
+    }
+
+    #[test]
+    fn vision_frame_rejects_zero_height() {
+        let err = VisionFrame::new(8, 0, vec![], 0).unwrap_err();
+        assert!(matches!(err, VisionError::ZeroDim));
+    }
+
+    #[test]
+    fn vision_frame_rejects_wrong_buffer_size() {
+        let err = VisionFrame::new(4, 4, vec![0u8; 10], 0).unwrap_err();
+        assert!(matches!(err, VisionError::SizeMismatch { expected: 64, got: 10 }));
+    }
+
+    #[test]
+    fn vision_frame_to_screenshot_succeeds() {
+        let pixels = vec![200u8; 16 * 16 * 4];
+        let frame = VisionFrame::new(16, 16, pixels, 1_000).unwrap();
+        let shot = frame.to_screenshot().unwrap();
+        assert_eq!(shot.dimensions(), (16, 16));
+        assert_eq!(shot.captured_at_ms(), 1_000);
+    }
+
+    // ── VisionAnalysis ────────────────────────────────────────────────────────
+
+    #[test]
+    fn vision_analysis_accessors() {
+        let a = VisionAnalysis::new(
+            "Terminal showing cargo build".into(),
+            vec!["error: unknown field".into()],
+            0.92,
+        );
+        assert_eq!(a.description(), "Terminal showing cargo build");
+        assert_eq!(a.anomalies().len(), 1);
+        assert!((a.confidence() - 0.92).abs() < 1e-6);
+    }
+
+    #[test]
+    fn vision_analysis_no_anomalies() {
+        let a = VisionAnalysis::new("Clean terminal prompt".into(), vec![], 1.0);
+        assert!(a.anomalies().is_empty());
     }
 }


### PR DESCRIPTION
## Summary

- Implements `VisionBackend` async trait with `analyze` / `analyze_with_template` methods
- `OpenAiVisionBackend` (`Gpt4VBackend` alias): calls `POST /v1/chat/completions` with base64 PNG data URI, system prompt for terminal anomaly detection, 100 KB cost guard, reads `OPENAI_API_KEY` from env
- `MockVisionBackend`: deterministic canned analysis, no network calls
- `VisionFrame`: lightweight RGBA capture buffer with private fields + public accessors (`width`, `height`, `pixels`, `timestamp_ms`)
- `VisionAnalysis`: compact result type (`description`, `anomalies`, `confidence`) with private fields + accessors
- `format` module: `Screenshot` PNG capture format with `tEXt` metadata sidecar + dHash dedup
- 4 `PromptTemplate` variants including `TerminalAnomalies` (terminal-optimised: flags errors and crashes)
- New deps: `async-trait`, `base64 = "0.22"`, `png = "0.17"`, `reqwest = "0.12"`, `serde`, `serde_json`

## Test plan

- [ ] `cargo test -p phantom-vision` — 45 tests pass, 1 ignored (live network)
- [ ] Network test: `cargo test -p phantom-vision -- --ignored` with `OPENAI_API_KEY` set
- [ ] `cargo check --workspace` — no regressions in other crates

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)