### PR TITLE
fix(#218): fix phantom-nlp and phantom-session workspace compile

### DIFF
--- a/crates/phantom-nlp/src/interpreter.rs
+++ b/crates/phantom-nlp/src/interpreter.rs
@@ -1,3 +1,5 @@
+use std::sync::LazyLock;
+
 use phantom_context::ProjectContext;
 use regex::Regex;
 
@@ -41,6 +43,7 @@ impl NlpInterpreter {
     ///
     /// Returns `PassThrough` if the input doesn't match any known pattern
     /// or looks like a real shell command.
+    #[must_use]
     pub fn interpret(input: &str, ctx: &ProjectContext) -> ResolvedAction {
         let trimmed = input.trim();
         if trimmed.is_empty() {
@@ -89,6 +92,7 @@ impl NlpInterpreter {
     /// Returns `true` when the input contains spaces and starts with a
     /// common English verb/question word, and does NOT contain shell
     /// operators.
+    #[must_use]
     pub fn is_natural_language(input: &str) -> bool {
         let trimmed = input.trim();
         if trimmed.is_empty() {
@@ -152,6 +156,71 @@ impl NlpInterpreter {
 }
 
 // ---------------------------------------------------------------------------
+// Static regexes (compiled once at first use via LazyLock)
+// ---------------------------------------------------------------------------
+
+static RE_BINARY_TOKEN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[a-z][a-z0-9_-]*$").expect("static regex"));
+
+static RE_TEST: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(?:test|tests|run\s+(?:the\s+)?tests?)$").expect("static regex"));
+
+static RE_RUN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"^(?:run|start|run\s+it|start\s+it|run\s+the\s+(?:app|project|server)|start\s+the\s+(?:app|project|server))$",
+    )
+    .expect("static regex")
+});
+
+static RE_LINT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(?:lint|check|run\s+(?:the\s+)?linter?)$").expect("static regex"));
+
+static RE_FORMAT: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^(?:format|fmt|format\s+(?:the\s+)?code|run\s+(?:the\s+)?formatter)$")
+        .expect("static regex")
+});
+
+static RE_CHANGES: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"^(?:what(?:'s|\s+has)?\s+changed(?:\s+today|\s+recently|\s+lately)?|recent\s+changes|show\s+(?:recent\s+)?changes)$",
+    )
+    .expect("static regex")
+});
+
+static RE_STATUS: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^(?:status|git\s+status|what(?:'s|\s+is)\s+the\s+status)$").expect("static regex")
+});
+
+static RE_DEPLOY: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^deploy(?:\s+(?:to\s+)?(staging|production|prod|dev|preview))?$")
+        .expect("static regex")
+});
+
+static RE_FIX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^fix\s+(?:it|this|the\s+(?:error|bug|issue|problem|failure))$")
+        .expect("static regex")
+});
+
+static RE_EXPLAIN: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^(?:explain(?:\s+(?:this|it|that))?|what\s+happened)$").expect("static regex")
+});
+
+static RE_PERF: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?:feels?\s+slow|it(?:'s|\s+is)\s+slow|performance|why\s+is\s+it\s+slow|diagnose\s+performance)",
+    )
+    .expect("static regex")
+});
+
+static RE_SHOW: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^(?:show\s+me|what\s+is|tell\s+me\s+about)\s+(.+)$").expect("static regex")
+});
+
+static RE_CI: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^(?:is\s+ci\s+green|ci\s+status|check\s+ci)$").expect("static regex")
+});
+
+// ---------------------------------------------------------------------------
 // Internal matchers
 // ---------------------------------------------------------------------------
 
@@ -186,8 +255,7 @@ fn is_shell_command(input: &str) -> bool {
 /// intended as executable binaries, not natural language requests.
 fn is_known_binary(word: &str) -> bool {
     // Must be a single token of lowercase alpha (maybe with hyphens/underscores).
-    let re = Regex::new(r"^[a-z][a-z0-9_-]*$").unwrap();
-    if !re.is_match(word) {
+    if !RE_BINARY_TOKEN.is_match(word) {
         return false;
     }
 
@@ -227,8 +295,7 @@ fn match_project_commands(lower: &str, ctx: &ProjectContext) -> Option<ResolvedA
     }
 
     // Test
-    let test_re = Regex::new(r"^(?:test|tests|run\s+(?:the\s+)?tests?)$").unwrap();
-    if test_re.is_match(lower) {
+    if RE_TEST.is_match(lower) {
         return ctx
             .commands
             .test
@@ -237,11 +304,7 @@ fn match_project_commands(lower: &str, ctx: &ProjectContext) -> Option<ResolvedA
     }
 
     // Run / start
-    let run_re = Regex::new(
-        r"^(?:run|start|run\s+it|start\s+it|run\s+the\s+(?:app|project|server)|start\s+the\s+(?:app|project|server))$",
-    )
-    .unwrap();
-    if run_re.is_match(lower) {
+    if RE_RUN.is_match(lower) {
         return ctx
             .commands
             .run
@@ -250,8 +313,7 @@ fn match_project_commands(lower: &str, ctx: &ProjectContext) -> Option<ResolvedA
     }
 
     // Lint / check
-    let lint_re = Regex::new(r"^(?:lint|check|run\s+(?:the\s+)?linter?)$").unwrap();
-    if lint_re.is_match(lower) {
+    if RE_LINT.is_match(lower) {
         return ctx
             .commands
             .lint
@@ -260,10 +322,7 @@ fn match_project_commands(lower: &str, ctx: &ProjectContext) -> Option<ResolvedA
     }
 
     // Format
-    let fmt_re =
-        Regex::new(r"^(?:format|fmt|format\s+(?:the\s+)?code|run\s+(?:the\s+)?formatter)$")
-            .unwrap();
-    if fmt_re.is_match(lower) {
+    if RE_FORMAT.is_match(lower) {
         return ctx
             .commands
             .format
@@ -277,20 +336,14 @@ fn match_project_commands(lower: &str, ctx: &ProjectContext) -> Option<ResolvedA
 /// Match git and VCS related patterns.
 fn match_git_patterns(lower: &str) -> Option<ResolvedAction> {
     // "what changed" / "what changed today" / "recent changes"
-    let changes_re = Regex::new(
-        r"^(?:what(?:'s|\s+has)?\s+changed(?:\s+today|\s+recently|\s+lately)?|recent\s+changes|show\s+(?:recent\s+)?changes)$",
-    )
-    .unwrap();
-    if changes_re.is_match(lower) {
+    if RE_CHANGES.is_match(lower) {
         return Some(ResolvedAction::RunCommand(
             "git log --oneline -10".to_string(),
         ));
     }
 
     // "status" / "git status" / "what's the status"
-    let status_re =
-        Regex::new(r"^(?:status|git\s+status|what(?:'s|\s+is)\s+the\s+status)$").unwrap();
-    if status_re.is_match(lower) {
+    if RE_STATUS.is_match(lower) {
         return Some(ResolvedAction::RunCommand("git status".to_string()));
     }
 
@@ -299,10 +352,7 @@ fn match_git_patterns(lower: &str) -> Option<ResolvedAction> {
 
 /// Match deploy patterns, returning Ambiguous when there's no clear target.
 fn match_deploy_patterns(lower: &str, _original: &str) -> Option<ResolvedAction> {
-    let deploy_re =
-        Regex::new(r"^deploy(?:\s+(?:to\s+)?(staging|production|prod|dev|preview))?$").unwrap();
-
-    if let Some(caps) = deploy_re.captures(lower) {
+    if let Some(caps) = RE_DEPLOY.captures(lower) {
         if let Some(target) = caps.get(1) {
             let env = match target.as_str() {
                 "prod" => "production",
@@ -326,44 +376,35 @@ fn match_deploy_patterns(lower: &str, _original: &str) -> Option<ResolvedAction>
 /// Match patterns that should delegate to an AI agent.
 fn match_agent_patterns(lower: &str) -> Option<ResolvedAction> {
     // "fix it" / "fix the error" / "fix this"
-    let fix_re =
-        Regex::new(r"^fix\s+(?:it|this|the\s+(?:error|bug|issue|problem|failure))$").unwrap();
-    if fix_re.is_match(lower) {
+    if RE_FIX.is_match(lower) {
         return Some(ResolvedAction::SpawnAgent(
             "fix the last error".to_string(),
         ));
     }
 
     // "explain" / "explain this" / "what happened"
-    let explain_re =
-        Regex::new(r"^(?:explain(?:\s+(?:this|it|that))?|what\s+happened)$").unwrap();
-    if explain_re.is_match(lower) {
+    if RE_EXPLAIN.is_match(lower) {
         return Some(ResolvedAction::SpawnAgent(
             "explain the last output".to_string(),
         ));
     }
 
     // "something feels slow" / "it's slow" / "performance" / "why is it slow"
-    let perf_re = Regex::new(
-        r"(?:feels?\s+slow|it(?:'s|\s+is)\s+slow|performance|why\s+is\s+it\s+slow|diagnose\s+performance)",
-    )
-    .unwrap();
-    if perf_re.is_match(lower) {
+    if RE_PERF.is_match(lower) {
         return Some(ResolvedAction::SpawnAgent(
             "diagnose performance".to_string(),
         ));
     }
 
     // "show me X" / "what is X" — general agent delegation.
-    let show_re = Regex::new(r"^(?:show\s+me|what\s+is|tell\s+me\s+about)\s+(.+)$").unwrap();
-    if let Some(caps) = show_re.captures(lower) {
-        let topic = caps.get(1).unwrap().as_str().to_string();
+    if let Some(caps) = RE_SHOW.captures(lower) {
+        // cap(1) is guaranteed by the regex structure.
+        let topic = caps[1].to_string();
         return Some(ResolvedAction::SpawnAgent(topic));
     }
 
     // "is CI green" / "CI status" / "check CI"
-    let ci_re = Regex::new(r"^(?:is\s+ci\s+green|ci\s+status|check\s+ci)$").unwrap();
-    if ci_re.is_match(lower) {
+    if RE_CI.is_match(lower) {
         return Some(ResolvedAction::ShowInfo("CI status check".to_string()));
     }
 

--- a/crates/phantom-nlp/src/translate.rs
+++ b/crates/phantom-nlp/src/translate.rs
@@ -107,6 +107,7 @@ impl Intent {
     // -- field accessors -------------------------------------------------------
 
     /// Return the `cmd` field if this is a [`Intent::RunCommand`], else `None`.
+    #[must_use]
     pub fn cmd(&self) -> Option<&str> {
         match self {
             Self::RunCommand { cmd } => Some(cmd),
@@ -115,6 +116,7 @@ impl Intent {
     }
 
     /// Return the `query` field if this is a [`Intent::SearchHistory`], else `None`.
+    #[must_use]
     pub fn query(&self) -> Option<&str> {
         match self {
             Self::SearchHistory { query } => Some(query),
@@ -123,6 +125,7 @@ impl Intent {
     }
 
     /// Return the `goal` field if this is a [`Intent::SpawnAgent`], else `None`.
+    #[must_use]
     pub fn goal(&self) -> Option<&str> {
         match self {
             Self::SpawnAgent { goal } => Some(goal),
@@ -131,6 +134,7 @@ impl Intent {
     }
 
     /// Return the `question` field if this is a [`Intent::Clarify`], else `None`.
+    #[must_use]
     pub fn question(&self) -> Option<&str> {
         match self {
             Self::Clarify { question } => Some(question),
@@ -139,6 +143,7 @@ impl Intent {
     }
 
     /// Human-readable name of this intent variant (for logging).
+    #[must_use]
     pub fn variant_name(&self) -> &'static str {
         match self {
             Self::RunCommand { .. } => "RunCommand",
@@ -222,6 +227,7 @@ impl ClaudeLlmBackend {
     }
 
     /// Return the model identifier in use.
+    #[must_use]
     pub fn model(&self) -> &str {
         &self.model
     }

--- a/crates/phantom-session/src/agent_state.rs
+++ b/crates/phantom-session/src/agent_state.rs
@@ -70,6 +70,7 @@ impl SavedMessage {
     ///   `CompletedToolUse` entry.
     /// - Any buffered (unmatched) calls at the end are dropped — these are
     ///   the in-flight calls the issue asks us to discard.
+    #[must_use]
     pub fn from_agent_messages(messages: &[AgentMessage]) -> Vec<Self> {
         use phantom_agents::tools::ToolCall;
 
@@ -150,6 +151,7 @@ impl AgentSnapshot {
     ///
     /// In-flight tool calls are stripped.  In-progress status is normalised to
     /// `Queued` so the agent can restart from a clean state.
+    #[must_use]
     pub fn from_agent(agent: &phantom_agents::Agent) -> Self {
         let status = match agent.status {
             AgentStatus::Working
@@ -180,42 +182,50 @@ impl AgentSnapshot {
     // -- Accessors -----------------------------------------------------------
 
     /// The agent's numeric identifier.
+    #[must_use]
     pub fn id(&self) -> u32 {
         self.id
     }
 
     /// The task the agent was performing.
+    #[must_use]
     pub fn task(&self) -> &AgentTask {
         &self.task
     }
 
     /// The normalised lifecycle status (never `Working`, `WaitingForTool`,
     /// `Planning`, or `AwaitingApproval`).
+    #[must_use]
     pub fn status(&self) -> AgentStatus {
         self.status
     }
 
     /// Saved conversation messages (in-flight tool calls stripped).
+    #[must_use]
     pub fn messages(&self) -> &[SavedMessage] {
         &self.messages
     }
 
     /// Approximate creation timestamp (unix epoch seconds).
+    #[must_use]
     pub fn created_at_secs(&self) -> u64 {
         self.created_at_secs
     }
 
     /// Flatline reason if the agent was in Flatline state at shutdown.
+    #[must_use]
     pub fn flatline_reason(&self) -> Option<&str> {
         self.flatline_reason.as_deref()
     }
 
     /// Visible output lines at the time of save.
+    #[must_use]
     pub fn output_log(&self) -> &[String] {
         &self.output_log
     }
 
     /// Number of non-system messages in the saved history.
+    #[must_use]
     pub fn conversation_depth(&self) -> usize {
         self.messages
             .iter()
@@ -241,6 +251,7 @@ pub struct AgentStateFile {
 
 impl AgentStateFile {
     /// Create a new agent state file from a collection of snapshots.
+    #[must_use]
     pub fn new(agents: Vec<AgentSnapshot>) -> Self {
         let saved_at = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -256,21 +267,25 @@ impl AgentStateFile {
     // -- Accessors -----------------------------------------------------------
 
     /// Schema version.
+    #[must_use]
     pub fn version(&self) -> u32 {
         self.version
     }
 
     /// When this file was saved (unix epoch seconds).
+    #[must_use]
     pub fn saved_at(&self) -> u64 {
         self.saved_at
     }
 
     /// All saved agent snapshots.
+    #[must_use]
     pub fn agents(&self) -> &[AgentSnapshot] {
         &self.agents
     }
 
     /// Number of saved agents.
+    #[must_use]
     pub fn agent_count(&self) -> usize {
         self.agents.len()
     }
@@ -334,6 +349,7 @@ impl AgentStatePersister {
     /// Derive the agent-state sidecar path from a session file path.
     ///
     /// Given `{hash}_{ts}.json`, returns `{hash}_{ts}_agents.json`.
+    #[must_use]
     pub fn sidecar_path(session_path: &Path) -> PathBuf {
         let stem = session_path
             .file_stem()
@@ -347,6 +363,7 @@ impl AgentStatePersister {
     }
 
     /// Create a persister for the given sidecar path.
+    #[must_use]
     pub fn new(path: PathBuf) -> Self {
         Self { path }
     }
@@ -391,6 +408,7 @@ impl AgentStatePersister {
     }
 
     /// The path this persister writes to.
+    #[must_use]
     pub fn path(&self) -> &Path {
         &self.path
     }
@@ -421,6 +439,7 @@ pub enum RestoreOutcome<T> {
 /// Returns a vec of `RestoreOutcome`, one per saved snapshot.  Callers can
 /// count `Ok` entries to decide whether to show the "resume" prompt and can
 /// log `Skipped`/`Corrupt` entries for diagnostics.
+#[must_use]
 pub fn partial_restore(file: &AgentStateFile) -> Vec<RestoreOutcome<AgentSnapshot>> {
     file.agents()
         .iter()

--- a/crates/phantom-session/src/goal_state.rs
+++ b/crates/phantom-session/src/goal_state.rs
@@ -52,6 +52,7 @@ impl SavedStepStatus {
     ///
     /// `Active` → `Pending` (retry policy from the issue spec).
     /// All other statuses are restored as-is.
+    #[must_use]
     pub fn restore_as(self) -> Self {
         match self {
             Self::Active => Self::Pending,
@@ -108,30 +109,37 @@ impl SavedPlanStep {
 
     // -- Accessors -----------------------------------------------------------
 
+    #[must_use]
     pub fn description(&self) -> &str {
         &self.description
     }
 
+    #[must_use]
     pub fn assigned_task(&self) -> &AgentTask {
         &self.assigned_task
     }
 
+    #[must_use]
     pub fn status(&self) -> SavedStepStatus {
         self.status
     }
 
+    #[must_use]
     pub fn agent_id(&self) -> Option<u32> {
         self.agent_id
     }
 
+    #[must_use]
     pub fn attempts(&self) -> u32 {
         self.attempts
     }
 
+    #[must_use]
     pub fn max_attempts(&self) -> u32 {
         self.max_attempts
     }
 
+    #[must_use]
     pub fn result_summary(&self) -> Option<&str> {
         self.result_summary.as_deref()
     }
@@ -139,6 +147,7 @@ impl SavedPlanStep {
     /// The status that should be used when reconstructing a live `PlanStep`.
     ///
     /// `Active` → `Pending` (conflict policy: retry in-progress work).
+    #[must_use]
     pub fn restore_status(&self) -> SavedStepStatus {
         self.status.restore_as()
     }
@@ -166,14 +175,17 @@ pub struct SavedFact {
 }
 
 impl SavedFact {
+    #[must_use]
     pub fn content(&self) -> &str {
         &self.content
     }
 
+    #[must_use]
     pub fn confidence(&self) -> SavedFactConfidence {
         self.confidence
     }
 
+    #[must_use]
     pub fn source(&self) -> &str {
         &self.source
     }
@@ -213,6 +225,7 @@ impl GoalSnapshot {
     /// the values they need.  The `active → pending` demotion is applied
     /// at restore time (see `restore_status()`), not at save time, so the
     /// saved record faithfully records what was running.
+    #[must_use]
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         goal: String,
@@ -242,42 +255,52 @@ impl GoalSnapshot {
 
     // -- Accessors -----------------------------------------------------------
 
+    #[must_use]
     pub fn goal(&self) -> &str {
         &self.goal
     }
 
+    #[must_use]
     pub fn facts(&self) -> &[SavedFact] {
         &self.facts
     }
 
+    #[must_use]
     pub fn plan(&self) -> &[SavedPlanStep] {
         &self.plan
     }
 
+    #[must_use]
     pub fn plan_history(&self) -> &[Vec<SavedPlanStep>] {
         &self.plan_history
     }
 
+    #[must_use]
     pub fn stall_counter(&self) -> u32 {
         self.stall_counter
     }
 
+    #[must_use]
     pub fn stall_threshold(&self) -> u32 {
         self.stall_threshold
     }
 
+    #[must_use]
     pub fn replan_count(&self) -> u32 {
         self.replan_count
     }
 
+    #[must_use]
     pub fn max_replans(&self) -> u32 {
         self.max_replans
     }
 
+    #[must_use]
     pub fn created_at_secs(&self) -> u64 {
         self.created_at_secs
     }
 
+    #[must_use]
     pub fn last_replan_at_secs(&self) -> Option<u64> {
         self.last_replan_at_secs
     }
@@ -288,6 +311,7 @@ impl GoalSnapshot {
     ///
     /// The reconciler uses this to detect whether completed steps would be
     /// re-executed after restore (they should not).
+    #[must_use]
     pub fn done_step_count(&self) -> usize {
         self.plan
             .iter()
@@ -297,6 +321,7 @@ impl GoalSnapshot {
 
     /// Count steps that would be `Pending` after restore (includes `Active`
     /// steps that are demoted).
+    #[must_use]
     pub fn pending_after_restore(&self) -> usize {
         self.plan
             .iter()
@@ -327,6 +352,7 @@ pub struct GoalStateFile {
 
 impl GoalStateFile {
     /// Create a new file from a collection of goal snapshots.
+    #[must_use]
     pub fn new(goals: Vec<GoalSnapshot>) -> Self {
         let saved_at = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -341,18 +367,22 @@ impl GoalStateFile {
 
     // -- Accessors -----------------------------------------------------------
 
+    #[must_use]
     pub fn version(&self) -> u32 {
         self.version
     }
 
+    #[must_use]
     pub fn saved_at(&self) -> u64 {
         self.saved_at
     }
 
+    #[must_use]
     pub fn goals(&self) -> &[GoalSnapshot] {
         &self.goals
     }
 
+    #[must_use]
     pub fn goal_count(&self) -> usize {
         self.goals.len()
     }
@@ -412,6 +442,7 @@ pub struct GoalStatePersister {
 impl GoalStatePersister {
     /// Return the canonical global goal-state path:
     /// `~/.local/share/phantom/goals.json`.
+    #[must_use]
     pub fn default_path() -> PathBuf {
         if let Ok(home) = std::env::var("HOME") {
             PathBuf::from(home)
@@ -427,6 +458,7 @@ impl GoalStatePersister {
     /// Derive a project-scoped sidecar path from a session file path.
     ///
     /// Given `{hash}_{ts}.json`, returns `{hash}_{ts}_goals.json`.
+    #[must_use]
     pub fn sidecar_path(session_path: &Path) -> PathBuf {
         let stem = session_path
             .file_stem()
@@ -440,6 +472,7 @@ impl GoalStatePersister {
     }
 
     /// Create a persister targeting `path`.
+    #[must_use]
     pub fn new(path: PathBuf) -> Self {
         Self { path }
     }
@@ -472,6 +505,7 @@ impl GoalStatePersister {
         }
     }
 
+    #[must_use]
     pub fn path(&self) -> &Path {
         &self.path
     }
@@ -493,6 +527,7 @@ pub struct PlanStepBuilder {
 }
 
 impl PlanStepBuilder {
+    #[must_use]
     pub fn new(description: impl Into<String>, task: AgentTask) -> Self {
         Self {
             description: description.into(),
@@ -505,31 +540,37 @@ impl PlanStepBuilder {
         }
     }
 
+    #[must_use]
     pub fn status(mut self, status: SavedStepStatus) -> Self {
         self.status = status;
         self
     }
 
+    #[must_use]
     pub fn agent_id(mut self, id: u32) -> Self {
         self.agent_id = Some(id);
         self
     }
 
+    #[must_use]
     pub fn attempts(mut self, n: u32) -> Self {
         self.attempts = n;
         self
     }
 
+    #[must_use]
     pub fn max_attempts(mut self, n: u32) -> Self {
         self.max_attempts = n;
         self
     }
 
+    #[must_use]
     pub fn result_summary(mut self, s: impl Into<String>) -> Self {
         self.result_summary = Some(s.into());
         self
     }
 
+    #[must_use]
     pub fn build(self) -> SavedPlanStep {
         SavedPlanStep::from_raw(
             self.description,
@@ -558,6 +599,7 @@ pub enum GoalRestoreOutcome {
 }
 
 /// Attempt to restore goals from a saved file, tolerating per-goal failures.
+#[must_use]
 pub fn partial_restore_goals(file: &GoalStateFile) -> Vec<GoalRestoreOutcome> {
     if file.version() < 1 {
         return vec![GoalRestoreOutcome::Corrupt {

--- a/crates/phantom-session/src/session.rs
+++ b/crates/phantom-session/src/session.rs
@@ -87,6 +87,7 @@ impl SessionManager {
     /// Return the default session directory path without creating it.
     ///
     /// Falls back to `"."` as an absolute last resort when `HOME` is unset.
+    #[must_use]
     pub fn session_dir_path() -> PathBuf {
         if let Ok(home) = std::env::var("HOME") {
             PathBuf::from(home)
@@ -225,6 +226,7 @@ impl SessionManager {
     }
 
     /// Build a welcome-back message from a saved session.
+    #[must_use]
     pub fn welcome_message(state: &SessionState) -> String {
         let mut parts = vec![format!(
             "Welcome back. You were working on {}",
@@ -350,6 +352,7 @@ fn now_epoch() -> u64 {
 /// The check is cheap: only filenames are inspected, no JSON is parsed.
 /// Returns `false` on any I/O error so the caller never has to handle an
 /// error just to decide whether to show the boot animation.
+#[must_use]
 pub fn is_session_restore(session_dir: &Path, project_dir: &str) -> bool {
     is_session_restore_with_env(
         session_dir,


### PR DESCRIPTION
## Summary

Closes #218

Both `phantom-nlp` and `phantom-session` were already registered in the workspace `Cargo.toml` but failed CI due to two lint violations:

- **Missing `#[must_use]`** on all public constructor/accessor methods — the workspace enforces `clippy::must_use_candidate = warn` + `warnings = deny`, which converts these to hard errors
- **`.unwrap()` on `Regex::new()`** in non-test production code in `phantom-nlp/interpreter.rs` — replaced with `std::sync::LazyLock<Regex>` static constants compiled once at first use

### Files changed

| File | Change |
|------|--------|
| `phantom-nlp/src/interpreter.rs` | Static `LazyLock<Regex>` for 13 patterns; `#[must_use]` on `interpret` + `is_natural_language` |
| `phantom-nlp/src/translate.rs` | `#[must_use]` on 6 `Intent` accessor methods + `ClaudeLlmBackend::model` |
| `phantom-session/src/agent_state.rs` | `#[must_use]` on all public methods across 4 types + `partial_restore` |
| `phantom-session/src/goal_state.rs` | `#[must_use]` on all public methods across 6 types + `partial_restore_goals` |
| `phantom-session/src/session.rs` | `#[must_use]` on `session_dir_path`, `welcome_message`, `is_session_restore` |

## Test plan

- [x] `cargo test -p phantom-nlp` — 65 tests + 1 doctest pass
- [x] `cargo test -p phantom-session` — 77 tests pass
- [x] `cargo clippy -p phantom-nlp --no-deps` — clean
- [x] `cargo clippy -p phantom-session --no-deps` — clean
- [x] No `.unwrap()` outside `#[cfg(test)]` in changed files
- [x] No `pub` fields added (existing pub fields on serde data types unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)