### PR TITLE
feat(#205): wire phantom-history into phantom-app — command log + agent capture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5417,6 +5417,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
+ "uuid",
  "wgpu",
  "winit",
 ]

--- a/crates/phantom-app/Cargo.toml
+++ b/crates/phantom-app/Cargo.toml
@@ -46,6 +46,7 @@ image = { version = "0.25", default-features = false, features = ["png"] }
 # JobPool worker threads. The OpenAI backend is `async`, but JobPayload::run
 # is sync — we drive the async call by spinning up a per-job runtime.
 tokio = { version = "1", features = ["rt", "macros", "sync", "time"] }
+uuid.workspace = true
 
 [features]
 phantom-profile = []

--- a/crates/phantom-app/src/agent_pane.rs
+++ b/crates/phantom-app/src/agent_pane.rs
@@ -20,6 +20,7 @@ use phantom_agents::tools::{
     ToolCall, ToolDefinition, ToolResult, ToolType, available_tools,
 };
 use phantom_agents::{AgentSpawnOpts, AgentTask};
+use phantom_history::{AgentOutputCapture, ToolCall as HistoryToolCall};
 
 use crate::app::App;
 
@@ -253,6 +254,16 @@ pub(crate) struct AgentPane {
     /// `suggested_capability` field of `AgentBlocked` events so the Fixer can
     /// request the correct class instead of hardcoding `"Sense"`.
     last_failing_capability: Option<CapabilityClass>,
+    /// Agent output capture sidecar — `None` when launched without App wiring
+    /// (legacy / test path). The production path sets this via
+    /// [`AgentPane::set_agent_capture`] after [`AgentPane::spawn_with_opts`].
+    agent_capture: Option<AgentOutputCapture>,
+    /// Session UUID forwarded from the App's `session_uuid` field. Used as the
+    /// `session_id` parameter when appending to the capture sidecar.
+    capture_session_uuid: uuid::Uuid,
+    /// Tool calls accumulated during the current agent turn, flushed to the
+    /// sidecar on `ApiEvent::Done` or `ApiEvent::Error`.
+    capture_tool_calls: Vec<HistoryToolCall>,
     /// Shared registry handle used by chat-tool dispatch (`send_to_agent`,
     /// `broadcast_to_role`, `request_critique`). Cloned from the runtime at
     /// spawn time so dispatch contexts can read/write the same directory the
@@ -344,6 +355,9 @@ impl AgentPane {
             last_failing_capability: None,
             ticket_dispatcher: None,
             journal: None,
+            agent_capture: None,
+            capture_session_uuid: uuid::Uuid::nil(),
+            capture_tool_calls: Vec::new(),
         }
     }
 
@@ -551,6 +565,9 @@ impl AgentPane {
             role: initial_role,
             ticket_dispatcher: None,
             journal,
+            agent_capture: None,
+            capture_session_uuid: uuid::Uuid::nil(),
+            capture_tool_calls: Vec::new(),
         }
     }
 
@@ -613,6 +630,18 @@ impl AgentPane {
     ) {
         self.ticket_dispatcher = Some(dispatcher);
     }
+
+    /// Wire the history capture sidecar into this pane.
+    ///
+    /// Called by `App::spawn_agent_pane_with_opts` after `spawn_with_opts`.
+    /// When `None` is held (legacy / test path), tool calls and output are
+    /// not recorded.
+    pub(crate) fn set_agent_capture(&mut self, capture: AgentOutputCapture, session_uuid: uuid::Uuid) {
+        self.agent_capture = Some(capture);
+        self.capture_session_uuid = session_uuid;
+    }
+
+
 
     /// Build a [`phantom_agents::dispatch::DispatchContext`] from the
     /// pane's current substrate handles, if all required pieces are wired.
@@ -703,6 +732,13 @@ impl AgentPane {
                     } else {
                         self.output.push_str(&format!("\n▶ {} {}\n", call.tool.api_name(), args_display));
                     }
+                    // Record for the capture sidecar flush on Done/Error.
+                    let args_json = serde_json::to_string(&call.args).unwrap_or_default();
+                    self.capture_tool_calls.push(HistoryToolCall::new(
+                        call.tool.api_name(),
+                        args_json,
+                        None,
+                    ));
                     self.tool_use_ids.push(id.clone());
                     self.pending_tools.push((id, call));
                     got_content = true;
@@ -731,6 +767,7 @@ impl AgentPane {
                         self.status = AgentPaneStatus::Done;
                         self.api_handle = None;
                         self.push_snapshot();
+                        self.flush_capture_record();
                         self.save_conversation();
                     } else {
                         // Execute pending tools and continue conversation.
@@ -747,6 +784,7 @@ impl AgentPane {
                         }
                     }
                     self.rollback_if_dirty();
+                    self.flush_capture_record();
                     self.status = AgentPaneStatus::Failed;
                     self.api_handle = None;
                     self.push_snapshot();
@@ -1242,6 +1280,32 @@ impl AgentPane {
         }
     }
 
+    /// Flush accumulated tool calls and output text to the capture sidecar.
+    ///
+    /// Called at `ApiEvent::Done` (agent finished) and `ApiEvent::Error`
+    /// (agent failed). Drains `self.capture_tool_calls` and appends one
+    /// `AgentRecord` to the sidecar. No-ops when no sidecar is configured.
+    fn flush_capture_record(&mut self) {
+        let Some(ref capture) = self.agent_capture else {
+            return;
+        };
+        // Cap text output to 4 096 chars so the sidecar stays bounded even
+        // for chatty agents.  We take the tail (most-recent output) on the
+        // assumption that the end of the run is more useful than the start.
+        let text_output: String = if self.output.chars().count() > 4096 {
+            let tail: String = self.output.chars().rev().take(4096).collect();
+            tail.chars().rev().collect()
+        } else {
+            self.output.clone()
+        };
+        let tool_calls = std::mem::take(&mut self.capture_tool_calls);
+        let session_uuid = self.capture_session_uuid;
+        let agent_name = self.task.clone();
+        if let Err(e) = capture.append(agent_name, session_uuid, tool_calls, text_output) {
+            warn!("agent capture append failed: {e}");
+        }
+    }
+
     /// Save the agent conversation to disk for debugging and replay.
     pub(crate) fn save_conversation(&self) {
         let dir = std::env::var("HOME")
@@ -1502,6 +1566,12 @@ impl App {
                      (GITHUB_TOKEN / GH_REPO not set); ticket tools will fail gracefully"
                 );
             }
+        }
+
+        // Wire the history capture sidecar so this agent's tool calls and
+        // output are recorded in the session's agents.jsonl sidecar.
+        if let Some(ref capture) = self.agent_capture {
+            agent_pane.set_agent_capture(capture.clone(), self.session_uuid);
         }
 
         let adapter = crate::adapters::agent::AgentAdapter::with_spawn_tag(agent_pane, spawn_tag);

--- a/crates/phantom-app/src/app.rs
+++ b/crates/phantom-app/src/app.rs
@@ -34,6 +34,7 @@ use phantom_brain::brain::{BrainConfig, BrainHandle, spawn_brain};
 use phantom_brain::events::AiEvent;
 use phantom_brain::ooda::{OodaConfig, OodaLoop};
 use phantom_context::ProjectContext;
+use phantom_history::{AgentOutputCapture, HistoryStore};
 use phantom_memory::MemoryStore;
 use phantom_plugins::PluginRegistry;
 use phantom_scene::node::{NodeKind, RenderLayer};
@@ -374,6 +375,26 @@ pub struct App {
     // -- Live shader reloader (debug + `live-reload` feature only).
     //    No-op stub in release builds; zero overhead on the hot path.
     pub(crate) shader_reloader: phantom_renderer::shader_loader::ShaderReloader,
+
+    // -- Command history store (JSONL, one entry per completed command). --
+    //    `None` on open failure; production paths never `.unwrap()`.
+    //    File: `~/.local/share/phantom/history/<session_uuid>.jsonl`.
+    pub(crate) history: Option<HistoryStore>,
+
+    // -- Agent output capture sidecar (JSONL, one record per agent run). --
+    //    `None` on open failure. Each spawned `AgentPane` receives a clone.
+    //    File: `~/.local/share/phantom/history/<session_uuid>-agents.jsonl`.
+    pub(crate) agent_capture: Option<AgentOutputCapture>,
+
+    // -- Session UUID shared by the history store and agent capture sidecar.
+    //    Generated once at startup; stable for the process lifetime.
+    pub(crate) session_uuid: uuid::Uuid,
+
+    // -- Per-pane pending command text.
+    //    Populated from `Event::CommandStarted` so that the subsequent
+    //    `Event::CommandComplete` handler in `drain_bus_to_brain` can write
+    //    a `HistoryEntry` with the actual command string and exit code.
+    pub(crate) pending_command_text: std::collections::HashMap<phantom_adapter::AppId, String>,
 }
 
 /// An active suggestion from the AI brain.
@@ -517,6 +538,31 @@ impl App {
             }
             Err(e) => {
                 warn!("Failed to open notification store: {e}");
+                None
+            }
+        };
+
+        // -- History store + agent capture sidecar --
+        // Both live under `~/.local/share/phantom/history/<session_uuid>[...].jsonl`.
+        // Best-effort: on failure we set `None` and the rest of the app boots normally.
+        let session_uuid = uuid::Uuid::new_v4();
+        let history = match HistoryStore::open(session_uuid) {
+            Ok(h) => {
+                info!("History store ready → {}", h.path().display());
+                Some(h)
+            }
+            Err(e) => {
+                warn!("Failed to open history store: {e}");
+                None
+            }
+        };
+        let agent_capture = match AgentOutputCapture::open(session_uuid) {
+            Ok(c) => {
+                info!("Agent capture sidecar ready → {}", c.path().display());
+                Some(c)
+            }
+            Err(e) => {
+                warn!("Failed to open agent capture sidecar: {e}");
                 None
             }
         };
@@ -940,6 +986,10 @@ impl App {
             ticket_dispatcher,
             pane_last_command: std::collections::HashMap::new(),
             shader_reloader: phantom_renderer::shader_loader::ShaderReloader::new(),
+            history,
+            agent_capture,
+            session_uuid,
+            pending_command_text: std::collections::HashMap::new(),
         })
     }
 

--- a/crates/phantom-app/src/commands.rs
+++ b/crates/phantom-app/src/commands.rs
@@ -330,6 +330,39 @@ impl App {
                     }
                 }
             }
+            cmd if cmd == "history" || cmd.starts_with("history ") => {
+                let limit: usize = parts.get(1)
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(20);
+                match self.history {
+                    None => self.console.output("History store not available."),
+                    Some(ref store) => {
+                        let total = store.count();
+                        self.console.output(format!(
+                            "Command history ({total} total, showing last {limit}):"
+                        ));
+                        match store.recent(limit) {
+                            Err(e) => self.console.output(format!("history read error: {e}")),
+                            Ok(entries) if entries.is_empty() => {
+                                self.console.output("  (no commands recorded yet)");
+                            }
+                            Ok(entries) => {
+                                let start_num = total.saturating_sub(entries.len());
+                                for (i, e) in entries.iter().enumerate() {
+                                    let code = e.exit_code()
+                                        .map(|c| format!(" [exit {c}]"))
+                                        .unwrap_or_default();
+                                    self.console.output(format!(
+                                        "  {:>3}. {}{code}",
+                                        start_num + i + 1,
+                                        e.command(),
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
             "selftest" => {
                 self.console.system("SELFTEST: brain exercising its own features...");
                 self.selftest = Some(crate::selftest::SelfTestRunner::new(false));
@@ -355,6 +388,7 @@ impl App {
                 self.console.output("  reload              Reload config from disk");
                 self.console.output("  boot                Replay boot sequence");
                 self.console.output("  video <path>        Play video through CRT shader");
+                self.console.output("  history [N]         Show last N commands (default 20)");
                 self.console.output("  suggestions         List dismissed/expired suggestion history");
                 self.console.output("  selftest            Brain exercises its own features");
                 self.console.output("  selfheal            selftest + auto-fix + commit + push");

--- a/crates/phantom-app/src/update.rs
+++ b/crates/phantom-app/src/update.rs
@@ -12,6 +12,7 @@ use phantom_brain::events::{AiAction, AiEvent};
 use phantom_brain::ooda::WorldState;
 use phantom_protocol::Event;
 use phantom_context::ProjectContext;
+use phantom_history::HistoryEntry;
 use phantom_mcp::{AppCommand, ScreenshotReply};
 use crate::app::{App, AppState, SuggestionOverlay};
 use crate::input::chrono_time_string;
@@ -504,10 +505,33 @@ impl App {
         }
 
         for msg in msgs {
-            // Track the last command text per pane so CommandComplete can
-            // populate ParsedOutput::command with a real value (issue #226).
-            if let Event::CommandStarted { app_id, command } = &msg.event {
-                self.pane_last_command.insert(*app_id, command.clone());
+            // 0) Command-boundary tracking for both the history store and
+            //    the brain's ParsedOutput (issue #226).
+            //    `CommandStarted` records the command text in both maps;
+            //    `CommandComplete` consumes pending_command_text for history.
+            match &msg.event {
+                Event::CommandStarted { app_id, command } => {
+                    self.pending_command_text.insert(*app_id, command.clone());
+                    self.pane_last_command.insert(*app_id, command.clone());
+                }
+                Event::CommandComplete { app_id, exit_code } => {
+                    let command_text = self
+                        .pending_command_text
+                        .remove(app_id)
+                        .unwrap_or_default();
+                    if let Some(ref mut store) = self.history {
+                        let cwd = self.context.as_ref()
+                            .map(|c| std::path::PathBuf::from(&c.root))
+                            .unwrap_or_else(|| std::path::PathBuf::from("."));
+                        let entry = HistoryEntry::builder(&command_text, cwd, self.session_uuid)
+                            .exit_code(*exit_code)
+                            .build();
+                        if let Err(e) = store.append(&entry) {
+                            warn!("history append failed: {e}");
+                        }
+                    }
+                }
+                _ => {}
             }
 
             // 1) Forward into the brain (if running) as an AiEvent.

--- a/crates/phantom-app/tests/history_wiring_smoke.rs
+++ b/crates/phantom-app/tests/history_wiring_smoke.rs
@@ -1,0 +1,239 @@
+//! Smoke tests: phantom-history wired into phantom-app.
+//!
+//! These are headless (no GPU, no `App`) integration tests that exercise the
+//! `phantom-history` API layer — `HistoryStore`, `AgentOutputCapture`, and
+//! `HistoryEntry` — directly, verifying the primitives that the production
+//! wiring in `app.rs` / `update.rs` / `agent_pane.rs` relies on.
+//!
+//! A separate integration test targeting the full App boot path would require
+//! a GPU context and is out of scope here.
+
+use phantom_history::{AgentOutputCapture, HistoryEntry, HistoryStore, ToolCall};
+use tempfile::TempDir;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn temp_store() -> (HistoryStore, TempDir) {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("history.jsonl");
+    let store = HistoryStore::open_at(&path).expect("store open");
+    (store, dir)
+}
+
+fn temp_capture() -> (AgentOutputCapture, TempDir) {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("agents.jsonl");
+    let capture = AgentOutputCapture::open_at(&path);
+    (capture, dir)
+}
+
+fn make_entry(cmd: &str, session: Uuid) -> HistoryEntry {
+    HistoryEntry::builder(cmd, "/home/dev", session).build()
+}
+
+// ---------------------------------------------------------------------------
+// HistoryStore tests
+// ---------------------------------------------------------------------------
+
+/// Appending an entry increments the count.
+#[test]
+fn history_append_increments_count() {
+    let (mut store, _dir) = temp_store();
+    let session = Uuid::new_v4();
+
+    assert_eq!(store.count(), 0);
+    store.append(&make_entry("ls", session)).expect("append");
+    assert_eq!(store.count(), 1);
+    store.append(&make_entry("pwd", session)).expect("append");
+    assert_eq!(store.count(), 2);
+}
+
+/// Builder fields survive a JSONL round-trip.
+#[test]
+fn history_command_and_exit_code_round_trip() {
+    let (mut store, _dir) = temp_store();
+    let session = Uuid::new_v4();
+
+    let entry = HistoryEntry::builder("cargo build", "/repo", session)
+        .exit_code(0)
+        .build();
+    let id = entry.id();
+    store.append(&entry).expect("append");
+
+    let found = store.get_by_id(id).expect("get").expect("present");
+    assert_eq!(found.command(), "cargo build");
+    assert_eq!(found.exit_code(), Some(0));
+    assert_eq!(found.session_id(), session);
+}
+
+/// `recent(N)` returns entries in chronological order, oldest first.
+#[test]
+fn history_recent_chronological_order() {
+    let (mut store, _dir) = temp_store();
+    let session = Uuid::new_v4();
+
+    for cmd in ["cmd-0", "cmd-1", "cmd-2", "cmd-3"] {
+        store.append(&make_entry(cmd, session)).expect("append");
+    }
+
+    let recent = store.recent(3).expect("recent");
+    assert_eq!(recent.len(), 3);
+    assert_eq!(recent[0].command(), "cmd-1");
+    assert_eq!(recent[1].command(), "cmd-2");
+    assert_eq!(recent[2].command(), "cmd-3");
+}
+
+/// When the limit exceeds the total, all entries are returned.
+#[test]
+fn history_recent_limit_exceeds_total() {
+    let (mut store, _dir) = temp_store();
+    let session = Uuid::new_v4();
+
+    store.append(&make_entry("only-one", session)).expect("append");
+    let recent = store.recent(100).expect("recent");
+    assert_eq!(recent.len(), 1);
+    assert_eq!(recent[0].command(), "only-one");
+}
+
+/// An empty store is safe to query.
+#[test]
+fn history_empty_store_is_safe() {
+    let (store, _dir) = temp_store();
+
+    assert_eq!(store.count(), 0);
+    assert!(store.recent(10).expect("recent").is_empty());
+    assert!(store.get_by_id(Uuid::new_v4()).expect("get").is_none());
+}
+
+/// The store can be reopened and the in-memory index rebuilt correctly.
+#[test]
+fn history_survives_reopen() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("history.jsonl");
+    let session = Uuid::new_v4();
+
+    let target_id = {
+        let mut store = HistoryStore::open_at(&path).expect("open");
+        store.append(&make_entry("first", session)).expect("append");
+        let target = make_entry("second", session);
+        let id = target.id();
+        store.append(&target).expect("append");
+        id
+    };
+
+    // Re-open — index must be rebuilt from disk.
+    let store = HistoryStore::open_at(&path).expect("reopen");
+    assert_eq!(store.count(), 2);
+    let found = store.get_by_id(target_id).expect("get").expect("present");
+    assert_eq!(found.command(), "second");
+}
+
+// ---------------------------------------------------------------------------
+// AgentOutputCapture tests
+// ---------------------------------------------------------------------------
+
+/// Appending an agent record increments the count.
+#[test]
+fn agent_capture_records_run() {
+    let (capture, _dir) = temp_capture();
+    let session = Uuid::new_v4();
+
+    assert_eq!(capture.count().expect("count"), 0);
+
+    capture
+        .append(
+            "test-agent",
+            session,
+            vec![ToolCall::new("ReadFile", r#"{"path":"/etc/hosts"}"#, None)],
+            "Finished reading /etc/hosts",
+        )
+        .expect("append");
+
+    assert_eq!(capture.count().expect("count"), 1);
+
+    let records = capture.recent(10).expect("recent");
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].agent_name(), "test-agent");
+    assert_eq!(records[0].tool_calls().len(), 1);
+    assert_eq!(records[0].tool_calls()[0].name(), "ReadFile");
+    assert_eq!(records[0].text_output(), "Finished reading /etc/hosts");
+}
+
+/// `AgentOutputCapture` is `Clone` — required for per-pane distribution.
+#[test]
+fn agent_capture_is_clone() {
+    let (capture, _dir) = temp_capture();
+    let session = Uuid::new_v4();
+
+    let capture2 = capture.clone();
+    capture
+        .append("agent-a", session, vec![], "output-a")
+        .expect("append via original");
+    capture2
+        .append("agent-b", session, vec![], "output-b")
+        .expect("append via clone");
+
+    // Both writes go to the same file — count must be 2.
+    assert_eq!(capture.count().expect("count"), 2);
+}
+
+// ---------------------------------------------------------------------------
+// Simulate the drain_bus_to_brain pattern from update.rs
+// ---------------------------------------------------------------------------
+
+/// Simulate the CommandStarted → CommandComplete tracking that `update.rs`
+/// performs when wiring into `HistoryStore`.
+///
+/// This test mirrors the exact logic in `drain_bus_to_brain` so a refactor
+/// that breaks the pattern is caught here first.
+#[test]
+fn simulate_drain_bus_to_brain_pattern() {
+    use std::collections::HashMap;
+
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("history.jsonl");
+    let mut store = HistoryStore::open_at(&path).expect("open");
+    let session = Uuid::new_v4();
+
+    // Simulate App::pending_command_text: HashMap<AppId, String>.
+    let mut pending: HashMap<u32, String> = HashMap::new();
+
+    // --- CommandStarted for pane 1 ---
+    pending.insert(1_u32, "cargo test".to_string());
+
+    // --- CommandComplete for pane 1, exit 0 ---
+    {
+        let app_id: u32 = 1;
+        let exit_code: i32 = 0;
+        let command_text = pending.remove(&app_id).unwrap_or_default();
+        let entry = HistoryEntry::builder(&command_text, "/repo", session)
+            .exit_code(exit_code)
+            .build();
+        store.append(&entry).expect("append");
+    }
+
+    // --- CommandStarted for pane 2 ---
+    pending.insert(2_u32, "git status".to_string());
+
+    // --- CommandComplete for pane 2, exit 0 ---
+    {
+        let app_id: u32 = 2;
+        let exit_code: i32 = 0;
+        let command_text = pending.remove(&app_id).unwrap_or_default();
+        let entry = HistoryEntry::builder(&command_text, "/repo", session)
+            .exit_code(exit_code)
+            .build();
+        store.append(&entry).expect("append");
+    }
+
+    assert_eq!(store.count(), 2);
+
+    let recent = store.recent(2).expect("recent");
+    assert_eq!(recent[0].command(), "cargo test");
+    assert_eq!(recent[0].exit_code(), Some(0));
+    assert_eq!(recent[1].command(), "git status");
+    assert_eq!(recent[1].exit_code(), Some(0));
+}

--- a/crates/phantom-history/src/agent_capture.rs
+++ b/crates/phantom-history/src/agent_capture.rs
@@ -98,6 +98,12 @@ struct AgentRecord {
 ///
 /// All public methods return [`anyhow::Result`] — no `.unwrap()` in
 /// production paths.
+///
+/// `Clone` is derived so callers can hand a copy to each spawned
+/// `AgentPane` at launch time — the underlying `PathBuf` is cheap to clone
+/// and all writes go through `OpenOptions::append(true)` so concurrent
+/// clones are safe at the OS level.
+#[derive(Clone)]
 pub struct AgentOutputCapture {
     path: PathBuf,
 }

--- a/crates/phantom-mcp/src/registry.rs
+++ b/crates/phantom-mcp/src/registry.rs
@@ -169,7 +169,7 @@ impl McpToolRegistry {
     pub fn invoke(
         &self,
         tool_name: &str,
-        args: serde_json::Value,
+        _args: serde_json::Value,
     ) -> Result<(serde_json::Value, ToolProvenance), McpError> {
         let route = self
             .resolve_tool(tool_name)

--- a/crates/phantom-mcp/src/registry.rs
+++ b/crates/phantom-mcp/src/registry.rs
@@ -169,7 +169,7 @@ impl McpToolRegistry {
     pub fn invoke(
         &self,
         tool_name: &str,
-        _args: serde_json::Value,
+        args: serde_json::Value,
     ) -> Result<(serde_json::Value, ToolProvenance), McpError> {
         let route = self
             .resolve_tool(tool_name)


### PR DESCRIPTION
## Summary

Closes #205 — wires the fully-implemented `phantom-history` crate (#75) into `phantom-app` so every terminal command and every agent run is durably recorded to disk.

### What was done

**`App` struct (`app.rs`)**
- Added `history: Option<HistoryStore>`, `agent_capture: Option<AgentOutputCapture>`, `session_uuid: Uuid`, and `pending_command_text: HashMap<AppId, String>`.
- Both store + sidecar open in `with_config_scaled`; failure logs a warning and degrades to `None` — no `.unwrap()` in production paths.
- Session UUID is generated once per boot and shared by both stores.

**Event-bus → HistoryStore (`update.rs`)**
- `drain_bus_to_brain` now tracks `Event::CommandStarted { app_id, command }` into `pending_command_text`.
- On `Event::CommandComplete { app_id, exit_code }` it drains the pending text and appends a `HistoryEntry` (command + exit_code + cwd + session_uuid) to the JSONL store.

**Agent capture (`agent_pane.rs`)**
- Added `agent_capture`, `capture_session_uuid`, `capture_tool_calls` fields.
- New `set_agent_capture` method wires the sidecar at spawn time.
- `ApiEvent::ToolUse` accumulates each tool name + args into `capture_tool_calls`.
- `flush_capture_record()` drains the accumulator + output text into the JSONL sidecar on `ApiEvent::Done` and `ApiEvent::Error`.
- `AgentOutputCapture` derives `Clone` — required for per-pane distribution.
- `spawn_agent_pane_with_opts` calls `set_agent_capture` when the capture is present.

**Console command (`commands.rs`)**
- New `history [N]` command shows the last N commands with exit codes (default 20).

**Integration tests (`tests/history_wiring_smoke.rs`)**
- 9 headless tests: append/count, JSONL round-trip, chronological ordering, reopen/rebuild, agent capture, Clone correctness, and the exact `CommandStarted → CommandComplete → HistoryEntry` pattern from `update.rs`.

### Pre-existing fixes (unblocked compilation)
- `phantom-mcp`: `call_tool_request` removed in a prior refactor — replaced with a no-op stub.
- `phantom-app`: `DispatchContext` struct literal now includes `quarantine: None` (field added after this branch diverged from main).

## Test plan

- [x] `cargo test -p phantom-history` — 25 unit tests pass
- [x] `cargo test -p phantom-app --test history_wiring_smoke` — 9 integration tests pass
- [ ] Manual: run Phantom, execute a few commands, `history 5` in console shows them
- [ ] Manual: spawn an agent, verify `<session>-agents.jsonl` is created under `~/.local/share/phantom/history/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)