### PR TITLE
fix(#219,#221,#222): test fn + overflow + mutex panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5238,6 +5238,7 @@ dependencies = [
  "phantom-terminal",
  "phantom-ui",
  "serde_json",
+ "uuid",
  "winit",
 ]
 

--- a/crates/phantom-agents/src/dispatch.rs
+++ b/crates/phantom-agents/src/dispatch.rs
@@ -853,6 +853,117 @@ mod tests {
         Arc::new(Mutex::new(log))
     }
 
+    /// Collect the ordered list of event IDs reachable by walking the
+    /// `source_event_id` chain backwards from `start_id`.
+    ///
+    /// This helper mirrors the walk that [`taint_from_source_chain`] performs
+    /// but returns the event IDs rather than an aggregated [`TaintLevel`],
+    /// making it straightforward to assert which events are (and are not)
+    /// visited in chain-walk tests (#219 — function was referenced in planned
+    /// tests but never defined).
+    fn collect_source_chain(
+        start_id: u64,
+        log: &Arc<Mutex<EventLog>>,
+    ) -> Vec<u64> {
+        let tail = {
+            let g = log.lock().unwrap();
+            g.tail(usize::MAX)
+        };
+        let by_id: std::collections::HashMap<u64, &phantom_memory::event_log::EventEnvelope> =
+            tail.iter().map(|e| (e.id, e)).collect();
+
+        let mut chain = Vec::new();
+        let mut cursor: Option<u64> = Some(start_id);
+        let mut visited: std::collections::HashSet<u64> = std::collections::HashSet::new();
+
+        while let Some(id) = cursor {
+            if !visited.insert(id) {
+                break; // cycle guard
+            }
+            let Some(ev) = by_id.get(&id) else {
+                break; // event not in tail
+            };
+            chain.push(id);
+            cursor = ev.payload.get("source_event_id").and_then(|v| v.as_u64());
+        }
+        chain
+    }
+
+    /// Verify that `collect_source_chain` walks a linear three-event chain
+    /// correctly and returns IDs in traversal order (newest → oldest).
+    #[test]
+    fn collect_source_chain_walks_linear_chain() {
+        let tmp = TempDir::new().unwrap();
+        let log = open_event_log(tmp.path());
+
+        // Build a three-event chain: ev3 → ev2 → ev1 (via source_event_id).
+        let ev1_id = {
+            let mut g = log.lock().unwrap();
+            g.append(LogEventSource::Substrate, "root", json!({}))
+                .unwrap()
+                .id
+        };
+        let ev2_id = {
+            let mut g = log.lock().unwrap();
+            g.append(
+                LogEventSource::Substrate,
+                "middle",
+                json!({ "source_event_id": ev1_id }),
+            )
+            .unwrap()
+            .id
+        };
+        let ev3_id = {
+            let mut g = log.lock().unwrap();
+            g.append(
+                LogEventSource::Substrate,
+                "leaf",
+                json!({ "source_event_id": ev2_id }),
+            )
+            .unwrap()
+            .id
+        };
+
+        let chain = collect_source_chain(ev3_id, &log);
+        assert_eq!(
+            chain,
+            vec![ev3_id, ev2_id, ev1_id],
+            "chain must walk ev3 → ev2 → ev1 in traversal order",
+        );
+    }
+
+    /// `collect_source_chain` must terminate on a self-referential event
+    /// (cycle guard) and return only the event IDs visited before the cycle
+    /// was detected.
+    #[test]
+    fn collect_source_chain_terminates_on_cycle() {
+        let tmp = TempDir::new().unwrap();
+        let log = open_event_log(tmp.path());
+
+        // Create an event that references itself.
+        let ev_id = {
+            let mut g = log.lock().unwrap();
+            // Append placeholder to learn the id.
+            let placeholder = g
+                .append(LogEventSource::Substrate, "self-ref", json!({}))
+                .unwrap();
+            let self_id = placeholder.id;
+            // Append the actual self-referential event (id = self_id + 1).
+            g.append(
+                LogEventSource::Substrate,
+                "self-ref",
+                json!({ "source_event_id": self_id + 1 }),
+            )
+            .unwrap()
+            .id
+        };
+
+        // Must return exactly one element and not loop forever.
+        let chain = collect_source_chain(ev_id, &log);
+        assert_eq!(chain.len(), 1, "self-referential chain must yield exactly one id");
+        assert_eq!(chain[0], ev_id);
+    }
+
     /// Acceptance test 1 (Sec.7.2): clean source chain → result taint is `Clean`.
     ///
     /// When `source_event_id` points to an event with a benign kind (not

--- a/crates/phantom-app/src/runtime.rs
+++ b/crates/phantom-app/src/runtime.rs
@@ -214,8 +214,13 @@ impl AgentRuntime {
 
     /// Lock the event log and return a guard. Used by callers (and tests)
     /// that want to drive `tail`, `path`, etc. directly.
+    ///
+    /// Recovers from a poisoned mutex (#222) — the inner value is still
+    /// usable after the thread that panicked released the guard.
     pub fn event_log(&self) -> std::sync::MutexGuard<'_, EventLog> {
-        self.event_log.lock().expect("event log mutex poisoned")
+        self.event_log
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
     }
 
     /// Clone the event-log handle for sharing with a
@@ -230,8 +235,13 @@ impl AgentRuntime {
     /// Lock the registry and return a guard. Read-only consumers (e.g.
     /// `commands.rs::pair`) use this to look up agents by label without
     /// taking ownership.
+    ///
+    /// Recovers from a poisoned mutex (#222) — the inner value is still
+    /// usable after the thread that panicked released the guard.
     pub fn registry(&self) -> std::sync::MutexGuard<'_, AgentRegistry> {
-        self.registry.lock().expect("registry mutex poisoned")
+        self.registry
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
     }
 
     /// Clone the registry handle for sharing with dispatch contexts. Same
@@ -268,8 +278,13 @@ impl AgentRuntime {
 
     /// Force a flush of the underlying event log buffer. Useful before
     /// shutdown or in tests asserting on-disk state.
+    ///
+    /// Recovers from a poisoned mutex (#222).
     pub fn flush(&mut self) -> std::io::Result<()> {
-        let mut log = self.event_log.lock().expect("event log mutex poisoned");
+        let mut log = self
+            .event_log
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         log.flush()
     }
 
@@ -296,7 +311,10 @@ impl AgentRuntime {
         // gets newest-on-bottom; the inspector adapter is free to reverse if
         // it prefers newest-on-top.
         let envelopes = {
-            let log = self.event_log.lock().expect("event log mutex poisoned");
+            let log = self
+                .event_log
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
             log.tail(phantom_agents::inspector::MAX_RECENT_EVENTS)
         };
         for env in &envelopes {
@@ -325,7 +343,10 @@ impl AgentRuntime {
             .map(|d| d.as_millis() as u64)
             .unwrap_or(0);
         let agent_refs: Vec<_> = {
-            let reg = self.registry.lock().expect("registry mutex poisoned");
+            let reg = self
+                .registry
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
             reg.list().into_iter().cloned().collect()
         };
         for agent_ref in agent_refs {
@@ -709,5 +730,41 @@ mod tests {
             payload.get("attempted_class").and_then(|v| v.as_str()),
             Some("Act"),
         );
+    }
+
+    // -- Issue #222: poisoned mutex recovery -----------------------------------
+
+    /// Poison the `event_log` mutex by panicking inside a lock guard, then
+    /// assert that `AgentRuntime::event_log()` still returns a usable guard
+    /// rather than propagating the panic to the caller (#222).
+    #[test]
+    fn event_log_accessor_recovers_from_poisoned_mutex() {
+        let (rt, _dir) = make_runtime();
+
+        // Poison the event_log mutex: lock it in a thread that panics.
+        let handle = Arc::clone(&rt.event_log);
+        let _ = std::panic::catch_unwind(|| {
+            let _guard = handle.lock().unwrap();
+            panic!("intentional poison");
+        });
+
+        // The mutex is now poisoned. event_log() must not panic.
+        let _guard = rt.event_log();
+        // If we reach this line the recovery path worked.
+    }
+
+    /// Same as above but for the `registry` accessor.
+    #[test]
+    fn registry_accessor_recovers_from_poisoned_mutex() {
+        let (rt, _dir) = make_runtime();
+
+        let handle = Arc::clone(&rt.registry);
+        let _ = std::panic::catch_unwind(|| {
+            let _guard = handle.lock().unwrap();
+            panic!("intentional poison");
+        });
+
+        // Must not panic even though the mutex is poisoned.
+        let _guard = rt.registry();
     }
 }

--- a/crates/phantom-brain/src/reconciler.rs
+++ b/crates/phantom-brain/src/reconciler.rs
@@ -56,7 +56,9 @@ pub struct ReconcilerState {
     active_dispatches: HashMap<usize, (AgentId, Instant)>,
     /// Monotonically increasing agent ID namespace for reconciler-dispatched
     /// agents. Starts high to avoid collision with AgentManager's IDs.
-    next_agent_id: AgentId,
+    /// Stored as `u64` to guarantee no silent wraparound on long-running
+    /// sessions (#221).
+    next_agent_id: u64,
     /// Configurable stall timeout (overrideable in tests).
     pub stall_timeout: Duration,
 }
@@ -225,18 +227,23 @@ impl ReconcilerState {
             .collect();
 
         for (idx, task, description) in eligible {
-            let agent_id = self.next_agent_id;
-            self.next_agent_id += 1;
+            let agent_id: u64 = self.next_agent_id;
+            self.next_agent_id = self
+                .next_agent_id
+                .checked_add(1)
+                .expect("reconciler next_agent_id overflowed u64 — unreachable in practice");
 
             // Advance step to Active before emitting SpawnAgent so that a
             // synchronous ledger inspection sees the correct state.
+            // `agent_id` fits in u32 for the ledger field; saturate rather
+            // than truncate so corrupt IDs are visible (#221).
             if let Some(s) = ledger.plan.get_mut(idx) {
                 s.status = StepStatus::Active;
-                s.agent_id = Some(agent_id as u32);
+                s.agent_id = Some(u32::try_from(agent_id).unwrap_or(u32::MAX));
                 s.attempts += 1;
             }
 
-            self.active_dispatches.insert(idx, (agent_id, Instant::now()));
+            self.active_dispatches.insert(idx, (agent_id as AgentId, Instant::now()));
 
             log::info!(
                 "Reconciler: dispatching step {idx} (agent_id={agent_id}) — {description}"
@@ -244,7 +251,7 @@ impl ReconcilerState {
 
             let _ = action_tx.send(AiAction::SpawnAgent {
                 task,
-                spawn_tag: Some(agent_id as u64),
+                spawn_tag: Some(agent_id),
             });
         }
     }
@@ -656,6 +663,38 @@ mod tests {
             state.active_dispatches.len(),
             1,
             "dispatch must still be registered"
+        );
+    }
+
+    // -- Issue #221: next_agent_id must not overflow silently -----------------
+
+    /// Drive `next_agent_id` forward 100 000 times and assert the counter
+    /// never wraps. Under the old `u32` scheme this would silently overflow
+    /// at 4 294 967 295; with `u64` the range is effectively unlimited for
+    /// any realistic session.
+    #[test]
+    fn next_agent_id_does_not_overflow_after_100k_increments() {
+        let mut state = ReconcilerState::new();
+        let start = state.next_agent_id;
+
+        for i in 0..100_000u64 {
+            // Each increment must not overflow (would panic via checked_add).
+            state.next_agent_id = state
+                .next_agent_id
+                .checked_add(1)
+                .expect("next_agent_id overflowed — u64 counter is broken");
+
+            // Verify monotonic increase (no wrap-around).
+            assert!(
+                state.next_agent_id > start,
+                "next_agent_id wrapped at iteration {i}",
+            );
+        }
+
+        assert_eq!(
+            state.next_agent_id,
+            start + 100_000,
+            "counter must advance by exactly 100 000"
         );
     }
 

--- a/crates/phantom/Cargo.toml
+++ b/crates/phantom/Cargo.toml
@@ -31,6 +31,7 @@ env_logger.workspace = true
 dotenvy = "0.15"
 serde_json = "1"
 libc = "0.2"
+uuid.workspace = true
 
 [lints]
 workspace = true

--- a/crates/phantom/src/headless.rs
+++ b/crates/phantom/src/headless.rs
@@ -6,9 +6,9 @@
 
 use std::io::{self, BufRead, Write};
 use std::path::Path;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::Result;
+use uuid::Uuid;
 
 use phantom_agents::api::{ApiEvent, ClaudeConfig, send_message};
 use phantom_agents::cli::{AgentCommand, execute_agent_command, parse_agent_command};
@@ -19,8 +19,7 @@ use phantom_app::config::PhantomConfig;
 use phantom_brain::brain::{BrainConfig, spawn_brain};
 use phantom_brain::events::{AiAction, AiEvent};
 use phantom_context::ProjectContext;
-use phantom_history::HistoryStore;
-use phantom_history::store::HistoryEntry;
+use phantom_history::{HistoryEntry, HistoryStore};
 use phantom_memory::MemoryStore;
 use phantom_nlp::NlpInterpreter;
 use phantom_nlp::interpreter::ResolvedAction;
@@ -45,7 +44,8 @@ pub fn run_headless(_config: PhantomConfig) -> Result<()> {
 
     // Open persistent stores.
     let memory = MemoryStore::open(&project_dir)?;
-    let history = HistoryStore::open(&project_dir)?;
+    let session_id = Uuid::new_v4();
+    let mut history = HistoryStore::open(session_id)?;
 
     // Spawn the AI brain thread.
     let brain = spawn_brain(BrainConfig {
@@ -100,11 +100,10 @@ pub fn run_headless(_config: PhantomConfig) -> Result<()> {
                         } else {
                             for entry in &entries {
                                 let code = entry
-                                    .parsed
-                                    .exit_code
+                                    .exit_code()
                                     .map(|c| format!(" [exit {c}]"))
                                     .unwrap_or_default();
-                                println!("  $ {}{code}", entry.parsed.command);
+                                println!("  $ {}{code}", entry.command());
                             }
                         }
                     }
@@ -192,7 +191,7 @@ pub fn run_headless(_config: PhantomConfig) -> Result<()> {
                     &cmd,
                     &project_dir,
                     &brain,
-                    &history,
+                    &mut history,
                     &agents,
                     &claude_config,
                 );
@@ -225,7 +224,7 @@ pub fn run_headless(_config: PhantomConfig) -> Result<()> {
                     &input,
                     &project_dir,
                     &brain,
-                    &history,
+                    &mut history,
                     &agents,
                     &claude_config,
                 );
@@ -252,7 +251,7 @@ fn run_shell_command(
     cmd: &str,
     project_dir: &str,
     brain: &phantom_brain::brain::BrainHandle,
-    history: &HistoryStore,
+    history: &mut HistoryStore,
     _agents: &AgentManager,
     _claude_config: &Option<ClaudeConfig>,
 ) {
@@ -292,16 +291,13 @@ fn run_shell_command(
             }
 
             // Append to history.
-            let timestamp = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .map(|d| d.as_secs())
-                .unwrap_or(0);
-
-            let entry = HistoryEntry {
-                timestamp,
-                working_dir: project_dir.to_string(),
-                parsed,
-            };
+            let entry = HistoryEntry::builder(
+                cmd,
+                project_dir,
+                Uuid::new_v4(),
+            )
+            .exit_code(out.status.code().unwrap_or(-1))
+            .build();
             if let Err(e) = history.append(&entry) {
                 log::warn!("failed to append history: {e}");
             }


### PR DESCRIPTION
## Summary

- **#219** — `collect_source_chain` test helper was never defined in `dispatch.rs`. Added it as a `#[cfg(test)]` function that walks the `source_event_id` chain and returns visited event IDs (the counterpart to the production `taint_from_source_chain`). Added two acceptance tests: linear chain walk and cycle-guard termination.

- **#221** — `ReconcilerState::next_agent_id` was typed as `AgentId` (u32), silently wrapping at 2³²-1 on long-running sessions. Changed to `u64` and replaced bare `+= 1` with `.checked_add(1).expect(…)` for an explicit loud failure. Added a test that drives 100k increments and asserts monotonic growth.

- **#222** — `AgentRuntime::event_log()`, `registry()`, `flush()`, and `snapshot()` all called `.lock().expect("mutex poisoned")`, crashing the production update loop on poison. Replaced every instance with `.unwrap_or_else(|e| e.into_inner())` for poison recovery. Added two tests that deliberately poison each mutex and assert the accessor returns a usable guard.

Also fixed `crates/phantom/src/headless.rs` which used the stale `HistoryStore`/`HistoryEntry` API (struct literals, `open(&String)`, `.parsed.*` field access) — updated to builder API, `open(Uuid)`, and getter methods.

## Test plan

- [ ] `cargo test --workspace` passes (verified locally — all crates green)
- [ ] `runtime::tests::event_log_accessor_recovers_from_poisoned_mutex` passes
- [ ] `runtime::tests::registry_accessor_recovers_from_poisoned_mutex` passes
- [ ] `reconciler::tests::next_agent_id_does_not_overflow_after_100k_increments` passes
- [ ] `dispatch::tests::collect_source_chain_walks_linear_chain` passes
- [ ] `dispatch::tests::collect_source_chain_terminates_on_cycle` passes

Closes #219
Closes #221
Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)