### PR TITLE
test: Unicode stress — emoji, RTL, combining chars, null bytes (closes #180)

### DIFF
--- a/crates/phantom-terminal/src/input.rs
+++ b/crates/phantom-terminal/src/input.rs
@@ -72,6 +72,7 @@ pub struct KeyEvent {
 }
 
 /// Encode a key event into the byte sequence expected by a VT100/xterm PTY.
+#[must_use]
 pub fn encode_key(event: &KeyEvent) -> Vec<u8> {
     let KeyEvent { key, mods } = event;
 
@@ -119,6 +120,7 @@ pub fn encode_key(event: &KeyEvent) -> Vec<u8> {
 }
 
 /// Encode a paste payload using bracketed paste mode.
+#[must_use]
 pub fn encode_paste(text: &str) -> Vec<u8> {
     let mut buf = Vec::with_capacity(text.len() + 12);
     buf.extend_from_slice(b"\x1b[200~");
@@ -156,6 +158,7 @@ impl MouseButton {
 ///
 /// Format: `\x1b[<{button};{col+1};{row+1}{M|m}`
 /// where M = press, m = release. Coordinates are 1-based.
+#[must_use]
 pub fn encode_mouse_sgr(button: MouseButton, col: usize, row: usize, pressed: bool) -> Vec<u8> {
     let btn = button.sgr_code();
     let suffix = if pressed { 'M' } else { 'm' };
@@ -165,6 +168,7 @@ pub fn encode_mouse_sgr(button: MouseButton, col: usize, row: usize, pressed: bo
 /// Encode a mouse motion event as SGR 1006 sequence.
 ///
 /// Motion events add 32 to the button code.
+#[must_use]
 pub fn encode_mouse_motion_sgr(button: MouseButton, col: usize, row: usize) -> Vec<u8> {
     let btn = button.sgr_code() + 32;
     format!("\x1b[<{};{};{}M", btn, col + 1, row + 1).into_bytes()

--- a/crates/phantom-terminal/src/kitty.rs
+++ b/crates/phantom-terminal/src/kitty.rs
@@ -100,6 +100,7 @@ pub struct KittyCommand {
 /// Format: `key=value,key=value;base64data`
 ///
 /// Returns `None` if the payload is malformed.
+#[must_use]
 pub fn parse_kitty_command(payload: &str) -> Option<KittyCommand> {
     // Split header from base64 data at the first semicolon.
     let (header, data) = match payload.find(';') {

--- a/crates/phantom-terminal/src/output.rs
+++ b/crates/phantom-terminal/src/output.rs
@@ -245,7 +245,7 @@ pub fn extract_grid_themed<T: EventListener>(
             // Check if this cell is in the selection.
             let is_selected = selection_range
                 .as_ref()
-                .map_or(false, |range| {
+                .is_some_and(|range| {
                     range.contains(Point::new(Line(row_idx as i32), Column(col_idx)))
                 });
 
@@ -350,6 +350,7 @@ fn extract_cursor<T: EventListener>(term: &Term<T>) -> CursorState {
 /// - Indices 0..16: standard ANSI colors.
 /// - Indices 16..232: 6x6x6 color cube.
 /// - Indices 232..256: grayscale ramp.
+#[must_use]
 pub fn ansi_color_table() -> [[f32; 4]; 256] {
     let mut t = [[0.0f32; 4]; 256];
 

--- a/crates/phantom-terminal/src/terminal.rs
+++ b/crates/phantom-terminal/src/terminal.rs
@@ -102,11 +102,13 @@ pub struct TerminalSize {
 }
 
 impl TerminalSize {
+    #[must_use]
     pub fn new(cols: u16, rows: u16) -> Self {
         Self { cols, rows }
     }
 
     /// Build the `WindowSize` that the PTY / kernel expects.
+    #[must_use]
     pub fn window_size(&self) -> WindowSize {
         WindowSize {
             num_cols: self.cols,
@@ -285,6 +287,7 @@ impl PhantomTerminal {
     /// exactly the bytes that were filled during the most recent `pty_read`.
     /// Returns an empty slice between reads or when `pty_read` returned `Ok(0)`.
     /// The returned slice is only valid until the next `pty_read` call.
+    #[must_use]
     #[inline]
     pub fn last_read_buf(&self) -> &[u8] {
         &self.read_buf[..self.last_read_len]
@@ -299,6 +302,7 @@ impl PhantomTerminal {
     }
 
     /// Immutable access to the terminal state (grid, cursor, modes).
+    #[must_use]
     #[inline]
     pub fn term(&self) -> &Term<PhantomEventListener> {
         &self.term
@@ -311,12 +315,14 @@ impl PhantomTerminal {
     }
 
     /// Current terminal dimensions.
+    #[must_use]
     #[inline]
     pub fn size(&self) -> TerminalSize {
         self.size
     }
 
     /// The PTY file descriptor for ioctl queries (e.g. foreground process group).
+    #[must_use]
     #[inline]
     pub fn pty_fd(&self) -> &File {
         &self.pty_reader
@@ -355,11 +361,13 @@ impl PhantomTerminal {
     }
 
     /// Current display offset from the bottom (0 = at live output).
+    #[must_use]
     pub fn display_offset(&self) -> usize {
         self.term.grid().display_offset()
     }
 
     /// Total number of lines in scrollback history.
+    #[must_use]
     pub fn history_size(&self) -> usize {
         self.term.grid().history_size()
     }
@@ -367,6 +375,7 @@ impl PhantomTerminal {
     // -- Mouse mode API ----------------------------------------------------
 
     /// Check which mouse tracking mode the running program has requested.
+    #[must_use]
     pub fn mouse_mode(&self) -> MouseMode {
         let mode = self.term.mode();
         if mode.contains(TermMode::MOUSE_MOTION) {
@@ -381,11 +390,13 @@ impl PhantomTerminal {
     }
 
     /// Whether the terminal is in SGR mouse mode (1006).
+    #[must_use]
     pub fn sgr_mouse(&self) -> bool {
         self.term.mode().contains(TermMode::SGR_MOUSE)
     }
 
     /// Whether the terminal is using the alternate screen buffer.
+    #[must_use]
     pub fn is_alt_screen(&self) -> bool {
         self.term.mode().contains(TermMode::ALT_SCREEN)
     }
@@ -410,11 +421,13 @@ impl PhantomTerminal {
     }
 
     /// Get the selected text as a string (for clipboard copy).
+    #[must_use]
     pub fn selection_to_string(&self) -> Option<String> {
         self.term.selection_to_string()
     }
 
     /// Whether any text is currently selected.
+    #[must_use]
     pub fn has_selection(&self) -> bool {
         self.term.selection.is_some()
     }
@@ -423,6 +436,7 @@ impl PhantomTerminal {
     ///
     /// Row values are relative to the visible screen (0 = top visible row).
     /// Returns `None` if there is no selection.
+    #[must_use]
     pub fn selection_range(&self) -> Option<(usize, usize, usize, usize)> {
         let range = self.term.selection.as_ref().and_then(|s| s.to_range(&self.term))?;
         let start_col = range.start.column.0;

--- a/crates/phantom-terminal/tests/unicode.rs
+++ b/crates/phantom-terminal/tests/unicode.rs
@@ -1,0 +1,262 @@
+//! Unicode stress tests for the terminal parser.
+//!
+//! These tests exercise the VTE / ANSI byte processor with edge-case Unicode
+//! sequences to ensure no panics occur and the terminal state machine
+//! handles malformed or complex input gracefully.
+//!
+//! The tests use `Term<VoidListener>` directly — no PTY is spawned — so
+//! they run in CI without a controlling terminal.
+
+use alacritty_terminal::{
+    event::VoidListener,
+    grid::Dimensions,
+    term::Config,
+    vte::ansi::Processor,
+    Term,
+};
+
+/// Minimal terminal size that implements `Dimensions`.
+struct TestSize {
+    cols: usize,
+    rows: usize,
+}
+
+impl TestSize {
+    fn new(cols: usize, rows: usize) -> Self {
+        Self { cols, rows }
+    }
+}
+
+impl Dimensions for TestSize {
+    fn total_lines(&self) -> usize {
+        self.rows
+    }
+
+    fn screen_lines(&self) -> usize {
+        self.rows
+    }
+
+    fn columns(&self) -> usize {
+        self.cols
+    }
+}
+
+/// Build a headless `Term<VoidListener>` and a fresh `Processor`.
+fn headless_term() -> (Term<VoidListener>, Processor) {
+    let size = TestSize::new(80, 24);
+    let config = Config::default();
+    let term = Term::new(config, &size, VoidListener);
+    let parser = Processor::new();
+    (term, parser)
+}
+
+/// Feed `bytes` through the parser into `term`.
+///
+/// This mirrors what `PhantomTerminal::pty_read` does:
+/// `parser.advance(&mut term, bytes)`.
+fn feed(term: &mut Term<VoidListener>, parser: &mut Processor, bytes: &[u8]) {
+    parser.advance(term, bytes);
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 — Fire + skull emoji
+// ---------------------------------------------------------------------------
+
+/// Fire (U+1F525) + skull (U+1F480) should not panic.
+///
+/// Bytes: F0 9F 94 A5  F0 9F 92 80
+#[test]
+fn no_panic_fire_skull_emoji() {
+    let (mut term, mut parser) = headless_term();
+    feed(
+        &mut term,
+        &mut parser,
+        b"\xF0\x9F\x94\xA5\xF0\x9F\x92\x80",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2 — Arabic "Marhaba" (مرحبا) RTL text
+// ---------------------------------------------------------------------------
+
+/// Arabic text should not panic and the grid column count must be unchanged.
+#[test]
+fn no_panic_arabic_marhaba() {
+    let (mut term, mut parser) = headless_term();
+
+    // "مرحبا" in UTF-8
+    let marhaba = "مرحبا".as_bytes();
+    let cols_before = term.columns();
+    feed(&mut term, &mut parser, marhaba);
+    // Grid width must not change — layout intact.
+    assert_eq!(term.columns(), cols_before);
+}
+
+// ---------------------------------------------------------------------------
+// Test 3 — e + combining acute accent (U+0301)
+// ---------------------------------------------------------------------------
+
+/// `e` followed by a combining acute accent (U+0301) must not panic
+/// and must not be split across cells incorrectly.
+///
+/// Bytes: 65 CC 81
+#[test]
+fn no_panic_e_combining_acute() {
+    let (mut term, mut parser) = headless_term();
+    feed(&mut term, &mut parser, b"e\xCC\x81");
+}
+
+// ---------------------------------------------------------------------------
+// Test 4 — Null byte
+// ---------------------------------------------------------------------------
+
+/// A raw null byte (U+0000) must not panic.
+/// It should be silently dropped or replaced.
+#[test]
+fn no_panic_null_byte() {
+    let (mut term, mut parser) = headless_term();
+    feed(&mut term, &mut parser, b"\x00");
+}
+
+// ---------------------------------------------------------------------------
+// Test 5 — All edge-case sequences concatenated
+// ---------------------------------------------------------------------------
+
+/// Concatenating all edge-case byte sequences must not cause a panic.
+#[test]
+fn no_panic_combined_edge_cases() {
+    let (mut term, mut parser) = headless_term();
+
+    // Fire + skull
+    feed(
+        &mut term,
+        &mut parser,
+        b"\xF0\x9F\x94\xA5\xF0\x9F\x92\x80",
+    );
+    // Arabic
+    feed(&mut term, &mut parser, "مرحبا".as_bytes());
+    // e + combining acute
+    feed(&mut term, &mut parser, b"e\xCC\x81");
+    // Null byte
+    feed(&mut term, &mut parser, b"\x00");
+    // ZWJ family (test 7 payload)
+    feed(
+        &mut term,
+        &mut parser,
+        b"\xF0\x9F\x91\xA8\xE2\x80\x8D\xF0\x9F\x91\xA9\xE2\x80\x8D\xF0\x9F\x91\xA7",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 6 — Overlong UTF-8 sequences
+// ---------------------------------------------------------------------------
+
+/// Overlong two-byte encoding of U+002F (ASCII '/') must be rejected, not
+/// interpreted as a valid codepoint.
+///
+/// `C0 AF` is the canonical overlong encoding of '/'. A correct UTF-8 decoder
+/// must treat this as two replacement characters (or simply discard), never
+/// as U+002F.
+#[test]
+fn overlong_utf8_rejected() {
+    let (mut term, mut parser) = headless_term();
+
+    // Overlong two-byte encoding of U+002F ('/')
+    let overlong_slash: &[u8] = &[0xC0, 0xAF];
+    feed(&mut term, &mut parser, overlong_slash);
+
+    // Overlong three-byte encoding of U+0041 ('A'): E0 80 81
+    let overlong_a: &[u8] = &[0xE0, 0x80, 0x81];
+    feed(&mut term, &mut parser, overlong_a);
+
+    // Overlong four-byte encoding of U+0000 (null): F0 80 80 80
+    let overlong_null: &[u8] = &[0xF0, 0x80, 0x80, 0x80];
+    feed(&mut term, &mut parser, overlong_null);
+}
+
+/// A sequence that starts like a valid 3-byte character but has an invalid
+/// continuation byte must not cause a panic.
+#[test]
+fn no_panic_truncated_multibyte() {
+    let (mut term, mut parser) = headless_term();
+
+    // Start of a 3-byte sequence (U+2764 HEAVY BLACK HEART = E2 9D A4)
+    // but cut off after the first byte.
+    feed(&mut term, &mut parser, &[0xE2]);
+
+    // Then send a standalone ASCII character — parser must recover.
+    feed(&mut term, &mut parser, b"X");
+}
+
+/// High surrogate value (U+D800–U+DFFF) encoded as if it were a valid
+/// 3-byte UTF-8 sequence must not cause a panic.
+///
+/// ED A0 80 would be the (illegal) UTF-8 encoding of U+D800.
+#[test]
+fn no_panic_surrogate_half() {
+    let (mut term, mut parser) = headless_term();
+    feed(&mut term, &mut parser, &[0xED, 0xA0, 0x80]);
+}
+
+// ---------------------------------------------------------------------------
+// Test 7 — ZWJ family emoji sequence
+// ---------------------------------------------------------------------------
+
+/// Man + ZWJ + Woman + ZWJ + Girl emoji (U+1F468 + ZWJ + U+1F469 + ZWJ + U+1F467)
+/// must not cause a panic.
+///
+/// Bytes: F0 9F 91 A8  E2 80 8D  F0 9F 91 A9  E2 80 8D  F0 9F 91 A7
+#[test]
+fn no_panic_zwj_family_emoji() {
+    let (mut term, mut parser) = headless_term();
+    feed(
+        &mut term,
+        &mut parser,
+        b"\xF0\x9F\x91\xA8\xE2\x80\x8D\xF0\x9F\x91\xA9\xE2\x80\x8D\xF0\x9F\x91\xA7",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 8 — Repeated emoji must not grow unboundedly
+// ---------------------------------------------------------------------------
+
+/// Feeding the same emoji 1 000 times must not panic.
+///
+/// This is a proxy for atlas-growth safety at the terminal-parser level:
+/// if the same codepoints are processed many times the internal parser state
+/// must remain O(1) and not accumulate unbounded allocations.
+#[test]
+fn no_panic_repeated_emoji_1000x() {
+    // Fire emoji UTF-8: F0 9F 94 A5
+    let emoji = b"\xF0\x9F\x94\xA5";
+
+    // Build a single 4 000-byte payload rather than re-entering the parser
+    // loop 1 000 times, to also test large buffer handling.
+    let payload: Vec<u8> = emoji.iter().cycle().take(emoji.len() * 1_000).copied().collect();
+
+    let (mut term, mut parser) = headless_term();
+    feed(&mut term, &mut parser, &payload);
+
+    // The grid dimensions must be unchanged — the parser must not have
+    // resized or corrupted the terminal.
+    assert_eq!(term.columns(), 80);
+    assert_eq!(term.screen_lines(), 24);
+}
+
+// ---------------------------------------------------------------------------
+// Bonus — random high-entropy bytes must not panic
+// ---------------------------------------------------------------------------
+
+/// A block of bytes spanning all possible byte values 0x00–0xFF must not panic.
+#[test]
+fn no_panic_all_byte_values() {
+    let (mut term, mut parser) = headless_term();
+
+    // Feed all 256 possible byte values in sequence.
+    let all_bytes: Vec<u8> = (0u8..=255).collect();
+    feed(&mut term, &mut parser, &all_bytes);
+
+    // And again in reverse — the parser must have recovered from any error.
+    let reversed: Vec<u8> = (0u8..=255).rev().collect();
+    feed(&mut term, &mut parser, &reversed);
+}


### PR DESCRIPTION
## Summary

Closes #180

- Adds `crates/phantom-terminal/tests/unicode.rs` with 11 integration tests that feed byte sequences directly into the VTE/ANSI parser (`Term<VoidListener>`, no PTY spawn) covering every scenario from the issue
- Fixes pre-existing `clippy -D warnings` failures in `phantom-terminal` source files (missing `#[must_use]` on pure-query methods, `map_or(false,…)` → `is_some_and`)
- No panics found — the alacritty VTE parser already handles all edge cases gracefully

## Test plan

- [ ] `cargo test -p phantom-terminal --test unicode` → 11 tests, all pass
- [ ] `cargo clippy -p phantom-terminal` → clean (exit 0)
- [ ] No new `#[allow(…)]` suppressions were added

🤖 Generated with [Claude Code](https://claude.com/claude-code)