### PR TITLE
fix(#261): cursor_to_cell skip chrome inset in single-pane mode

### DIFF
--- a/crates/phantom-app/src/coordinator.rs
+++ b/crates/phantom-app/src/coordinator.rs
@@ -743,6 +743,20 @@ impl AppCoordinator {
         self.registry.count()
     }
 
+    /// Number of running visual adapters that are in the tiled grid (not floating).
+    ///
+    /// This mirrors the `tiled_count <= 1` check in `render.rs`: chrome (title
+    /// strip, border, margin) is only drawn when there are 2+ tiled visual
+    /// adapters, so mouse-coordinate mapping must make the same distinction.
+    pub(crate) fn tiled_visual_count(&self) -> usize {
+        self.registry
+            .all_running()
+            .into_iter()
+            .filter_map(|id| self.registry.get(id))
+            .filter(|e| e.visual && !self.floating.contains(&e.id))
+            .count()
+    }
+
     /// All app IDs that are currently running.
     pub fn all_app_ids(&self) -> Vec<AppId> {
         self.registry.all_running()

--- a/crates/phantom-app/src/mouse.rs
+++ b/crates/phantom-app/src/mouse.rs
@@ -158,13 +158,25 @@ impl App {
     }
 
     /// Convert cursor pixel position to terminal cell (col, row) for the given adapter.
+    ///
+    /// In single-pane mode the renderer skips all container chrome (outer margin,
+    /// title strip, side padding), so we must map the cursor directly against the
+    /// raw layout rect.  The check mirrors the `tiled_count <= 1` guard that
+    /// suppresses chrome drawing in `render.rs` (see PR #259).
     fn cursor_to_cell(&self, app_id: u32) -> Option<(usize, usize)> {
         let pane_id = self.coordinator.pane_id_for(app_id)?;
         let layout_rect = self.layout.get_pane_rect(pane_id).ok()?;
-        let cr = container_rect(layout_rect, self.cell_size);
-        let inner = pane_inner_rect(self.cell_size, cr);
+
+        // Single-pane: no chrome drawn → use the full layout rect directly.
+        let inner = if self.coordinator.tiled_visual_count() <= 1 {
+            layout_rect
+        } else {
+            let cr = container_rect(layout_rect, self.cell_size);
+            pane_inner_rect(self.cell_size, cr)
+        };
+
         let (px, py) = self.cursor_position;
-        // Compute grid dimensions from the pane inner rect for clamping.
+        // Compute grid dimensions from the rect for clamping.
         let max_col = if self.cell_size.0 > 0.0 {
             (inner.width / self.cell_size.0).floor() as usize
         } else {
@@ -550,5 +562,71 @@ mod tests {
         assert_eq!(winit_to_term_button(MouseButton::Middle), Some(TermMouseButton::Middle));
         assert_eq!(winit_to_term_button(MouseButton::Back), None);
         assert_eq!(winit_to_term_button(MouseButton::Forward), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #261 — single-pane chrome inset regression
+    // -----------------------------------------------------------------------
+    //
+    // Regression guard: `cursor_to_cell` must skip container/pane-inner chrome
+    // insets when only one tiled pane is present (no chrome is drawn).
+    //
+    // The test encodes the rect selection logic that `cursor_to_cell` performs:
+    //   • Single-pane path  → inner = full layout rect (origin 0,0)
+    //   • Multi-pane path   → inner = pane_inner_rect(container_rect(layout_rect))
+    //
+    // We verify that:
+    //  1. On the single-pane path, cursor at (0,0) maps to cell (0,0).
+    //  2. The multi-pane chrome insets produce a strictly positive inner origin,
+    //     which would shift the coordinate mapping — proving the bug was real.
+
+    #[test]
+    fn cursor_to_cell_single_pane_no_chrome_offset() {
+        use crate::pane::{container_rect, pane_inner_rect, CONTAINER_TITLE_H_CELLS};
+        use phantom_ui::layout::Rect;
+
+        let cell_w = 8.0_f32;
+        let cell_h = 16.0_f32;
+        let cell_size = (cell_w, cell_h);
+
+        // Full-screen layout rect (single-pane: no margin/chrome applied).
+        let layout_rect = Rect { x: 0.0, y: 0.0, width: 1280.0, height: 800.0 };
+
+        // ── Single-pane path (the fix) ──────────────────────────────────
+        // inner == layout_rect, so cursor (0,0) → cell (0,0).
+        let inner_single = layout_rect;
+        let max_col = (inner_single.width / cell_w).floor() as usize;
+        let max_row = (inner_single.height / cell_h).floor() as usize;
+        let (col, row) = pixel_to_cell(
+            0.0, 0.0,
+            inner_single.x, inner_single.y,
+            cell_w, cell_h,
+            max_col.saturating_sub(1), max_row.saturating_sub(1),
+        );
+        assert_eq!(
+            (col, row), (0, 0),
+            "single-pane: cursor at (0,0) must map to cell (0,0); got ({col},{row})",
+        );
+
+        // ── Multi-pane / pre-fix path ────────────────────────────────────
+        // Chrome insets produce a non-zero inner origin, shifting coordinates.
+        let cr = container_rect(layout_rect, cell_size);
+        let inner_multi = pane_inner_rect(cell_size, cr);
+
+        // The inner rect origin must be offset by margin + title strip.
+        assert!(
+            inner_multi.x > 0.0 || inner_multi.y > 0.0,
+            "multi-pane inner rect must have a non-zero origin due to chrome insets; \
+             got ({}, {})", inner_multi.x, inner_multi.y,
+        );
+
+        // Specifically: inner.y must be at least one title-strip height from the
+        // window top, documenting the ~12px + 1.2-cell offset that #261 reported.
+        let title_h = cell_h * CONTAINER_TITLE_H_CELLS;
+        assert!(
+            inner_multi.y >= title_h - 0.5,
+            "multi-pane inner.y must be at least one title-strip height ({title_h}px) \
+             from the window top; got {}", inner_multi.y,
+        );
     }
 }


### PR DESCRIPTION
Fixes #261

In single-pane mode, cursor_to_cell was applying chrome insets that don't exist, offsetting all mouse coordinates by ~12px + title height. Mirrors the tiled_count <= 1 short-circuit added in PR #259 for scrollbar geometry.