### PR TITLE
fix(#103): populate source_chain in CapabilityDenied events (Sec.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5428,6 +5428,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "log",
+ "phantom-adapter",
  "phantom-agents",
  "phantom-context",
  "phantom-history",

--- a/crates/phantom-agents/src/agent.rs
+++ b/crates/phantom-agents/src/agent.rs
@@ -176,6 +176,7 @@ pub struct Agent {
     id: AgentId,
     /// The task this agent was spawned to perform.
     task: AgentTask,
+    #[allow(dead_code)] // Intent classification — read by tests; production use comes with Sec.8+ disposition routing.
     disposition: Disposition,
     /// Current lifecycle status.
     status: AgentStatus,

--- a/crates/phantom-agents/src/dispatch.rs
+++ b/crates/phantom-agents/src/dispatch.rs
@@ -336,6 +336,59 @@ fn taint_from_source_chain(
     accumulated
 }
 
+/// Walk the `source_event_id` chain in `log` starting from `start_id` and
+/// return the ordered list of event IDs encountered, including `start_id`
+/// itself.
+///
+/// The list is ordered from `start_id` to the earliest ancestor reachable
+/// through the chain. The walk terminates when:
+/// - an event ID is not found in the in-memory tail (scrolled out), or
+/// - a cycle is detected (the same ID would be visited twice).
+///
+/// This is the Sec.2 counterpart to [`taint_from_source_chain`]: instead of
+/// accumulating taint it collects the provenance chain that is stored in
+/// `EventKind::CapabilityDenied::source_chain`.
+///
+/// # Locking
+///
+/// Takes `log` once to snapshot the tail; no lock is held during the walk.
+pub fn collect_source_chain(start_id: u64, log: &Arc<Mutex<EventLog>>) -> Vec<u64> {
+    // Snapshot the in-memory tail once — avoids repeated locking in the walk.
+    let tail = {
+        let Ok(guard) = log.lock() else {
+            return vec![start_id];
+        };
+        guard.tail(usize::MAX)
+    };
+
+    // Build a lookup table: event_id → envelope for O(1) chain hops.
+    let by_id: std::collections::HashMap<u64, &phantom_memory::event_log::EventEnvelope> =
+        tail.iter().map(|e| (e.id, e)).collect();
+
+    let mut chain: Vec<u64> = Vec::new();
+    let mut visited: std::collections::HashSet<u64> = std::collections::HashSet::new();
+    let mut cursor: Option<u64> = Some(start_id);
+
+    while let Some(id) = cursor {
+        // Cycle guard: if we've already visited this ID, stop walking.
+        if !visited.insert(id) {
+            break;
+        }
+        chain.push(id);
+        let Some(ev) = by_id.get(&id) else {
+            // Event has scrolled out of the tail — stop walking.
+            break;
+        };
+        // Follow the chain link stored in the event payload.
+        cursor = ev
+            .payload
+            .get("source_event_id")
+            .and_then(|v| v.as_u64());
+    }
+
+    chain
+}
+
 /// Extract the originating agent id from an [`EventEnvelope`], if present.
 ///
 /// Events emitted by agents carry `source: Agent { id }`. We also check a
@@ -1927,5 +1980,125 @@ mod tests {
                   Disposition::Decompose, Disposition::Audit] {
             assert_eq!(d.runs_hooks(), d.creates_branch());
         }
+    }
+
+    // ---- Sec.2: collect_source_chain -----------------------------------------
+
+    /// Helper: write a minimal event envelope to `log` and return its assigned
+    /// id. The optional `source_event_id` value is embedded in the payload so
+    /// `collect_source_chain` can follow the chain link.
+    fn push_event_with_source(
+        log: &Arc<Mutex<EventLog>>,
+        kind: &str,
+        source_event_id: Option<u64>,
+    ) -> u64 {
+        use phantom_memory::event_log::EventSource as LogEventSource;
+        let mut payload = serde_json::json!({});
+        if let Some(id) = source_event_id {
+            payload["source_event_id"] = serde_json::json!(id);
+        }
+        log.lock()
+            .unwrap()
+            .append(LogEventSource::Substrate, kind, payload)
+            .unwrap()
+            .id
+    }
+
+    /// A 3-event chain A -> B -> C (C triggered by B, B triggered by A) must
+    /// produce [C_id, B_id, A_id] — i.e. from the leaf to the root.
+    #[test]
+    fn source_chain_collects_full_causal_path() {
+        let tmp = TempDir::new().unwrap();
+        let log = Arc::new(Mutex::new(
+            EventLog::open(&tmp.path().join("ev.jsonl")).unwrap(),
+        ));
+
+        let a_id = push_event_with_source(&log, "root.event", None);
+        let b_id = push_event_with_source(&log, "middle.event", Some(a_id));
+        let c_id = push_event_with_source(&log, "leaf.event", Some(b_id));
+
+        let chain = collect_source_chain(c_id, &log);
+
+        assert_eq!(
+            chain,
+            vec![c_id, b_id, a_id],
+            "chain must traverse C -> B -> A, got {chain:?}"
+        );
+    }
+
+    /// A root event with no `source_event_id` in its payload must produce a
+    /// single-element chain containing only its own ID.
+    #[test]
+    fn source_chain_root_event_returns_single_element_chain() {
+        let tmp = TempDir::new().unwrap();
+        let log = Arc::new(Mutex::new(
+            EventLog::open(&tmp.path().join("ev.jsonl")).unwrap(),
+        ));
+
+        let root_id = push_event_with_source(&log, "standalone.event", None);
+
+        let chain = collect_source_chain(root_id, &log);
+
+        assert_eq!(
+            chain,
+            vec![root_id],
+            "single root event must yield [root_id], got {chain:?}"
+        );
+    }
+
+    /// A self-referential event (source_event_id == own id) must not loop:
+    /// the cycle guard must terminate the walk after visiting the ID once.
+    #[test]
+    fn source_chain_self_referential_event_does_not_loop() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("ev.jsonl");
+
+        let log = Arc::new(Mutex::new(EventLog::open(&path).unwrap()));
+
+        // Step 1: write a normal event to get an id.
+        let placeholder_id = push_event_with_source(&log, "placeholder", None);
+        // The next id will be placeholder_id + 1. Write an event whose
+        // source_event_id points to its own id (the +1 slot).
+        let self_id = placeholder_id + 1;
+        {
+            use phantom_memory::event_log::EventSource as LogEventSource;
+            let payload = serde_json::json!({ "source_event_id": self_id });
+            log.lock()
+                .unwrap()
+                .append(LogEventSource::Substrate, "self.ref", payload)
+                .unwrap();
+        }
+
+        let chain = collect_source_chain(self_id, &log);
+
+        assert_eq!(
+            chain,
+            vec![self_id],
+            "self-referential event must yield [self_id], got {chain:?}"
+        );
+    }
+
+    /// `collect_source_chain` must traverse the same path as a manual walk
+    /// of `source_event_id` payload links. A 4-node chain is used to cover
+    /// more hops than the basic 3-node test.
+    #[test]
+    fn collect_source_chain_matches_source_event_id_traversal() {
+        let tmp = TempDir::new().unwrap();
+        let log = Arc::new(Mutex::new(
+            EventLog::open(&tmp.path().join("ev.jsonl")).unwrap(),
+        ));
+
+        let e1 = push_event_with_source(&log, "ev1", None);
+        let e2 = push_event_with_source(&log, "ev2", Some(e1));
+        let e3 = push_event_with_source(&log, "ev3", Some(e2));
+        let e4 = push_event_with_source(&log, "ev4", Some(e3));
+
+        let chain = collect_source_chain(e4, &log);
+
+        assert_eq!(
+            chain,
+            vec![e4, e3, e2, e1],
+            "4-node chain must traverse e4 -> e3 -> e2 -> e1, got {chain:?}"
+        );
     }
 }

--- a/crates/phantom-app/src/agent_pane.rs
+++ b/crates/phantom-app/src/agent_pane.rs
@@ -128,16 +128,14 @@ fn build_capability_denied_payload(
     attempted_class: CapabilityClass,
     attempted_tool: &str,
     denied_at_unix_ms: u64,
+    source_chain: &[u64],
 ) -> serde_json::Value {
-    let source_chain: Vec<u64> = Vec::new();
     serde_json::json!({
         "agent_id": agent_id,
         "agent_role": agent_role,
         "attempted_class": class_label(attempted_class),
         "attempted_tool": attempted_tool,
         "denied_at_unix_ms": denied_at_unix_ms,
-        // Sec.2 will fill source_chain; we serialize the empty Vec so the
-        // shape is stable.
         "source_chain": source_chain,
     })
 }
@@ -903,6 +901,10 @@ impl AgentPane {
                     None,
                 )
             };
+            // Capture source_event_id before dropping the dispatch context —
+            // needed for Sec.2 provenance wiring in maybe_emit_capability_denied_event.
+            let dispatch_source_event_id: Option<u64> =
+                dispatch_ctx.as_ref().and_then(|c| c.source_event_id);
             // Drop the dispatch context borrow before mutating `self` below.
             drop(dispatch_ctx);
             let elapsed = start.elapsed();
@@ -935,14 +937,16 @@ impl AgentPane {
                 ));
             }
 
-            // Sec.1 capability-denial instrumentation: when the dispatch
+            // Sec.1/2 capability-denial instrumentation: when the dispatch
             // gate refused the call, surface a `CapabilityDenied` substrate
-            // event + matching audit-log entry before the per-result loop
-            // continues. The check is keyed on the canonical
-            // `"capability denied: …"` prefix so we catch denials from both
-            // `execute_tool` and `dispatch_tool` without coupling to the
-            // DispatchError type.
-            self.maybe_emit_capability_denied_event(call.tool, &call.args, &result, None);
+            // event + matching audit-log entry. Sec.2 populates source_chain
+            // via dispatch_source_event_id when the event log is wired.
+            self.maybe_emit_capability_denied_event(
+                call.tool,
+                &call.args,
+                &result,
+                dispatch_source_event_id,
+            );
 
             // Lars fix-thread instrumentation (Phase 2.E producer).
             //
@@ -1086,14 +1090,15 @@ impl AgentPane {
     /// with [`AuditOutcome::Denied`] so the on-disk audit trail and the
     /// substrate event log carry matching denial signals.
     ///
-    /// `source_chain` is empty until Sec.2 wires per-call provenance.
+    /// `source_chain` is populated when `source_event_id` is `Some` and the
+    /// event log is wired; otherwise it is empty (Sec.2 wiring).
     /// No-op when the sink isn't wired (test / legacy paths).
     fn maybe_emit_capability_denied_event(
         &self,
         tool: ToolType,
         args: &serde_json::Value,
         result: &ToolResult,
-        _source_event_id: Option<u64>,
+        source_event_id: Option<u64>,
     ) {
         // The dispatch gate's denial message is a contract: we match on the
         // exact prefix the model sees. This keeps us in sync with the
@@ -1124,12 +1129,21 @@ impl AgentPane {
             return;
         };
 
+        // Sec.2: walk the event-log chain to collect provenance IDs.
+        let source_chain: Vec<u64> =
+            if let (Some(start_id), Some(log)) = (source_event_id, self.event_log.as_ref()) {
+                phantom_agents::dispatch::collect_source_chain(start_id, log)
+            } else {
+                Vec::new()
+            };
+
         let payload = build_capability_denied_payload(
             agent_id,
             role.label(),
             attempted_class,
             &attempted_tool,
             now_unix_ms(),
+            &source_chain,
         );
 
         let event = SubstrateEvent {
@@ -1138,7 +1152,7 @@ impl AgentPane {
                 role,
                 attempted_class,
                 attempted_tool,
-                source_chain: Vec::new(),
+                source_chain,
             },
             payload,
             source: EventSource::Agent { role },
@@ -2223,7 +2237,7 @@ mod tests {
                 assert_eq!(attempted_tool, "run_command");
                 assert!(
                     source_chain.is_empty(),
-                    "Sec.1 emits empty source_chain; Sec.2 will populate it"
+                    "root-level denial must have empty source_chain (no event log wired)"
                 );
             }
             other => panic!("expected CapabilityDenied, got {other:?}"),


### PR DESCRIPTION
## Summary

Closes #103 — `CapabilityDenied` always emitted `source_chain: []`.

- Added `pub fn collect_source_chain(start_id, log) -> Vec<u64>` to `phantom-agents::dispatch`. It walks the `source_event_id` chain in the `EventLog` tail from the given start ID, returning ancestor event IDs in traversal order (leaf → root), with cycle detection.
- Updated `agent_pane::maybe_emit_capability_denied_event` to accept a new `source_event_id: Option<u64>` parameter. When `Some` and the event log is wired, the chain is collected via `collect_source_chain` and placed in both `EventKind::CapabilityDenied::source_chain` and the serialized payload's `"source_chain"` field.
- Updated `build_capability_denied_payload` to accept `source_chain: &[u64]` instead of hard-coding `Vec::new()`.
- Captured `dispatch_source_event_id` from `DispatchContext` before dropping the context borrow in `execute_pending_tools`, and threaded it through to the denial hook.

## Tests

Four new TDD tests in `dispatch::tests`:
- `source_chain_collects_full_causal_path` — 3-event chain A→B→C → `[C, B, A]`
- `source_chain_root_event_returns_single_element_chain` — no upstream → `[root]`
- `source_chain_self_referential_event_does_not_loop` — cycle guard terminates
- `collect_source_chain_matches_source_event_id_traversal` — 4-node exact order

All 552 `phantom-agents` lib tests pass. `phantom-app` compiles clean.

## Test plan

- [x] `cargo test -p phantom-agents --lib` — 552 passed, 0 failed
- [x] `cargo check -p phantom-app` — no errors
- [x] Four new `dispatch::tests::source_chain_*` / `collect_source_chain_*` tests all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)