### PR TITLE
fix: inject DYLD_FALLBACK_LIBRARY_PATH in supervisor for macOS audio (closes #9)

### DIFF
--- a/crates/phantom-supervisor/src/main.rs
+++ b/crates/phantom-supervisor/src/main.rs
@@ -601,6 +601,76 @@ fn install_signal_handlers(shutdown: Arc<AtomicBool>) {
 }
 
 // ---------------------------------------------------------------------------
+// macOS: DYLD_FALLBACK_LIBRARY_PATH injection
+// ---------------------------------------------------------------------------
+
+/// On macOS, `DYLD_FALLBACK_LIBRARY_PATH` must be set before the dynamic
+/// linker resolves Swift runtime libraries used by the audio-capture backend.
+/// When Phantom is launched via `cargo run --bin phantom` (without `run.sh`)
+/// this variable may be absent, causing `dlopen` failures at runtime.
+///
+/// This function injects a suitable path early in the supervisor — before the
+/// phantom child process is spawned — so the child inherits it automatically.
+/// It is a no-op if the variable is already set.
+#[cfg(target_os = "macos")]
+fn inject_dyld_fallback() {
+    if std::env::var("DYLD_FALLBACK_LIBRARY_PATH").is_ok() {
+        // Already set (e.g. caller exported it, or run.sh set it). Respect it.
+        return;
+    }
+
+    match find_swift_runtime_path() {
+        Some(path) => {
+            info!("injecting DYLD_FALLBACK_LIBRARY_PATH={path}");
+            // SAFETY: single-threaded at this point in main(); no other threads
+            // have been spawned yet when we call this.
+            #[allow(unused_unsafe)]
+            unsafe {
+                std::env::set_var("DYLD_FALLBACK_LIBRARY_PATH", &path);
+            }
+        }
+        None => {
+            warn!(
+                "Swift runtime not found — audio capture will be unavailable \
+                 (set DYLD_FALLBACK_LIBRARY_PATH manually if needed)"
+            );
+        }
+    }
+}
+
+/// Probe for the Swift standard-library directory on the host macOS system.
+///
+/// Strategy (in order):
+/// 1. Ask `xcrun --show-sdk-path` and derive `<sdk>/usr/lib/swift`.
+/// 2. Fall back to the well-known system path `/usr/lib/swift`.
+#[cfg(target_os = "macos")]
+fn find_swift_runtime_path() -> Option<String> {
+    // --- Strategy 1: xcrun SDK path -------------------------------------------
+    if let Ok(output) = std::process::Command::new("xcrun")
+        .args(["--show-sdk-path"])
+        .output()
+    {
+        if output.status.success() {
+            let sdk = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !sdk.is_empty() {
+                let candidate = format!("{sdk}/usr/lib/swift");
+                if std::path::Path::new(&candidate).exists() {
+                    return Some(candidate);
+                }
+            }
+        }
+    }
+
+    // --- Strategy 2: well-known system path ------------------------------------
+    let fallback = "/usr/lib/swift";
+    if std::path::Path::new(fallback).exists() {
+        return Some(fallback.to_string());
+    }
+
+    None
+}
+
+// ---------------------------------------------------------------------------
 // Entrypoint
 // ---------------------------------------------------------------------------
 
@@ -608,6 +678,11 @@ fn main() -> Result<()> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
         .format_timestamp_millis()
         .init();
+
+    // Inject DYLD_FALLBACK_LIBRARY_PATH on macOS so Swift-backed audio capture
+    // works when launched directly via `cargo run --bin phantom` without run.sh.
+    #[cfg(target_os = "macos")]
+    inject_dyld_fallback();
 
     print_banner();
 

--- a/crates/phantom-supervisor/src/orphan.rs
+++ b/crates/phantom-supervisor/src/orphan.rs
@@ -101,7 +101,10 @@ impl Drop for PidFile {
             if let Err(e) = fs::remove_file(&self.path) {
                 warn!("failed to delete PID file on shutdown: {e}");
             } else {
-                info!("deleted PID file on clean shutdown: {}", self.path.display());
+                info!(
+                    "deleted PID file on clean shutdown: {}",
+                    self.path.display()
+                );
             }
         }
     }
@@ -124,8 +127,13 @@ fn write_pid_file(path: &Path, main_pid: u32, child_pids: Vec<u32>) -> Result<()
     let tmp_path = path.with_extension("pid.tmp");
     fs::write(&tmp_path, json.as_bytes())
         .with_context(|| format!("failed to write temp PID file {}", tmp_path.display()))?;
-    fs::rename(&tmp_path, path)
-        .with_context(|| format!("failed to rename PID file {} -> {}", tmp_path.display(), path.display()))?;
+    fs::rename(&tmp_path, path).with_context(|| {
+        format!(
+            "failed to rename PID file {} -> {}",
+            tmp_path.display(),
+            path.display()
+        )
+    })?;
 
     info!(
         "wrote PID file: main={} children={:?} -> {}",
@@ -159,11 +167,17 @@ fn write_pid_file(path: &Path, main_pid: u32, child_pids: Vec<u32>) -> Result<()
 pub fn recover_orphans(path: &Path) -> Result<()> {
     // Step 1: no file → nothing to do.
     if !path.exists() {
-        info!("no stale PID file at {} — skipping orphan scan", path.display());
+        info!(
+            "no stale PID file at {} — skipping orphan scan",
+            path.display()
+        );
         return Ok(());
     }
 
-    info!("stale PID file found at {} — starting orphan scan", path.display());
+    info!(
+        "stale PID file found at {} — starting orphan scan",
+        path.display()
+    );
 
     // Step 2: parse.
     let data = match read_pid_file(path) {
@@ -236,8 +250,8 @@ pub fn recover_orphans(path: &Path) -> Result<()> {
 // ---------------------------------------------------------------------------
 
 fn read_pid_file(path: &Path) -> Result<PidFileData> {
-    let bytes = fs::read(path)
-        .with_context(|| format!("cannot read PID file {}", path.display()))?;
+    let bytes =
+        fs::read(path).with_context(|| format!("cannot read PID file {}", path.display()))?;
     let data: PidFileData = serde_json::from_slice(&bytes)
         .with_context(|| format!("cannot parse PID file {}", path.display()))?;
     Ok(data)
@@ -337,7 +351,10 @@ mod tests {
         let result = recover_orphans(&path);
         assert!(result.is_ok());
         // File must be deleted after recovery.
-        assert!(!path.exists(), "stale PID file must be removed after recovery");
+        assert!(
+            !path.exists(),
+            "stale PID file must be removed after recovery"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -356,7 +373,10 @@ mod tests {
         let result = recover_orphans(&path);
         assert!(result.is_ok());
         // File must NOT be deleted — main is still alive.
-        assert!(path.exists(), "PID file must be preserved when main is alive");
+        assert!(
+            path.exists(),
+            "PID file must be preserved when main is alive"
+        );
 
         cleanup(&path);
     }
@@ -398,7 +418,10 @@ mod tests {
         assert_eq!(data.child_pids, children);
 
         // Temp file must not linger.
-        assert!(!path.with_extension("pid.tmp").exists(), "tmp file must be gone after rename");
+        assert!(
+            !path.with_extension("pid.tmp").exists(),
+            "tmp file must be gone after rename"
+        );
 
         cleanup(&path);
     }
@@ -417,7 +440,10 @@ mod tests {
             assert!(path.exists(), "file must exist while handle is live");
         }
         // Handle dropped → file must be gone.
-        assert!(!path.exists(), "PID file must be deleted when PidFile is dropped");
+        assert!(
+            !path.exists(),
+            "PID file must be deleted when PidFile is dropped"
+        );
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Closes #9

## Summary

- Moves `DYLD_FALLBACK_LIBRARY_PATH` injection from `run.sh` into `phantom-supervisor/src/main.rs`, called early in `main()` before any threads are spawned
- Fully `#[cfg(target_os = "macos")]` gated — zero effect on Linux/Windows
- Probes in order: `xcrun --show-sdk-path` → `<sdk>/usr/lib/swift`, then falls back to `/usr/lib/swift`
- Graceful `warn!` if Swift runtime genuinely not found; never panics
- `cargo run --bin phantom` now works on macOS without `run.sh`
- Also applies `rustfmt` to pre-existing line-length violations in `orphan.rs`

## Test plan

- [ ] `cargo build -p phantom-supervisor` passes clean
- [ ] `cargo fmt -p phantom-supervisor -- --check` passes clean
- [ ] On macOS without `DYLD_FALLBACK_LIBRARY_PATH` set: supervisor logs `injecting DYLD_FALLBACK_LIBRARY_PATH=...` at startup
- [ ] On macOS with `DYLD_FALLBACK_LIBRARY_PATH` already set: supervisor skips injection (respects caller)
- [ ] On Linux: functions are compiled out, no behaviour change

🤖 Generated with [Claude Code](https://claude.com/claude-code)