### PR TITLE
feat: monotonic SequenceClock for memory block ordering (closes #28)

### DIFF
--- a/crates/phantom-memory/src/clock.rs
+++ b/crates/phantom-memory/src/clock.rs
@@ -1,0 +1,125 @@
+//! Monotonically-increasing sequence clock for ordering memory blocks and events.
+//!
+//! [`SequenceClock`] wraps an [`AtomicU64`] and provides a simple
+//! lock-free, thread-safe counter.  Every call to [`SequenceClock::next`]
+//! returns a value strictly greater than the previous call (assuming fewer than
+//! `u64::MAX` total increments, which is safe in practice).
+//!
+//! # Why this exists
+//!
+//! Wall-clock timestamps are subject to NTP skew and monotonic-clock resets
+//! across process restarts.  Sequence numbers have neither problem: they are
+//! deterministically ordered regardless of when or on which thread they were
+//! generated.
+//!
+//! # Usage
+//!
+//! ```rust
+//! use phantom_memory::clock::SequenceClock;
+//!
+//! let clock = SequenceClock::new();
+//! let first = clock.next();   // 0
+//! let second = clock.next();  // 1
+//! assert!(second > first);
+//! ```
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// A lock-free, monotonically-increasing sequence clock.
+///
+/// Each call to [`next`](Self::next) increments the counter and returns the
+/// *previous* value (i.e. the counter starts at 0 and the first `next()`
+/// returns 0, the second returns 1, and so on).  Use
+/// [`current`](Self::current) to observe the counter without advancing it.
+///
+/// `SequenceClock` is `Send + Sync` and can be placed in an `Arc` to share
+/// it across threads.
+#[derive(Debug)]
+pub struct SequenceClock {
+    inner: AtomicU64,
+}
+
+impl Default for SequenceClock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SequenceClock {
+    /// Create a new clock starting at zero.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: AtomicU64::new(0),
+        }
+    }
+
+    /// Advance the clock and return the next sequence number.
+    ///
+    /// The returned value is monotonically increasing across all callers,
+    /// even when called concurrently from multiple threads.
+    pub fn next(&self) -> u64 {
+        self.inner.fetch_add(1, Ordering::SeqCst)
+    }
+
+    /// Observe the current counter value without advancing it.
+    ///
+    /// Note: the returned value may already have been surpassed by another
+    /// thread calling [`next`](Self::next) concurrently.
+    #[must_use]
+    pub fn current(&self) -> u64 {
+        self.inner.load(Ordering::SeqCst)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::sync::Arc;
+    use std::thread;
+
+    use super::*;
+
+    #[test]
+    fn clock_starts_at_zero() {
+        let clock = SequenceClock::new();
+        assert_eq!(clock.current(), 0, "clock must start at zero");
+        let first = clock.next();
+        assert_eq!(first, 0, "first next() must return 0");
+    }
+
+    #[test]
+    fn clock_next_increments_monotonically() {
+        let clock = SequenceClock::new();
+        let values: Vec<u64> = (0..10).map(|_| clock.next()).collect();
+
+        for pair in values.windows(2) {
+            assert!(
+                pair[1] > pair[0],
+                "sequence must be strictly increasing: {pair:?}"
+            );
+        }
+        // After 10 next() calls, current should be 10.
+        assert_eq!(clock.current(), 10);
+    }
+
+    #[test]
+    fn clock_is_thread_safe() {
+        let clock = Arc::new(SequenceClock::new());
+        let handles: Vec<_> = (0..100)
+            .map(|_| {
+                let c = Arc::clone(&clock);
+                thread::spawn(move || c.next())
+            })
+            .collect();
+
+        let values: Vec<u64> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+        let unique: HashSet<u64> = values.iter().copied().collect();
+
+        assert_eq!(
+            unique.len(),
+            100,
+            "all 100 sequence numbers must be unique; got duplicates among {values:?}"
+        );
+    }
+}

--- a/crates/phantom-memory/src/event_log.rs
+++ b/crates/phantom-memory/src/event_log.rs
@@ -209,10 +209,7 @@ impl EventLog {
         }
         drop(probe);
 
-        let file = OpenOptions::new()
-            .append(true)
-            .create(true)
-            .open(path)?;
+        let file = OpenOptions::new().append(true).create(true).open(path)?;
         let writer = BufWriter::new(file);
 
         let (tx, _rx) = broadcast::channel(BROADCAST_CAPACITY);
@@ -492,12 +489,8 @@ mod tests {
         let (path, _dir) = ev_path("tail.jsonl");
         let mut log = EventLog::open(&path).unwrap();
         for i in 0..10 {
-            log.append(
-                EventSource::Substrate,
-                "evt",
-                serde_json::json!({ "i": i }),
-            )
-            .unwrap();
+            log.append(EventSource::Substrate, "evt", serde_json::json!({ "i": i }))
+                .unwrap();
         }
 
         let tail = log.tail(3);
@@ -526,8 +519,12 @@ mod tests {
             .unwrap();
         log.append(EventSource::Substrate, "foo.bar", serde_json::json!({}))
             .unwrap();
-        log.append(EventSource::Agent { id: 1 }, "foo.baz", serde_json::json!({}))
-            .unwrap();
+        log.append(
+            EventSource::Agent { id: 1 },
+            "foo.baz",
+            serde_json::json!({}),
+        )
+        .unwrap();
 
         let foos = log.filter_kind("foo.bar");
         assert_eq!(foos.len(), 2);
@@ -609,7 +606,10 @@ mod tests {
             .unwrap();
         log.flush().unwrap();
         let after = std::fs::read_to_string(&path).unwrap();
-        assert!(after.contains("\"kind\":\"a\""), "kind not flushed: {after}");
+        assert!(
+            after.contains("\"kind\":\"a\""),
+            "kind not flushed: {after}"
+        );
     }
 
     #[test]
@@ -817,7 +817,10 @@ mod tests {
         // Subsequent write: must fail immediately with poisoned error, not
         // attempt the underlying writer again.
         let second = machine.write_line(b"another line\n");
-        assert!(second.is_err(), "poisoned machine must reject subsequent writes");
+        assert!(
+            second.is_err(),
+            "poisoned machine must reject subsequent writes"
+        );
         assert_eq!(
             second.unwrap_err().kind(),
             ErrorKind::BrokenPipe,
@@ -845,9 +848,15 @@ mod tests {
         assert!(!log.is_poisoned(), "log must start un-poisoned");
         log.append(EventSource::Substrate, "ok", serde_json::json!({}))
             .unwrap();
-        assert!(!log.is_poisoned(), "successful append must not poison the log");
+        assert!(
+            !log.is_poisoned(),
+            "successful append must not poison the log"
+        );
         log.flush().unwrap();
-        assert!(!log.is_poisoned(), "successful flush must not poison the log");
+        assert!(
+            !log.is_poisoned(),
+            "successful flush must not poison the log"
+        );
     }
 
     /// StorageFull error kind constant is correctly identified.

--- a/crates/phantom-memory/src/handoff_log.rs
+++ b/crates/phantom-memory/src/handoff_log.rs
@@ -95,21 +95,37 @@ impl HandoffEntry {
     }
 
     /// The agent that transferred the task.
-    pub fn from_agent(&self) -> u64 { self.from_agent }
+    pub fn from_agent(&self) -> u64 {
+        self.from_agent
+    }
     /// The agent that received the task.
-    pub fn to_agent(&self) -> u64 { self.to_agent }
+    pub fn to_agent(&self) -> u64 {
+        self.to_agent
+    }
     /// Application-level task identifier.
-    pub fn task_id(&self) -> &str { &self.task_id }
+    pub fn task_id(&self) -> &str {
+        &self.task_id
+    }
     /// Brief summary of what the from-agent accomplished.
-    pub fn summary(&self) -> &str { &self.summary }
+    pub fn summary(&self) -> &str {
+        &self.summary
+    }
     /// Descriptions of already-tried, already-failed approaches.
-    pub fn failed_attempts(&self) -> &[String] { &self.failed_attempts }
+    pub fn failed_attempts(&self) -> &[String] {
+        &self.failed_attempts
+    }
     /// Memory-block identifiers the receiving agent should consult.
-    pub fn memory_refs(&self) -> &[String] { &self.memory_refs }
+    pub fn memory_refs(&self) -> &[String] {
+        &self.memory_refs
+    }
     /// Optional causality token linking this handoff to a pipeline run.
-    pub fn correlation_id(&self) -> Option<&str> { self.correlation_id.as_deref() }
+    pub fn correlation_id(&self) -> Option<&str> {
+        self.correlation_id.as_deref()
+    }
     /// Wall-clock time in milliseconds since the Unix epoch.
-    pub fn ts_unix_ms(&self) -> i64 { self.ts_unix_ms }
+    pub fn ts_unix_ms(&self) -> i64 {
+        self.ts_unix_ms
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -167,8 +183,13 @@ impl HandoffLog {
     /// independent clock sources or test determinism.
     pub fn record(&mut self, entry: &HandoffEntry) -> Result<(), HandoffError> {
         let payload = serde_json::to_value(entry)?;
-        self.log
-            .append(EventSource::Agent { id: entry.from_agent }, KIND, payload)?;
+        self.log.append(
+            EventSource::Agent {
+                id: entry.from_agent,
+            },
+            KIND,
+            payload,
+        )?;
         Ok(())
     }
 
@@ -357,8 +378,7 @@ mod tests {
         let lines: Vec<&str> = contents.lines().collect();
         assert_eq!(lines.len(), 1, "one line per record");
 
-        let env: crate::event_log::EventEnvelope =
-            serde_json::from_str(lines[0]).unwrap();
+        let env: crate::event_log::EventEnvelope = serde_json::from_str(lines[0]).unwrap();
         assert_eq!(env.kind, "agent.handoff");
 
         let entry: HandoffEntry = serde_json::from_value(env.payload).unwrap();
@@ -367,7 +387,10 @@ mod tests {
         assert_eq!(entry.task_id(), "t-persist");
         assert_eq!(entry.summary(), "wrote the thing");
         assert_eq!(entry.failed_attempts(), &["approach-A".to_string()]);
-        assert_eq!(entry.memory_refs(), &["mem-1".to_string(), "mem-2".to_string()]);
+        assert_eq!(
+            entry.memory_refs(),
+            &["mem-1".to_string(), "mem-2".to_string()]
+        );
         assert_eq!(entry.correlation_id(), Some("corr-xyz"));
         assert_eq!(entry.ts_unix_ms(), 1_700_000_000_000);
     }
@@ -379,8 +402,12 @@ mod tests {
         let (mut log, _, _dir) = mk_log("corr.jsonl");
 
         let entry = HandoffEntry::new(
-            1, 2, "t1", "done",
-            vec![], vec![],
+            1,
+            2,
+            "t1",
+            "done",
+            vec![],
+            vec![],
             Some("cid-abc-123".into()),
             0,
         );
@@ -416,7 +443,8 @@ mod tests {
         let cid = "corr-pipeline-42".to_string();
 
         log.record(&HandoffEntry::new(
-            1, 2,
+            1,
+            2,
             "pipeline-42",
             "scoped requirements",
             vec![],
@@ -427,7 +455,8 @@ mod tests {
         .unwrap();
 
         log.record(&HandoffEntry::new(
-            2, 3,
+            2,
+            3,
             "pipeline-42",
             "implemented core logic",
             vec!["mutex deadlock on naive impl".into()],
@@ -438,13 +467,21 @@ mod tests {
         .unwrap();
 
         let chain = log.by_task("pipeline-42");
-        assert_eq!(chain.len(), 2, "both hops must appear under the same task id");
+        assert_eq!(
+            chain.len(),
+            2,
+            "both hops must appear under the same task id"
+        );
 
         // Verify the chain is in chronological order.
         assert_eq!(chain[0].from_agent(), 1);
         assert_eq!(chain[1].from_agent(), 2);
 
         // Every hop in the chain shares the correlation id.
-        assert!(chain.iter().all(|e| e.correlation_id() == Some("corr-pipeline-42")));
+        assert!(
+            chain
+                .iter()
+                .all(|e| e.correlation_id() == Some("corr-pipeline-42"))
+        );
     }
 }

--- a/crates/phantom-memory/src/journal.rs
+++ b/crates/phantom-memory/src/journal.rs
@@ -357,11 +357,7 @@ impl AgentJournal {
     }
 
     /// All in-memory entries produced by `agent_id` in the given `phase`.
-    pub fn filter_by_agent_and_phase(
-        &self,
-        agent_id: AgentId,
-        phase: Phase,
-    ) -> Vec<JournalEntry> {
+    pub fn filter_by_agent_and_phase(&self, agent_id: AgentId, phase: Phase) -> Vec<JournalEntry> {
         self.log
             .tail(usize::MAX)
             .into_iter()
@@ -451,8 +447,10 @@ mod tests {
         let (mut j, _, _dir) = mk_journal("basic.jsonl");
 
         j.record(1, Phase::Lifecycle, Level::Info, "first").unwrap();
-        j.record(2, Phase::Execution, Level::Debug, "second").unwrap();
-        j.record(1, Phase::Completion, Level::Info, "third").unwrap();
+        j.record(2, Phase::Execution, Level::Debug, "second")
+            .unwrap();
+        j.record(1, Phase::Completion, Level::Info, "third")
+            .unwrap();
 
         let tail = j.tail(10);
         assert_eq!(tail.len(), 3);
@@ -635,8 +633,10 @@ mod tests {
     fn filter_by_level_returns_matching() {
         let (mut j, _, _dir) = mk_journal("level_filter.jsonl");
 
-        j.record(1, Phase::Execution, Level::Debug, "verbose").unwrap();
-        j.record(1, Phase::Execution, Level::Info, "normal").unwrap();
+        j.record(1, Phase::Execution, Level::Debug, "verbose")
+            .unwrap();
+        j.record(1, Phase::Execution, Level::Info, "normal")
+            .unwrap();
         j.record(1, Phase::Lifecycle, Level::Error, "dead").unwrap();
         j.record(2, Phase::Execution, Level::Warn, "odd").unwrap();
         j.record(2, Phase::Completion, Level::Info, "ok").unwrap();
@@ -663,7 +663,14 @@ mod tests {
 
         // Manually craft entries at known timestamps.
         let make = |agent_id: u64, ts: i64, msg: &str| {
-            JournalEntry::new(agent_id, next_global_sequence(), ts, Phase::Execution, Level::Info, msg)
+            JournalEntry::new(
+                agent_id,
+                next_global_sequence(),
+                ts,
+                Phase::Execution,
+                Level::Info,
+                msg,
+            )
         };
 
         j.append(make(1, 1000, "before")).unwrap();
@@ -695,16 +702,16 @@ mod tests {
         let (mut j, _, _dir) = mk_journal("seq.jsonl");
 
         let entries: Vec<_> = (0..10)
-            .map(|_| {
-                j.record(1, Phase::Execution, Level::Info, "x")
-                    .unwrap()
-            })
+            .map(|_| j.record(1, Phase::Execution, Level::Info, "x").unwrap())
             .collect();
 
         let seqs: Vec<u64> = entries.iter().map(|e| e.sequence()).collect();
         // All sequences must be strictly increasing.
         for pair in seqs.windows(2) {
-            assert!(pair[1] > pair[0], "sequence must be strictly increasing: {pair:?}");
+            assert!(
+                pair[1] > pair[0],
+                "sequence must be strictly increasing: {pair:?}"
+            );
         }
     }
 

--- a/crates/phantom-memory/src/lib.rs
+++ b/crates/phantom-memory/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod clock;
 pub mod event_log;
 pub mod handoff_log;
 pub mod journal;

--- a/crates/phantom-memory/src/memory_blocks.rs
+++ b/crates/phantom-memory/src/memory_blocks.rs
@@ -147,11 +147,7 @@ impl BlockHandle {
         }
 
         {
-            let mut guard = self
-                .block
-                .value
-                .write()
-                .expect("block value lock poisoned");
+            let mut guard = self.block.value.write().expect("block value lock poisoned");
             *guard = value;
         }
         let new_rev = self.block.revision.fetch_add(1, Ordering::AcqRel) + 1;
@@ -351,7 +347,9 @@ mod tests {
         writer.write("update".to_string()).unwrap();
 
         // Wait for the bump notification.
-        rx.changed().await.expect("watch sender must still be alive");
+        rx.changed()
+            .await
+            .expect("watch sender must still be alive");
         assert_eq!(*rx.borrow(), 1);
         assert_eq!(reader.read(), "update");
     }

--- a/crates/phantom-memory/src/notifications.rs
+++ b/crates/phantom-memory/src/notifications.rs
@@ -373,8 +373,7 @@ impl NotificationStore {
         let data = serde_json::to_string_pretty(&self.notifications)
             .context("failed to serialize notifications")?;
         let tmp = self.path.with_extension("json.tmp");
-        fs::write(&tmp, &data)
-            .with_context(|| format!("failed to write {}", tmp.display()))?;
+        fs::write(&tmp, &data).with_context(|| format!("failed to write {}", tmp.display()))?;
         fs::rename(&tmp, &self.path).with_context(|| {
             format!(
                 "failed to rename {} -> {}",
@@ -433,7 +432,12 @@ mod tests {
     fn all_fields_accessible_via_getters() {
         let (mut store, _dir) = tmp_store("/proj");
         let n = store
-            .push(NotificationKind::AgentFlatlined, "Flatline", "Agent died", Some(7))
+            .push(
+                NotificationKind::AgentFlatlined,
+                "Flatline",
+                "Agent died",
+                Some(7),
+            )
             .unwrap();
 
         assert_eq!(n.kind(), NotificationKind::AgentFlatlined);
@@ -566,7 +570,11 @@ mod tests {
 
         let running = store.by_kind(NotificationKind::AgentRunning);
         assert_eq!(running.len(), 2);
-        assert!(running.iter().all(|n| n.kind() == NotificationKind::AgentRunning));
+        assert!(
+            running
+                .iter()
+                .all(|n| n.kind() == NotificationKind::AgentRunning)
+        );
 
         let blocked = store.by_kind(NotificationKind::PipelineBlocked);
         assert_eq!(blocked.len(), 1);
@@ -665,7 +673,12 @@ mod tests {
         {
             let mut store = NotificationStore::open_in(project, dir.path()).unwrap();
             store
-                .push(NotificationKind::PlanReady, "Plan", "Ready to execute", None)
+                .push(
+                    NotificationKind::PlanReady,
+                    "Plan",
+                    "Ready to execute",
+                    None,
+                )
                 .unwrap();
             store
                 .push(NotificationKind::AgentRunning, "Agent", "Running", Some(42))
@@ -751,7 +764,10 @@ mod tests {
         assert_eq!(NotificationKind::PlanReady.to_string(), "plan_ready");
         assert_eq!(NotificationKind::AgentRunning.to_string(), "agent_running");
         assert_eq!(NotificationKind::AgentSynced.to_string(), "agent_synced");
-        assert_eq!(NotificationKind::AgentFlatlined.to_string(), "agent_flatlined");
+        assert_eq!(
+            NotificationKind::AgentFlatlined.to_string(),
+            "agent_flatlined"
+        );
         assert_eq!(
             NotificationKind::PipelineCompleted.to_string(),
             "pipeline_completed"

--- a/crates/phantom-memory/src/schema.rs
+++ b/crates/phantom-memory/src/schema.rs
@@ -362,8 +362,8 @@ mod tests {
     fn all_known_kinds_round_trip_via_from_str() {
         for &kind in KnownKind::all() {
             let s = kind.as_str();
-            let back = KnownKind::from_str(s)
-                .unwrap_or_else(|| panic!("from_str({s:?}) returned None"));
+            let back =
+                KnownKind::from_str(s).unwrap_or_else(|| panic!("from_str({s:?}) returned None"));
             assert_eq!(back, kind, "round-trip failed for {s:?}");
         }
     }
@@ -394,23 +394,22 @@ mod tests {
     #[test]
     fn new_with_known_kind_succeeds() {
         for &k in KnownKind::all() {
-            let entry = EventLogEntry::new(
-                1,
-                1_000_000,
-                k.as_str(),
-                json!({}),
-                vec![],
-            )
-            .unwrap_or_else(|e| panic!("new failed for {}: {e}", k.as_str()));
+            let entry = EventLogEntry::new(1, 1_000_000, k.as_str(), json!({}), vec![])
+                .unwrap_or_else(|e| panic!("new failed for {}: {e}", k.as_str()));
             assert_eq!(entry.kind(), k.as_str());
         }
     }
 
     #[test]
     fn new_with_unknown_prefix_succeeds() {
-        let entry =
-            EventLogEntry::new(42, 2_000, "unknown.future_field", json!({"x": 1}), vec![1, 2])
-                .unwrap();
+        let entry = EventLogEntry::new(
+            42,
+            2_000,
+            "unknown.future_field",
+            json!({"x": 1}),
+            vec![1, 2],
+        )
+        .unwrap();
         assert_eq!(entry.id(), 42);
         assert_eq!(entry.kind(), "unknown.future_field");
         assert_eq!(entry.source_chain(), &[1, 2]);
@@ -418,8 +417,7 @@ mod tests {
 
     #[test]
     fn new_with_invalid_kind_returns_error() {
-        let err =
-            EventLogEntry::new(1, 0, "bad-kind-string", json!({}), vec![]).unwrap_err();
+        let err = EventLogEntry::new(1, 0, "bad-kind-string", json!({}), vec![]).unwrap_err();
         assert!(matches!(err, SchemaError::InvalidKind { .. }));
     }
 
@@ -435,8 +433,14 @@ mod tests {
     fn getters_return_constructor_values() {
         let chain = vec![10u64, 20, 30];
         let payload = json!({"agent_id": 7, "task": "test"});
-        let entry = EventLogEntry::new(99, 1_234_567_890, "agent.spawn", payload.clone(), chain.clone())
-            .unwrap();
+        let entry = EventLogEntry::new(
+            99,
+            1_234_567_890,
+            "agent.spawn",
+            payload.clone(),
+            chain.clone(),
+        )
+        .unwrap();
 
         assert_eq!(entry.id(), 99);
         assert_eq!(entry.timestamp_ms(), 1_234_567_890);
@@ -455,8 +459,7 @@ mod tests {
 
     #[test]
     fn validate_unknown_prefix_ok() {
-        let entry =
-            EventLogEntry::new(1, 0, "unknown.v3_feature", json!({}), vec![]).unwrap();
+        let entry = EventLogEntry::new(1, 0, "unknown.v3_feature", json!({}), vec![]).unwrap();
         assert!(entry.validate().is_ok());
     }
 
@@ -530,8 +533,7 @@ mod tests {
     #[test]
     fn source_chain_preserves_causal_order() {
         let chain = vec![1u64, 5, 9];
-        let entry =
-            EventLogEntry::new(10, 0, "agent.spawn", json!({}), chain.clone()).unwrap();
+        let entry = EventLogEntry::new(10, 0, "agent.spawn", json!({}), chain.clone()).unwrap();
         assert_eq!(entry.source_chain(), chain.as_slice());
     }
 
@@ -582,7 +584,13 @@ mod tests {
 
     #[test]
     fn kind_with_no_dot_and_no_unknown_prefix_rejected() {
-        let kinds = ["agentspawn", "AGENT.SPAWN", "agent", " agent.spawn", "agent.spawn "];
+        let kinds = [
+            "agentspawn",
+            "AGENT.SPAWN",
+            "agent",
+            " agent.spawn",
+            "agent.spawn ",
+        ];
         for bad in kinds {
             let err = EventLogEntry::new(1, 0, bad, json!({}), vec![]).unwrap_err();
             assert!(

--- a/crates/phantom-memory/src/store.rs
+++ b/crates/phantom-memory/src/store.rs
@@ -2,10 +2,13 @@ use std::collections::hash_map::DefaultHasher;
 use std::fs;
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+
+use crate::clock::SequenceClock;
 
 /// A single memory entry.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -16,6 +19,13 @@ pub struct MemoryEntry {
     pub created_at: u64,
     pub updated_at: u64,
     pub source: MemorySource,
+    /// Monotonically-increasing sequence number assigned at insertion time.
+    ///
+    /// Enables total ordering of entries independent of wall-clock timestamps.
+    /// Entries loaded from a pre-existing JSON file that pre-dates this field
+    /// default to `0` via `serde(default)`.
+    #[serde(default)]
+    pub seq: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -49,9 +59,14 @@ pub enum MemorySource {
 /// Persistent per-project memory store.
 ///
 /// Backed by a JSON file at `~/.config/phantom/memory/{project_hash}.json`.
+///
+/// Each new entry is stamped with a monotonically-increasing sequence number
+/// via the embedded [`SequenceClock`], providing unambiguous insertion order
+/// even if multiple entries share the same wall-clock second.
 pub struct MemoryStore {
     entries: Vec<MemoryEntry>,
     path: PathBuf,
+    clock: Arc<SequenceClock>,
 }
 
 fn now_epoch() -> u64 {
@@ -75,8 +90,7 @@ impl MemoryStore {
     /// otherwise the store starts empty.
     pub fn open(project_dir: &str) -> Result<Self> {
         let home = std::env::var("HOME").context("HOME not set")?;
-        let dir = PathBuf::from(home)
-            .join(".config/phantom/memory");
+        let dir = PathBuf::from(home).join(".config/phantom/memory");
         Self::open_in(project_dir, &dir)
     }
 
@@ -88,7 +102,7 @@ impl MemoryStore {
         let hash = project_hash(project_dir);
         let path = base_dir.join(format!("{hash}.json"));
 
-        let entries = if path.exists() {
+        let entries: Vec<MemoryEntry> = if path.exists() {
             let data = fs::read_to_string(&path)
                 .with_context(|| format!("failed to read {}", path.display()))?;
             serde_json::from_str(&data)
@@ -97,10 +111,27 @@ impl MemoryStore {
             Vec::new()
         };
 
-        Ok(Self { entries, path })
+        // Seed the clock past the highest seq already on disk so that new
+        // entries are always strictly greater than any persisted value.
+        let max_seq = entries.iter().map(|e| e.seq).max().unwrap_or(0);
+        let clock = Arc::new(SequenceClock::new());
+        // Consume `max_seq` ticks so the next `clock.next()` yields max_seq + 1.
+        for _ in 0..=max_seq {
+            clock.next();
+        }
+
+        Ok(Self {
+            entries,
+            path,
+            clock,
+        })
     }
 
     /// Set a memory entry (insert or update by key).
+    ///
+    /// New entries are stamped with the next sequence number from the store's
+    /// [`SequenceClock`].  Updates to existing entries do *not* change `seq`
+    /// (the insertion order is immutable).
     pub fn set(
         &mut self,
         key: &str,
@@ -116,6 +147,7 @@ impl MemoryStore {
             entry.source = source;
             entry.updated_at = now;
         } else {
+            let seq = self.clock.next();
             self.entries.push(MemoryEntry {
                 key: key.to_owned(),
                 value: value.to_owned(),
@@ -123,10 +155,18 @@ impl MemoryStore {
                 created_at: now,
                 updated_at: now,
                 source,
+                seq,
             });
         }
 
         self.save()
+    }
+
+    /// Expose the store's [`SequenceClock`] for external callers that need to
+    /// stamp their own events with the same monotonic sequence.
+    #[must_use]
+    pub fn clock(&self) -> &Arc<SequenceClock> {
+        &self.clock
     }
 
     /// Get a memory entry by key.
@@ -163,9 +203,7 @@ impl MemoryStore {
         let q = query.to_lowercase();
         self.entries
             .iter()
-            .filter(|e| {
-                e.key.to_lowercase().contains(&q) || e.value.to_lowercase().contains(&q)
-            })
+            .filter(|e| e.key.to_lowercase().contains(&q) || e.value.to_lowercase().contains(&q))
             .collect()
     }
 
@@ -180,10 +218,14 @@ impl MemoryStore {
             .context("failed to serialize memory entries")?;
 
         let tmp = self.path.with_extension("json.tmp");
-        fs::write(&tmp, &data)
-            .with_context(|| format!("failed to write {}", tmp.display()))?;
-        fs::rename(&tmp, &self.path)
-            .with_context(|| format!("failed to rename {} -> {}", tmp.display(), self.path.display()))?;
+        fs::write(&tmp, &data).with_context(|| format!("failed to write {}", tmp.display()))?;
+        fs::rename(&tmp, &self.path).with_context(|| {
+            format!(
+                "failed to rename {} -> {}",
+                tmp.display(),
+                self.path.display()
+            )
+        })?;
 
         Ok(())
     }
@@ -218,7 +260,12 @@ mod tests {
     fn set_and_get() {
         let (mut store, _dir) = tmp_store("/home/user/project");
         store
-            .set("pkg_manager", "pnpm", MemoryCategory::ProjectConfig, MemorySource::Auto)
+            .set(
+                "pkg_manager",
+                "pnpm",
+                MemoryCategory::ProjectConfig,
+                MemorySource::Auto,
+            )
             .unwrap();
 
         let entry = store.get("pkg_manager").unwrap();
@@ -231,18 +278,31 @@ mod tests {
     fn update_existing_key() {
         let (mut store, _dir) = tmp_store("/proj");
         store
-            .set("port", "3000", MemoryCategory::ProjectConfig, MemorySource::Auto)
+            .set(
+                "port",
+                "3000",
+                MemoryCategory::ProjectConfig,
+                MemorySource::Auto,
+            )
             .unwrap();
         let original_created = store.get("port").unwrap().created_at;
 
         store
-            .set("port", "3001", MemoryCategory::ProjectConfig, MemorySource::User)
+            .set(
+                "port",
+                "3001",
+                MemoryCategory::ProjectConfig,
+                MemorySource::User,
+            )
             .unwrap();
 
         let entry = store.get("port").unwrap();
         assert_eq!(entry.value, "3001");
         assert_eq!(entry.source, MemorySource::User);
-        assert_eq!(entry.created_at, original_created, "created_at must not change on update");
+        assert_eq!(
+            entry.created_at, original_created,
+            "created_at must not change on update"
+        );
         assert_eq!(store.count(), 1, "should still be one entry, not two");
     }
 
@@ -276,9 +336,15 @@ mod tests {
     #[test]
     fn all_returns_every_entry() {
         let (mut store, _dir) = tmp_store("/proj");
-        store.set("a", "1", MemoryCategory::Convention, MemorySource::User).unwrap();
-        store.set("b", "2", MemoryCategory::Warning, MemorySource::Agent).unwrap();
-        store.set("c", "3", MemoryCategory::UserNote, MemorySource::User).unwrap();
+        store
+            .set("a", "1", MemoryCategory::Convention, MemorySource::User)
+            .unwrap();
+        store
+            .set("b", "2", MemoryCategory::Warning, MemorySource::Agent)
+            .unwrap();
+        store
+            .set("c", "3", MemoryCategory::UserNote, MemorySource::User)
+            .unwrap();
 
         assert_eq!(store.all().len(), 3);
     }
@@ -286,14 +352,26 @@ mod tests {
     #[test]
     fn by_category_filters_correctly() {
         let (mut store, _dir) = tmp_store("/proj");
-        store.set("a", "1", MemoryCategory::Convention, MemorySource::Auto).unwrap();
-        store.set("b", "2", MemoryCategory::Warning, MemorySource::Auto).unwrap();
-        store.set("c", "3", MemoryCategory::Convention, MemorySource::Auto).unwrap();
-        store.set("d", "4", MemoryCategory::Context, MemorySource::Auto).unwrap();
+        store
+            .set("a", "1", MemoryCategory::Convention, MemorySource::Auto)
+            .unwrap();
+        store
+            .set("b", "2", MemoryCategory::Warning, MemorySource::Auto)
+            .unwrap();
+        store
+            .set("c", "3", MemoryCategory::Convention, MemorySource::Auto)
+            .unwrap();
+        store
+            .set("d", "4", MemoryCategory::Context, MemorySource::Auto)
+            .unwrap();
 
         let conventions = store.by_category(MemoryCategory::Convention);
         assert_eq!(conventions.len(), 2);
-        assert!(conventions.iter().all(|e| e.category == MemoryCategory::Convention));
+        assert!(
+            conventions
+                .iter()
+                .all(|e| e.category == MemoryCategory::Convention)
+        );
 
         let warnings = store.by_category(MemoryCategory::Warning);
         assert_eq!(warnings.len(), 1);
@@ -306,9 +384,30 @@ mod tests {
     #[test]
     fn search_matches_key_and_value_case_insensitive() {
         let (mut store, _dir) = tmp_store("/proj");
-        store.set("pkg_manager", "pnpm", MemoryCategory::ProjectConfig, MemorySource::Auto).unwrap();
-        store.set("dev_port", "3001", MemoryCategory::ProjectConfig, MemorySource::Auto).unwrap();
-        store.set("warning", "Don't touch legacy/", MemoryCategory::Warning, MemorySource::Agent).unwrap();
+        store
+            .set(
+                "pkg_manager",
+                "pnpm",
+                MemoryCategory::ProjectConfig,
+                MemorySource::Auto,
+            )
+            .unwrap();
+        store
+            .set(
+                "dev_port",
+                "3001",
+                MemoryCategory::ProjectConfig,
+                MemorySource::Auto,
+            )
+            .unwrap();
+        store
+            .set(
+                "warning",
+                "Don't touch legacy/",
+                MemoryCategory::Warning,
+                MemorySource::Agent,
+            )
+            .unwrap();
 
         // match on value
         let results = store.search("pnpm");
@@ -335,14 +434,20 @@ mod tests {
         let (mut store, _dir) = tmp_store("/proj");
         assert_eq!(store.count(), 0);
 
-        store.set("a", "1", MemoryCategory::Context, MemorySource::Auto).unwrap();
+        store
+            .set("a", "1", MemoryCategory::Context, MemorySource::Auto)
+            .unwrap();
         assert_eq!(store.count(), 1);
 
-        store.set("b", "2", MemoryCategory::Context, MemorySource::Auto).unwrap();
+        store
+            .set("b", "2", MemoryCategory::Context, MemorySource::Auto)
+            .unwrap();
         assert_eq!(store.count(), 2);
 
         // update doesn't change count
-        store.set("a", "updated", MemoryCategory::Context, MemorySource::Auto).unwrap();
+        store
+            .set("a", "updated", MemoryCategory::Context, MemorySource::Auto)
+            .unwrap();
         assert_eq!(store.count(), 2);
 
         store.remove("a").unwrap();
@@ -357,9 +462,30 @@ mod tests {
         // Write data
         {
             let mut store = MemoryStore::open_in(project, dir.path()).unwrap();
-            store.set("pkg", "pnpm", MemoryCategory::ProjectConfig, MemorySource::Auto).unwrap();
-            store.set("style", "tabs", MemoryCategory::Convention, MemorySource::User).unwrap();
-            store.set("warn", "legacy is frozen", MemoryCategory::Warning, MemorySource::Agent).unwrap();
+            store
+                .set(
+                    "pkg",
+                    "pnpm",
+                    MemoryCategory::ProjectConfig,
+                    MemorySource::Auto,
+                )
+                .unwrap();
+            store
+                .set(
+                    "style",
+                    "tabs",
+                    MemoryCategory::Convention,
+                    MemorySource::User,
+                )
+                .unwrap();
+            store
+                .set(
+                    "warn",
+                    "legacy is frozen",
+                    MemoryCategory::Warning,
+                    MemorySource::Agent,
+                )
+                .unwrap();
         }
 
         // Re-open and verify
@@ -387,8 +513,12 @@ mod tests {
 
         {
             let mut store = MemoryStore::open_in(project, dir.path()).unwrap();
-            store.set("a", "1", MemoryCategory::Context, MemorySource::Auto).unwrap();
-            store.set("b", "2", MemoryCategory::Context, MemorySource::Auto).unwrap();
+            store
+                .set("a", "1", MemoryCategory::Context, MemorySource::Auto)
+                .unwrap();
+            store
+                .set("b", "2", MemoryCategory::Context, MemorySource::Auto)
+                .unwrap();
             store.remove("a").unwrap();
         }
 
@@ -409,9 +539,30 @@ mod tests {
     #[test]
     fn agent_context_formatting() {
         let (mut store, _dir) = tmp_store("/proj");
-        store.set("pkg_manager", "pnpm", MemoryCategory::ProjectConfig, MemorySource::Auto).unwrap();
-        store.set("style", "snake_case", MemoryCategory::Convention, MemorySource::User).unwrap();
-        store.set("auth_refactor", "don't touch legacy/", MemoryCategory::Warning, MemorySource::Agent).unwrap();
+        store
+            .set(
+                "pkg_manager",
+                "pnpm",
+                MemoryCategory::ProjectConfig,
+                MemorySource::Auto,
+            )
+            .unwrap();
+        store
+            .set(
+                "style",
+                "snake_case",
+                MemoryCategory::Convention,
+                MemorySource::User,
+            )
+            .unwrap();
+        store
+            .set(
+                "auth_refactor",
+                "don't touch legacy/",
+                MemoryCategory::Warning,
+                MemorySource::Agent,
+            )
+            .unwrap();
 
         let ctx = store.agent_context();
         let lines: Vec<&str> = ctx.lines().collect();
@@ -422,14 +573,62 @@ mod tests {
     }
 
     #[test]
+    fn memory_block_seq_stamps_increase_on_each_add() {
+        let (mut store, _dir) = tmp_store("/proj");
+
+        store
+            .set("a", "1", MemoryCategory::Context, MemorySource::Auto)
+            .unwrap();
+        store
+            .set("b", "2", MemoryCategory::Context, MemorySource::Auto)
+            .unwrap();
+        store
+            .set("c", "3", MemoryCategory::Context, MemorySource::Auto)
+            .unwrap();
+
+        let seq_a = store.get("a").unwrap().seq;
+        let seq_b = store.get("b").unwrap().seq;
+        let seq_c = store.get("c").unwrap().seq;
+
+        assert!(
+            seq_a < seq_b && seq_b < seq_c,
+            "seq stamps must be strictly increasing: a={seq_a} b={seq_b} c={seq_c}"
+        );
+    }
+
+    #[test]
+    fn update_does_not_change_seq() {
+        let (mut store, _dir) = tmp_store("/proj");
+
+        store
+            .set("x", "original", MemoryCategory::Context, MemorySource::Auto)
+            .unwrap();
+        let seq_before = store.get("x").unwrap().seq;
+
+        store
+            .set("x", "updated", MemoryCategory::Context, MemorySource::User)
+            .unwrap();
+        let seq_after = store.get("x").unwrap().seq;
+
+        assert_eq!(
+            seq_before, seq_after,
+            "update must not change the seq stamp"
+        );
+    }
+
+    #[test]
     fn different_projects_get_different_stores() {
         let dir = tempfile::tempdir().unwrap();
 
         let mut store_a = MemoryStore::open_in("/project-a", dir.path()).unwrap();
-        store_a.set("name", "alpha", MemoryCategory::Context, MemorySource::Auto).unwrap();
+        store_a
+            .set("name", "alpha", MemoryCategory::Context, MemorySource::Auto)
+            .unwrap();
 
         let mut store_b = MemoryStore::open_in("/project-b", dir.path()).unwrap();
-        store_b.set("name", "beta", MemoryCategory::Context, MemorySource::Auto).unwrap();
+        store_b
+            .set("name", "beta", MemoryCategory::Context, MemorySource::Auto)
+            .unwrap();
 
         // Re-open A and confirm isolation
         let store_a2 = MemoryStore::open_in("/project-a", dir.path()).unwrap();


### PR DESCRIPTION
## Summary

- Add `crates/phantom-memory/src/clock.rs` with `SequenceClock` — a lock-free `AtomicU64`-backed monotonic counter with `new()`, `next()` (SeqCst fetch_add), and `current()` (SeqCst load)
- Wire `SequenceClock` into `MemoryStore` as an `Arc<SequenceClock>` field; the clock is seeded past any max `seq` already on disk so reopened stores never regress
- Add `seq: u64` field to `MemoryEntry` (serde default = 0 for backward compat); stamped on insert, immutable on update
- Expose `MemoryStore::clock()` so callers can co-ordinate with the same clock
- Run `cargo fmt` across the crate (pre-existing style drift fixed)

## TDD tests added

- `clock::tests::clock_starts_at_zero` — first `next()` returns 0
- `clock::tests::clock_next_increments_monotonically` — 10 sequential calls produce a strictly increasing sequence
- `clock::tests::clock_is_thread_safe` — 100 threads each call `next()` once; all 100 values are unique
- `store::tests::memory_block_seq_stamps_increase_on_each_add` — three sequential `set()` calls produce strictly increasing `seq`
- `store::tests::update_does_not_change_seq` — updating an existing key does not change its `seq`

## Test plan

- [x] `cargo test -p phantom-memory` — 118 tests pass, 0 fail
- [x] `cargo fmt -p phantom-memory -- --check` — clean
- [x] Doc-tests pass (5/5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)