### PR TITLE
fix: unify AgentId as u64 across QuarantineRegistry and reconciler (closes #273)

### DIFF
--- a/crates/phantom-agents/src/agent.rs
+++ b/crates/phantom-agents/src/agent.rs
@@ -17,7 +17,11 @@ use crate::tools::{ToolCall, ToolResult};
 // ---------------------------------------------------------------------------
 
 /// Unique agent identifier (monotonically increasing within a session).
-pub type AgentId = u32;
+///
+/// Widened to `u64` (matches [`crate::role::AgentId`] and
+/// [`crate::quarantine::QuarantineRegistry`]) so no narrowing cast is required
+/// at the dispatch / quarantine boundary. Fixes issue #273.
+pub type AgentId = u64;
 
 // ---------------------------------------------------------------------------
 // AgentStatus

--- a/crates/phantom-agents/src/failure_store.rs
+++ b/crates/phantom-agents/src/failure_store.rs
@@ -245,7 +245,7 @@ mod tests {
             1,
         ));
 
-        for i in 1u32..=100 {
+        for i in 1u64..=100 {
             store.push(make_record(i, "bulk", 1));
         }
 
@@ -341,7 +341,7 @@ mod tests {
         let mut store = FailureStore::new();
 
         // Fill to capacity.
-        for i in 0u32..100 {
+        for i in 0u64..100 {
             store.push(make_record(i, &format!("err-{i}"), 1));
         }
 

--- a/crates/phantom-app/src/adapters/agent.rs
+++ b/crates/phantom-app/src/adapters/agent.rs
@@ -136,7 +136,7 @@ impl AppCore for AgentAdapter {
                     topic_id: 0,
                     sender: self.app_id,
                     event: phantom_protocol::Event::AgentTaskComplete {
-                        agent_id: self.app_id,
+                        agent_id: u64::from(self.app_id),
                         success,
                         summary,
                         spawn_tag: self.spawn_tag,

--- a/crates/phantom-app/src/agent_pane.rs
+++ b/crates/phantom-app/src/agent_pane.rs
@@ -533,10 +533,10 @@ impl AgentPane {
 
         info!("Agent pane spawned: {task_desc}");
 
-        let agent_id_u64 = agent.id() as u64;
-        let mut journal = open_agent_journal(agent_id_u64);
+        let agent_id = agent.id();
+        let mut journal = open_agent_journal(agent_id);
         if let Some(ref mut j) = journal {
-            if let Err(e) = j.record_spawn(agent_id_u64, &task_desc) {
+            if let Err(e) = j.record_spawn(agent_id, &task_desc) {
                 warn!("AgentJournal::record_spawn failed: {e}");
             }
         }
@@ -1060,7 +1060,7 @@ impl AgentPane {
         let role = self.role;
         let event = SubstrateEvent {
             kind: EventKind::AgentBlocked {
-                agent_id: self.agent.id() as u64,
+                agent_id: self.agent.id(),
                 reason: reason.clone(),
             },
             payload,
@@ -1109,7 +1109,7 @@ impl AgentPane {
 
         let attempted_class = tool.capability_class();
         let attempted_tool = tool.api_name().to_string();
-        let agent_id = self.agent.id() as u64;
+        let agent_id = self.agent.id();
         let role = self.role;
 
         // Audit-side record (always emitted regardless of whether a sink
@@ -1556,7 +1556,8 @@ impl App {
         // runtime's `Arc<Mutex<…>>` registry + event log and a clone of the
         // App's `pending_spawn_subagent` queue. The `AgentRef` is stamped
         // with a fresh id (currently 0 — the agent module's `AgentId` is a
-        // `u32` per-session counter) and the default
+        // `u64` per-session counter, unified with QuarantineRegistry, fixes #273)
+        // and the default
         // [`DEFAULT_AGENT_PANE_ROLE`]; when the next phase wires Composer
         // panes through this path the role override will live on
         // [`AgentSpawnOpts`].
@@ -2094,7 +2095,7 @@ mod tests {
         // Kind invariant.
         match &ev.kind {
             phantom_agents::spawn_rules::EventKind::AgentBlocked { agent_id, reason } => {
-                assert_eq!(*agent_id as u64, 0u64); // test_agent has id 0
+                assert_eq!(*agent_id, 0u64); // test_agent has id 0
                 assert!(
                     reason.contains("consecutive tool failures"),
                     "reason should mention the streak; got '{reason}'",

--- a/crates/phantom-brain/src/brain.rs
+++ b/crates/phantom-brain/src/brain.rs
@@ -1085,7 +1085,7 @@ mod tests {
         let (action_tx, action_rx) = std::sync::mpsc::channel::<AiAction>();
         let mut denial_counters: std::collections::HashMap<phantom_agents::AgentId, usize> =
             std::collections::HashMap::new();
-        let agent_id = 200u32;
+        let agent_id = 200u64;
 
         // Simulate brain handling 2 CapabilityDenied events.
         for i in 1u32..=2 {
@@ -1122,7 +1122,7 @@ mod tests {
         let (action_tx, action_rx) = std::sync::mpsc::channel::<AiAction>();
         let mut denial_counters: std::collections::HashMap<phantom_agents::AgentId, usize> =
             std::collections::HashMap::new();
-        let agent_id = 201u32;
+        let agent_id = 201u64;
 
         // Simulate 3 consecutive CapabilityDenied events.
         for _ in 1u32..=3 {

--- a/crates/phantom-brain/src/orchestrator.rs
+++ b/crates/phantom-brain/src/orchestrator.rs
@@ -102,7 +102,10 @@ pub struct PlanStep {
     /// Current execution status.
     pub status: StepStatus,
     /// The agent ID if one has been spawned for this step.
-    pub agent_id: Option<u32>,
+    ///
+    /// Stored as `u64` to match [`phantom_agents::AgentId`] (fixes #273 — no
+    /// narrowing cast required at the reconciler / quarantine boundary).
+    pub agent_id: Option<u64>,
     /// Number of times this step has been attempted (for retry tracking).
     pub attempts: u32,
     /// Maximum attempts before marking as Failed.

--- a/crates/phantom-brain/src/reconciler.rs
+++ b/crates/phantom-brain/src/reconciler.rs
@@ -56,10 +56,10 @@ pub struct ReconcilerState {
     active_dispatches: HashMap<usize, (AgentId, Instant)>,
     /// Monotonically increasing agent ID namespace for reconciler-dispatched
     /// agents. Starts high to avoid collision with AgentManager's IDs.
-    /// Stored as `u64` to guarantee no silent wraparound on long-running
-    /// sessions (#221). Narrowed to `AgentId` (`u32`) via
-    /// `u32::try_from(...).unwrap_or(u32::MAX)` at dispatch time (#272).
-    next_agent_id: u64,
+    ///
+    /// `AgentId` is now `u64` workspace-wide (fixes #273), so this field is
+    /// the same type and no narrowing cast is required at dispatch time.
+    next_agent_id: AgentId,
     /// Configurable stall timeout (overrideable in tests).
     pub stall_timeout: Duration,
 }
@@ -163,7 +163,7 @@ impl ReconcilerState {
         let idx = match self
             .active_dispatches
             .iter()
-            .find(|&(_, &(stored_id, _))| stored_id as u64 == tag)
+            .find(|&(_, &(stored_id, _))| stored_id == tag)
             .map(|(&idx, _)| idx)
         {
             Some(i) => i,
@@ -228,24 +228,21 @@ impl ReconcilerState {
             .collect();
 
         for (idx, task, description) in eligible {
-            let agent_id: u64 = self.next_agent_id;
+            let agent_id: AgentId = self.next_agent_id;
             self.next_agent_id = self
                 .next_agent_id
                 .checked_add(1)
                 .expect("reconciler next_agent_id overflowed u64 — unreachable in practice");
-            let agent_id_u32 = u32::try_from(agent_id).unwrap_or(u32::MAX);
 
             // Advance step to Active before emitting SpawnAgent so that a
             // synchronous ledger inspection sees the correct state.
-            // `agent_id` fits in u32 for the ledger field; saturate rather
-            // than truncate so corrupt IDs are visible (#221, #272).
             if let Some(s) = ledger.plan.get_mut(idx) {
                 s.status = StepStatus::Active;
-                s.agent_id = Some(agent_id_u32);
+                s.agent_id = Some(agent_id);
                 s.attempts += 1;
             }
 
-            self.active_dispatches.insert(idx, (agent_id_u32, Instant::now()));
+            self.active_dispatches.insert(idx, (agent_id, Instant::now()));
 
             log::info!(
                 "Reconciler: dispatching step {idx} (agent_id={agent_id}) — {description}"
@@ -286,7 +283,7 @@ impl ReconcilerState {
                         "Reconciler: step {idx} stalled and exhausted retries (agent_id={agent_id}) — {description}"
                     );
                     let _ = action_tx.send(AiAction::AgentFlatlined {
-                        id: agent_id as u32,
+                        id: agent_id,
                         reason: format!(
                             "step '{description}' stalled after {} attempts",
                             step.max_attempts
@@ -497,7 +494,7 @@ mod tests {
         let (&idx, &(stored_id, _)) = state.active_dispatches.iter().next()
             .expect("active_dispatches must have one entry");
         assert_eq!(idx, 0, "step 0 should be active");
-        assert_eq!(tag, stored_id as u64, "spawn_tag must match stored synthetic id");
+        assert_eq!(tag, stored_id, "spawn_tag must match stored synthetic id");
     }
 
     /// `on_agent_complete` must route by `spawn_tag`, not by sequential
@@ -840,24 +837,27 @@ mod tests {
         assert_eq!(state.active_dispatches.len(), 1, "dispatch count must not grow");
     }
 
-    // -- Issue #272: agent_id u64 → u32 saturating cast ---------------------------
+    // -- Issue #273: AgentId unified as u64 — no narrowing cast at dispatch --------
 
-    /// When `next_agent_id` is at `u32::MAX as u64 + 1` (i.e. it has overflowed
-    /// the u32 range), `dispatch_pending` must saturate to `u32::MAX` in
-    /// `active_dispatches` rather than silently truncating to 0.
+    /// Agent IDs above `u32::MAX` must survive the dispatch/complete round-trip
+    /// without any narrowing or saturation. Since `AgentId` is now `u64`
+    /// workspace-wide (fixes #273), the full value is stored in
+    /// `active_dispatches`, stamped into `PlanStep::agent_id`, and echoed back
+    /// in `spawn_tag` with no conversion at any boundary.
     ///
-    /// The `spawn_tag` on the emitted `SpawnAgent` action carries the full u64
-    /// value so `on_agent_complete` can still match the step correctly via
-    /// exact tag comparison.
+    /// Previously this range required a saturating cast to `u32::MAX`. That
+    /// cast is now gone — callers pass IDs above `u32::MAX` and get them back
+    /// unmodified.
     #[test]
-    fn dispatch_pending_agent_id_near_u32_max_uses_saturation() {
+    fn dispatch_pending_agent_id_above_u32_max_survives_roundtrip() {
         let (tx, rx) = mpsc::channel();
-        // Set next_agent_id just above u32::MAX so the first dispatch overflows.
+        // Set next_agent_id just above u32::MAX to exercise the formerly-broken range.
+        let above_u32_max = u32::MAX as u64 + 1;
         let mut state = ReconcilerState {
-            next_agent_id: u32::MAX as u64 + 1,
+            next_agent_id: above_u32_max,
             ..ReconcilerState::new()
         };
-        let mut ledger = make_ledger(&["overflow step"]);
+        let mut ledger = make_ledger(&["high-id step"]);
 
         state.tick(&mut ledger, &tx);
 
@@ -867,11 +867,14 @@ mod tests {
             panic!("expected SpawnAgent variant");
         };
 
-        // spawn_tag carries the full u64 value (u32::MAX + 1).
+        // spawn_tag carries the full u64 value — no narrowing.
         let tag = spawn_tag.expect("spawn_tag must be Some");
-        assert_eq!(tag, u32::MAX as u64 + 1, "spawn_tag must be the raw u64 counter value");
+        assert_eq!(
+            tag, above_u32_max,
+            "spawn_tag must preserve the full u64 agent ID (fixes #273)"
+        );
 
-        // The stored AgentId in active_dispatches must be u32::MAX (saturated), not 0.
+        // active_dispatches also stores the full u64 — no saturation to u32::MAX.
         let &(stored_id, _) = state
             .active_dispatches
             .values()
@@ -879,8 +882,15 @@ mod tests {
             .expect("active_dispatches must have one entry");
         assert_eq!(
             stored_id,
-            u32::MAX,
-            "active_dispatches must store u32::MAX (saturated), not 0 (truncated)"
+            above_u32_max,
+            "active_dispatches must store the raw u64 agent ID, not a saturated u32 (fixes #273)"
+        );
+
+        // PlanStep::agent_id must also hold the full value.
+        assert_eq!(
+            ledger.plan[0].agent_id,
+            Some(above_u32_max),
+            "PlanStep::agent_id must store the full u64 agent ID (fixes #273)"
         );
     }
 

--- a/crates/phantom-protocol/src/events.rs
+++ b/crates/phantom-protocol/src/events.rs
@@ -7,7 +7,10 @@
 pub type AppId = u32;
 
 /// Unique agent identifier.
-pub type AgentId = u32;
+///
+/// Widened to `u64` to match `phantom_agents::AgentId` (fixes #273 — no
+/// narrowing cast required across the IPC boundary).
+pub type AgentId = u64;
 
 /// Unique session identifier.
 pub type SessionId = u32;

--- a/crates/phantom-session/src/agent_state.rs
+++ b/crates/phantom-session/src/agent_state.rs
@@ -139,7 +139,7 @@ impl SavedMessage {
 /// no longer recognised.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentSnapshot {
-    id: u32,
+    id: u64,
     /// Raw task JSON. Stored as a `Value` so that unknown variants (e.g. from
     /// a snapshot written by a newer binary) do not cause `AgentStateFile::load`
     /// to fail. Use [`AgentSnapshot::task`] to attempt typed deserialization.
@@ -203,7 +203,7 @@ impl AgentSnapshot {
 
     /// The agent's numeric identifier.
     #[must_use]
-    pub fn id(&self) -> u32 {
+    pub fn id(&self) -> u64 {
         self.id
     }
 
@@ -459,7 +459,7 @@ pub enum RestoreOutcome<T> {
     /// The snapshot was present but could not be reconstructed.
     /// The caller should skip this agent but continue with others.
     Skipped {
-        agent_id: u32,
+        agent_id: u64,
         reason: String,
     },
     /// The snapshot was corrupt enough that we couldn't even extract an id.
@@ -517,7 +517,7 @@ mod tests {
     use phantom_agents::tools::{ToolCall, ToolResult, ToolType};
     use tempfile::TempDir;
 
-    fn free_agent(id: u32, prompt: &str) -> Agent {
+    fn free_agent(id: u64, prompt: &str) -> Agent {
         Agent::new(id, AgentTask::FreeForm { prompt: prompt.into() })
     }
 
@@ -817,7 +817,7 @@ mod tests {
 
     #[test]
     fn partial_restore_returns_ok_for_valid_snapshots() {
-        let agents: Vec<AgentSnapshot> = (1u32..=3)
+        let agents: Vec<AgentSnapshot> = (1u64..=3)
             .map(|i| AgentSnapshot::from_agent(&free_agent(i, "task")))
             .collect();
         let file = AgentStateFile::new(agents);

--- a/crates/phantom-session/src/goal_state.rs
+++ b/crates/phantom-session/src/goal_state.rs
@@ -74,7 +74,9 @@ pub struct SavedPlanStep {
     assigned_task: AgentTask,
     status: SavedStepStatus,
     /// The agent id that was handling this step, if any.
-    agent_id: Option<u32>,
+    ///
+    /// Stored as `u64` to match `phantom_agents::AgentId` (fixes #273).
+    agent_id: Option<u64>,
     attempts: u32,
     max_attempts: u32,
     result_summary: Option<String>,
@@ -91,7 +93,7 @@ impl SavedPlanStep {
         description: String,
         assigned_task: AgentTask,
         status: SavedStepStatus,
-        agent_id: Option<u32>,
+        agent_id: Option<u64>,
         attempts: u32,
         max_attempts: u32,
         result_summary: Option<String>,
@@ -125,7 +127,7 @@ impl SavedPlanStep {
     }
 
     #[must_use]
-    pub fn agent_id(&self) -> Option<u32> {
+    pub fn agent_id(&self) -> Option<u64> {
         self.agent_id
     }
 
@@ -537,7 +539,7 @@ pub struct PlanStepBuilder {
     description: String,
     task: AgentTask,
     status: SavedStepStatus,
-    agent_id: Option<u32>,
+    agent_id: Option<u64>,
     attempts: u32,
     max_attempts: u32,
     result_summary: Option<String>,
@@ -564,7 +566,7 @@ impl PlanStepBuilder {
     }
 
     #[must_use]
-    pub fn agent_id(mut self, id: u32) -> Self {
+    pub fn agent_id(mut self, id: u64) -> Self {
         self.agent_id = Some(id);
         self
     }


### PR DESCRIPTION
## Summary

- **Root cause**: `phantom-agents::agent::AgentId` was `u32` while `phantom-agents::role::AgentId` and `QuarantineRegistry` used `u64`, creating a silent cast hazard at every dispatch/quarantine boundary.
- **Fix**: Promote `agent::AgentId` to `u64` and propagate the type throughout the stack. Remove the `u32::try_from(agent_id).unwrap_or(u32::MAX)` saturating cast in `reconciler.rs` (and the `agent_id as u32` cast in `check_stalled`).
- **TDD**: Replaced the old `dispatch_pending_agent_id_near_u32_max_uses_saturation` test (which tested the now-removed cast) with `dispatch_pending_agent_id_above_u32_max_survives_roundtrip` — a correctness test asserting that IDs above `u32::MAX` survive the dispatch/`active_dispatches`/`PlanStep::agent_id` round-trip without narrowing.

## Files changed

| File | Change |
|------|--------|
| `phantom-agents/src/agent.rs` | `AgentId = u64` (was `u32`) |
| `phantom-brain/src/orchestrator.rs` | `PlanStep::agent_id: Option<u64>` |
| `phantom-brain/src/reconciler.rs` | Remove both narrowing casts; rewrite #272 saturation test as #273 round-trip test |
| `phantom-protocol/src/events.rs` | `AgentId = u64` (IPC wire type) |
| `phantom-app/src/adapters/agent.rs` | Widen `app_id` with `u64::from()` at IPC boundary |
| `phantom-app/src/agent_pane.rs` | Remove stale `as u64` casts (now no-ops) |
| `phantom-session/src/agent_state.rs` | `AgentSnapshot::id: u64`, `RestoreOutcome::Skipped::agent_id: u64` |
| `phantom-session/src/goal_state.rs` | `SavedPlanStep::agent_id: Option<u64>`, builder updated |
| `phantom-agents/src/failure_store.rs` | Fix test range literals `u32→u64` |
| `phantom-brain/src/brain.rs` | Fix test literal types `u32→u64` |

## Test plan

- [x] `cargo check --workspace` — clean (no errors)
- [x] `cargo test -p phantom-agents` — 605 tests, 0 failures
- [x] `cargo test -p phantom-brain` — 343 tests, 0 failures
- [x] New test `dispatch_pending_agent_id_above_u32_max_survives_roundtrip` asserts u64 IDs above `u32::MAX` are stored faithfully in `active_dispatches`, `spawn_tag`, and `PlanStep::agent_id`
- [x] No `unwrap()` outside `#[cfg(test)]`
- [x] No bare `pub` fields added

🤖 Generated with [Claude Code](https://claude.com/claude-code)