### PR TITLE
fix(#226): populate CommandComplete — OODA scoring was blind

### DIFF
--- a/crates/phantom-adapter/src/adapter.rs
+++ b/crates/phantom-adapter/src/adapter.rs
@@ -55,6 +55,18 @@ pub trait AppCore: Send {
     ///
     /// The default is a no-op so existing adapters compile without changes.
     fn tick(&mut self, _dt_ms: u64) {}
+
+    /// Snapshot of the adapter's raw PTY/stdout output buffer (last ~8 KiB).
+    ///
+    /// Terminal adapters return `Some(text)` so the OODA brain can populate
+    /// `ParsedOutput::raw_output` when a `CommandComplete` event fires.
+    /// Non-terminal adapters return `None` (the default) and are silently
+    /// skipped.
+    ///
+    /// The returned string may contain ANSI escape sequences.
+    fn output_buf_snapshot(&self) -> Option<String> {
+        None
+    }
 }
 
 /// Visual adapters that render into a rect.

--- a/crates/phantom-app/src/adapters/terminal.rs
+++ b/crates/phantom-app/src/adapters/terminal.rs
@@ -233,6 +233,12 @@ impl AppCore for TerminalAdapter {
             "mouse_mode": mouse_mode,
         })
     }
+
+    /// Return the raw PTY output buffer so the OODA brain can populate
+    /// `ParsedOutput::raw_output` when a `CommandComplete` event fires (#226).
+    fn output_buf_snapshot(&self) -> Option<String> {
+        Some(self.output_buf.clone())
+    }
 }
 
 impl Renderable for TerminalAdapter {

--- a/crates/phantom-app/src/app.rs
+++ b/crates/phantom-app/src/app.rs
@@ -352,6 +352,13 @@ pub struct App {
     //    jobs can hold their own handle without an extra clone-of-clone.
     pub(crate) bundle_store: Option<std::sync::Arc<phantom_bundle_store::BundleStore>>,
     pub(crate) capture_state: crate::capture::CaptureState,
+
+    // -- Per-pane last-command tracking (issue #226).
+    //    Populated from `Event::CommandStarted` so that the subsequent
+    //    `Event::CommandComplete` handler in `drain_bus_to_brain` can feed
+    //    a real command string into `ParsedOutput::command` instead of the
+    //    empty string that made OODA fix/explain scoring always return 0.
+    pub(crate) pane_last_command: std::collections::HashMap<u32, String>,
 }
 
 /// An active suggestion from the AI brain.
@@ -880,6 +887,7 @@ impl App {
             bundle_store,
             capture_state: crate::capture::CaptureState::new(),
             ticket_dispatcher,
+            pane_last_command: std::collections::HashMap::new(),
         })
     }
 

--- a/crates/phantom-app/src/coordinator.rs
+++ b/crates/phantom-app/src/coordinator.rs
@@ -778,6 +778,16 @@ impl AppCoordinator {
         &mut self.registry
     }
 
+    /// Snapshot of the PTY output buffer for the adapter registered under
+    /// `app_id`, or `None` if the adapter does not expose one (e.g. agent
+    /// panes, inspector, headless adapters).
+    ///
+    /// Used by the bus-drain loop to populate `ParsedOutput::raw_output`
+    /// when a `CommandComplete` event fires (issue #226).
+    pub fn terminal_output_buf(&self, app_id: AppId) -> Option<String> {
+        self.registry.get_adapter(app_id)?.output_buf_snapshot()
+    }
+
     /// Test-only constructor that skips layout/scene requirements.
     #[cfg(test)]
     fn new_test(bus: EventBus) -> Self {

--- a/crates/phantom-app/src/update.rs
+++ b/crates/phantom-app/src/update.rs
@@ -472,25 +472,39 @@ impl App {
         }
 
         for msg in msgs {
+            // Track the last command text per pane so CommandComplete can
+            // populate ParsedOutput::command with a real value (issue #226).
+            if let Event::CommandStarted { app_id, command } = &msg.event {
+                self.pane_last_command.insert(*app_id, command.clone());
+            }
+
             // 1) Forward into the brain (if running) as an AiEvent.
             if let Some(ref brain) = self.brain {
                 let ai_event = match &msg.event {
                     Event::TerminalOutput { bytes, .. } => {
                         Some(AiEvent::OutputChunk(format!("[{bytes} bytes]")))
                     }
-                    Event::CommandComplete { exit_code, .. } => {
-                        Some(AiEvent::CommandComplete(
-                            phantom_semantic::ParsedOutput {
-                                command: String::new(),
-                                command_type: phantom_semantic::CommandType::Unknown,
-                                exit_code: Some(*exit_code),
-                                content_type: phantom_semantic::ContentType::PlainText,
-                                errors: vec![],
-                                warnings: vec![],
-                                duration_ms: None,
-                                raw_output: String::new(),
-                            },
-                        ))
+                    Event::CommandComplete { app_id, exit_code } => {
+                        // Populate the ParsedOutput from the actual terminal
+                        // output buffer and tracked command text so the OODA
+                        // scorer's fix/explain curves have real signal to work
+                        // with (issue #226 — was always blind due to empty strings).
+                        let command = self
+                            .pane_last_command
+                            .get(app_id)
+                            .cloned()
+                            .unwrap_or_default();
+                        let raw_output = self
+                            .coordinator
+                            .terminal_output_buf(*app_id)
+                            .unwrap_or_default();
+                        let parsed = phantom_semantic::parser::SemanticParser::parse(
+                            &command,
+                            &raw_output,
+                            "",
+                            Some(*exit_code),
+                        );
+                        Some(AiEvent::CommandComplete(parsed))
                     }
                     Event::AgentTaskComplete { agent_id, success, summary, spawn_tag } => {
                         Some(AiEvent::AgentComplete {
@@ -515,15 +529,12 @@ impl App {
                 }
             }
 
-            // 2) Route command-boundary events into the capture pipeline.
-            //    `app_id` on the event is the pane that completed a
-            //    command — it maps 1:1 to the `AppId` keyed in the capture
-            //    state map. No transcript text is carried on the bus event
-            //    itself, so `intent` is `None` here; future PTY-side
-            //    wiring (shell prompt detection) can route the actual
-            //    command text through `App::on_command_boundary`.
+            // 2) Route command-boundary events into the capture pipeline,
+            //    now passing the tracked command intent so bundle metadata
+            //    records the actual command that ran.
             if let Event::CommandComplete { app_id, .. } = &msg.event {
-                let _ = self.on_command_boundary(*app_id, None);
+                let intent = self.pane_last_command.get(app_id).cloned();
+                let _ = self.on_command_boundary(*app_id, intent);
             }
         }
     }

--- a/crates/phantom-app/src/update.rs
+++ b/crates/phantom-app/src/update.rs
@@ -500,8 +500,8 @@ impl App {
                             .unwrap_or_default();
                         let parsed = phantom_semantic::parser::SemanticParser::parse(
                             &command,
-                            &raw_output,
                             "",
+                            &raw_output,
                             Some(*exit_code),
                         );
                         Some(AiEvent::CommandComplete(parsed))

--- a/crates/phantom-app/tests/phase5_integration.rs
+++ b/crates/phantom-app/tests/phase5_integration.rs
@@ -568,14 +568,19 @@ fn w4c_context_menu_hit_test() {
 #[test]
 fn b226_command_complete_with_real_output_yields_nonzero_fix_score() {
     // Simulate what drain_bus_to_brain now does: call SemanticParser::parse
-    // with a real command + stderr that contains a compiler error.
-    // Cargo writes diagnostics to stderr; the output buffer may contain both,
-    // so we use the same string for both stdout and the combined raw_output.
-    let stderr = "error[E0308]: mismatched types\n  --> src/main.rs:5:9\n   |\n5  |     return \"hello\";\n   |            ^^^^^^^ expected `i32`, found `&str`";
+    // with a real command + PTY buffer in the stderr slot.
+    //
+    // Production call (drain_bus_to_brain):
+    //   SemanticParser::parse(&command, "", &raw_output, Some(*exit_code))
+    //
+    // The PTY buffer is passed as `stderr` because parse_rust_errors only
+    // reads from that argument. Passing it as `stdout` (the old bug) meant
+    // cargo error parsing was always blind.
+    let raw_output = "error[E0308]: mismatched types\n  --> src/main.rs:5:9\n   |\n5  |     return \"hello\";\n   |            ^^^^^^^ expected `i32`, found `&str`";
     let parsed = phantom_semantic::parser::SemanticParser::parse(
         "cargo build",
-        "",      // stdout is empty for failed builds
-        stderr,  // cargo writes errors here
+        "",          // stdout: empty — mirrors production call
+        raw_output,  // stderr slot: PTY buffer — mirrors production call
         Some(1),
     );
 

--- a/crates/phantom-app/tests/phase5_integration.rs
+++ b/crates/phantom-app/tests/phase5_integration.rs
@@ -552,6 +552,55 @@ fn w4c_context_menu_hit_test() {
 }
 
 // ===========================================================================
+// Issue #226: CommandComplete must carry real output so OODA scoring works
+// ===========================================================================
+
+/// Regression test for #226.
+///
+/// Before the fix, `drain_bus_to_brain` constructed `ParsedOutput` with
+/// empty strings for `command` and `raw_output`, so `SemanticParser::parse`
+/// never ran and `errors` was always empty — making `fix_score` always 0.
+///
+/// After the fix the caller uses the terminal output buffer and the tracked
+/// command text.  This test simulates that path by calling
+/// `SemanticParser::parse` directly with realistic content and asserting the
+/// scorer sees the errors.
+#[test]
+fn b226_command_complete_with_real_output_yields_nonzero_fix_score() {
+    // Simulate what drain_bus_to_brain now does: call SemanticParser::parse
+    // with a real command + stderr that contains a compiler error.
+    // Cargo writes diagnostics to stderr; the output buffer may contain both,
+    // so we use the same string for both stdout and the combined raw_output.
+    let stderr = "error[E0308]: mismatched types\n  --> src/main.rs:5:9\n   |\n5  |     return \"hello\";\n   |            ^^^^^^^ expected `i32`, found `&str`";
+    let parsed = phantom_semantic::parser::SemanticParser::parse(
+        "cargo build",
+        "",      // stdout is empty for failed builds
+        stderr,  // cargo writes errors here
+        Some(1),
+    );
+
+    // The fix ensures `errors` is non-empty when the output contains error lines.
+    assert!(
+        !parsed.errors.is_empty(),
+        "SemanticParser must detect errors in real compiler output; got errors={:?}, raw_output={:?}",
+        parsed.errors, parsed.raw_output
+    );
+    assert_eq!(parsed.command, "cargo build", "ParsedOutput must carry the command string");
+    assert!(!parsed.raw_output.is_empty(), "ParsedOutput must carry the raw output");
+
+    // Confirm the brain scorer produces a non-zero fix score for this event.
+    let mut scorer = UtilityScorer::new();
+    scorer.idle_time = 5.0;
+    let ctx = phantom_context::ProjectContext::detect(std::path::Path::new("."));
+    let scored = scorer.fix_score(&parsed, &ctx);
+    assert!(
+        scored.score > 0.0,
+        "fix_score must be > 0 when CommandComplete carries real error output, got {}",
+        scored.score
+    );
+}
+
+// ===========================================================================
 // Helpers
 // ===========================================================================
 


### PR DESCRIPTION
## Summary

Closes #226

The brain's OODA scoring loop receives `AiEvent::CommandComplete(ParsedOutput)` on every terminal command completion, but `ParsedOutput` was always constructed with empty strings for `command`, `raw_output`, and `errors`. This made `fix_score` and `explain_score` permanently return 0.0 — the brain could never suggest fixes or explanations based on real command output.

### Changes

- **`phantom-adapter/src/adapter.rs`** — adds `AppCore::output_buf_snapshot() -> Option<String>` with a `None` default so trait objects can expose PTY buffer content without a downcast
- **`phantom-app/src/adapters/terminal.rs`** — overrides `output_buf_snapshot` to return `Some(self.output_buf.clone())`
- **`phantom-app/src/coordinator.rs`** — adds `terminal_output_buf(AppId) -> Option<String>` accessor
- **`phantom-app/src/app.rs`** — adds `pane_last_command: HashMap<u32, String>` to track typed command per pane
- **`phantom-app/src/update.rs`** — replaces empty `ParsedOutput` construction with a real `SemanticParser::parse()` call using the tracked command text and output buffer; passes command intent to `on_command_boundary`
- **`phantom-app/tests/phase5_integration.rs`** — adds `b226_command_complete_with_real_output_yields_nonzero_fix_score` regression test

## Test plan

- [x] `cargo test -p phantom-app` — 22 tests pass (21 existing + 1 new regression test)
- [x] `cargo test -p phantom-brain` — 262 + 7 tests pass
- [x] `cargo check -p phantom-app` — clean compilation
- [x] No bare `pub` fields added (all `pub(crate)`)
- [x] No `.unwrap()` outside `#[cfg(test)]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)