### PR TITLE
test: WASM sandbox adversarial tests — WASI imports rejected (closes #186)

### DIFF
--- a/crates/phantom-plugins/src/lib.rs
+++ b/crates/phantom-plugins/src/lib.rs
@@ -25,4 +25,4 @@ pub use manifest::{
 pub use marketplace::{Marketplace, MarketplaceListing};
 pub use registry::{LoadedPlugin, PluginInfo, PluginRegistry};
 pub use script::ScriptRuntime;
-pub use wasm_host::{WasmHost, WasmRuntime};
+pub use wasm_host::{SandboxViolation, WasmHost, WasmRuntime};

--- a/crates/phantom-plugins/src/wasm_host.rs
+++ b/crates/phantom-plugins/src/wasm_host.rs
@@ -32,6 +32,36 @@ use wasmtime::{Config, Engine, Instance, Module, Store, Val};
 use crate::host::{HookContext, HookResponse, PluginRuntime};
 use crate::manifest::{HookType, PluginManifest};
 
+// ---------------------------------------------------------------------------
+// Sandbox error
+// ---------------------------------------------------------------------------
+
+/// Typed error returned when a WASM module is rejected by the sandbox.
+///
+/// The [`WasmHost::load`] method wraps instantiation failures with this type
+/// so callers can pattern-match on sandbox violations separately from other
+/// wasmtime errors.
+#[derive(Debug)]
+pub enum SandboxViolation {
+    /// The module requested an import that the host does not provide.
+    ///
+    /// This covers all WASI imports (`wasi_snapshot_preview1::*`) as well as
+    /// any unknown host namespace.
+    UnsupportedImport(String),
+}
+
+impl std::fmt::Display for SandboxViolation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SandboxViolation::UnsupportedImport(msg) => {
+                write!(f, "sandbox violation — unsupported import: {msg}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SandboxViolation {}
+
 /// Fuel budget granted to each plugin store (approx 64 MiB equivalent of work).
 ///
 /// Fuel is a dimensionless counter decremented on each WASM instruction.
@@ -68,6 +98,13 @@ impl WasmHost {
     /// The bytes may be either binary WASM (`\0asm` magic) or WAT text format
     /// (wasmtime compiles WAT transparently when the `wat` feature is active).
     ///
+    /// # Sandbox guarantee
+    ///
+    /// The host provides **no imports**.  Any module that declares an import
+    /// (WASI or otherwise) is rejected at instantiation time with a
+    /// [`SandboxViolation::UnsupportedImport`] error — before any module code
+    /// runs.
+    ///
     /// On success, returns a [`WasmRuntime`] ready to accept calls.
     pub fn load(&self, wasm_bytes: &[u8]) -> Result<WasmRuntime> {
         let module = Module::new(&self.engine, wasm_bytes)
@@ -80,9 +117,30 @@ impl WasmHost {
             .map_err(|e| anyhow::anyhow!("failed to set store fuel: {e:#}"))?;
 
         // No host-side imports — plugins that require imports will fail here,
-        // which is the desired sandboxing behaviour.
-        let instance = Instance::new(&mut store, &module, &[])
-            .map_err(|e| anyhow::anyhow!("failed to instantiate WASM module: {e:#}"))?;
+        // which is the desired sandboxing behaviour.  Surface the failure as a
+        // typed `SandboxViolation` so callers can match on it specifically.
+        let instance = Instance::new(&mut store, &module, &[]).map_err(|e| {
+            let msg = e.to_string();
+            // wasmtime reports unsatisfied imports in several ways depending on
+            // version:
+            //   - "unknown import" (older wasmtime)
+            //   - "Imports provided" (older wasmtime)
+            //   - "expected N imports, found 0" (wasmtime ≥44)
+            //
+            // Any of these indicate the module declared host imports that the
+            // sandbox does not supply.  Wrap them in the typed error so callers
+            // can match on SandboxViolation specifically.
+            let is_import_error = msg.contains("unknown import")
+                || msg.contains("Imports provided")
+                || msg.contains("expected")
+                    && msg.contains("imports")
+                    && msg.contains("found");
+            if is_import_error {
+                anyhow::Error::new(SandboxViolation::UnsupportedImport(msg))
+            } else {
+                anyhow::anyhow!("failed to instantiate WASM module: {e:#}")
+            }
+        })?;
 
         Ok(WasmRuntime { store, instance })
     }
@@ -102,6 +160,12 @@ impl Default for WasmHost {
 pub struct WasmRuntime {
     store: Store<()>,
     instance: Instance,
+}
+
+impl std::fmt::Debug for WasmRuntime {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WasmRuntime").finish_non_exhaustive()
+    }
 }
 
 impl WasmRuntime {

--- a/crates/phantom-plugins/src/wasm_host.rs
+++ b/crates/phantom-plugins/src/wasm_host.rs
@@ -26,7 +26,7 @@
 //!
 //! All exports are optional; missing exports are silently skipped.
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use wasmtime::{Config, Engine, Instance, Module, Store, Val};
 
 use crate::host::{HookContext, HookResponse, PluginRuntime};
@@ -132,9 +132,7 @@ impl WasmHost {
             // can match on SandboxViolation specifically.
             let is_import_error = msg.contains("unknown import")
                 || msg.contains("Imports provided")
-                || msg.contains("expected")
-                    && msg.contains("imports")
-                    && msg.contains("found");
+                || msg.contains("expected") && msg.contains("imports") && msg.contains("found");
             if is_import_error {
                 anyhow::Error::new(SandboxViolation::UnsupportedImport(msg))
             } else {
@@ -612,9 +610,9 @@ mod tests {
                     "QA-#186: WASI import must produce Err, not Ok"
                 );
             }
-            Err(_) => panic!(
-                "QA-#186: WasmHost::load panicked on WASI import — must return Err instead"
-            ),
+            Err(_) => {
+                panic!("QA-#186: WasmHost::load panicked on WASI import — must return Err instead")
+            }
         }
     }
 }

--- a/crates/phantom-plugins/tests/wasm_sandbox.rs
+++ b/crates/phantom-plugins/tests/wasm_sandbox.rs
@@ -155,9 +155,7 @@ fn valid_plugin_loads_correctly() {
         .expect("valid module (no WASI imports) must load");
 
     // The module exports `init() -> i32`; it returns 42.
-    let results = rt
-        .call("init", &[])
-        .expect("init export must be callable");
+    let results = rt.call("init", &[]).expect("init export must be callable");
 
     assert_eq!(results.len(), 1, "init must return one value");
     assert_eq!(

--- a/crates/phantom-plugins/tests/wasm_sandbox.rs
+++ b/crates/phantom-plugins/tests/wasm_sandbox.rs
@@ -1,0 +1,191 @@
+//! Adversarial WASM sandbox tests for `phantom-plugins`.
+//!
+//! These tests verify that the [`WasmHost`] sandbox holds under hostile
+//! inputs: modules that declare WASI or unknown-namespace imports must be
+//! rejected *before* any code executes, the registry must remain usable after
+//! a rejection, and a conforming module (no imports) must load successfully.
+//!
+//! All WASM modules are generated inline from WAT source using the `wat` crate
+//! so the test file is self-contained — no pre-compiled `.wasm` fixtures.
+//!
+//! # Issue reference
+//! Closes #186 — WASM plugin sandbox: adversarial tests.
+
+use phantom_plugins::{SandboxViolation, WasmHost};
+
+// ---------------------------------------------------------------------------
+// WAT helpers
+// ---------------------------------------------------------------------------
+
+/// WASM module that imports `wasi_snapshot_preview1::fd_write` (stdio output).
+fn wasm_with_fd_write() -> Vec<u8> {
+    wat::parse_str(
+        r#"
+        (module
+          (import "wasi_snapshot_preview1" "fd_write"
+            (func (param i32 i32 i32 i32) (result i32)))
+        )
+    "#,
+    )
+    .expect("fd_write WAT should parse")
+}
+
+/// WASM module that imports `wasi_snapshot_preview1::sock_open` (socket).
+fn wasm_with_sock_open() -> Vec<u8> {
+    wat::parse_str(
+        r#"
+        (module
+          (import "wasi_snapshot_preview1" "sock_open"
+            (func (param i32 i32 i32) (result i32)))
+        )
+    "#,
+    )
+    .expect("sock_open WAT should parse")
+}
+
+/// Conforming WASM module with no host imports.
+fn wasm_valid_no_wasi() -> Vec<u8> {
+    wat::parse_str(
+        r#"
+        (module
+          (func (export "init") (result i32) i32.const 42)
+        )
+    "#,
+    )
+    .expect("valid WAT should parse")
+}
+
+/// WASM module that imports from an unknown/internal host namespace.
+fn wasm_with_custom_namespace() -> Vec<u8> {
+    wat::parse_str(
+        r#"
+        (module
+          (import "phantom_host_internal" "secret_fn"
+            (func (param i32) (result i32)))
+        )
+    "#,
+    )
+    .expect("custom-namespace WAT should parse")
+}
+
+// ---------------------------------------------------------------------------
+// Helper: check that an anyhow error is a SandboxViolation::UnsupportedImport
+// ---------------------------------------------------------------------------
+
+fn is_sandbox_violation(err: &anyhow::Error) -> bool {
+    err.downcast_ref::<SandboxViolation>().is_some()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Loading a WASM module that imports `fd_write` must be rejected.
+///
+/// `fd_write` is the canonical WASI output syscall.  No plugin should be
+/// allowed to write to file descriptors directly — all I/O goes through the
+/// Phantom host ABI.
+#[test]
+fn wasi_fd_write_rejected() {
+    let host = WasmHost::new().expect("WasmHost::new");
+    let result = host.load(&wasm_with_fd_write());
+
+    assert!(
+        result.is_err(),
+        "fd_write import must be rejected — sandbox failed to hold"
+    );
+    let err = result.unwrap_err();
+    assert!(
+        is_sandbox_violation(&err),
+        "rejection must surface as SandboxViolation::UnsupportedImport, got: {err}"
+    );
+}
+
+/// Loading a WASM module that imports `sock_open` must be rejected.
+///
+/// Network access is not available to plugins.  `sock_open` is a WASI socket
+/// syscall that would allow unrestricted outbound connections.
+#[test]
+fn wasi_sock_open_rejected() {
+    let host = WasmHost::new().expect("WasmHost::new");
+    let result = host.load(&wasm_with_sock_open());
+
+    assert!(
+        result.is_err(),
+        "sock_open import must be rejected — network access must be blocked"
+    );
+    let err = result.unwrap_err();
+    assert!(
+        is_sandbox_violation(&err),
+        "rejection must surface as SandboxViolation::UnsupportedImport, got: {err}"
+    );
+}
+
+/// After a bad module is rejected the registry remains in a consistent state.
+///
+/// This verifies that a single load failure does not corrupt the host engine
+/// or leave it in an unusable state — subsequent loads of valid modules must
+/// succeed.
+#[test]
+fn registry_stable_after_rejection() {
+    let host = WasmHost::new().expect("WasmHost::new");
+
+    // First load: a hostile module — must fail.
+    let bad = host.load(&wasm_with_fd_write());
+    assert!(bad.is_err(), "hostile module must be rejected");
+
+    // Second load: a conforming module — must succeed.
+    let good = host.load(&wasm_valid_no_wasi());
+    if let Err(ref e) = good {
+        panic!("host must remain usable after a rejection; got: {e}");
+    }
+    assert!(good.is_ok());
+}
+
+/// A conforming WASM module (no host imports, exports `init`) must load and
+/// the `init` export must be callable.
+///
+/// This is the control condition: we verify that the sandbox rejects WASI
+/// specifically, not all modules.
+#[test]
+fn valid_plugin_loads_correctly() {
+    let host = WasmHost::new().expect("WasmHost::new");
+    let mut rt = host
+        .load(&wasm_valid_no_wasi())
+        .expect("valid module (no WASI imports) must load");
+
+    // The module exports `init() -> i32`; it returns 42.
+    let results = rt
+        .call("init", &[])
+        .expect("init export must be callable");
+
+    assert_eq!(results.len(), 1, "init must return one value");
+    assert_eq!(
+        results[0].unwrap_i32(),
+        42,
+        "init must return 42 per the WAT source"
+    );
+}
+
+/// Loading a module that imports from an unknown namespace must be rejected.
+///
+/// The Phantom host only exposes the documented plugin ABI surface.  A module
+/// importing from `phantom_host_internal` or any other undocumented namespace
+/// has no legitimate use and must be denied.
+#[test]
+fn custom_namespace_rejected() {
+    let host = WasmHost::new().expect("WasmHost::new");
+    let result = host.load(&wasm_with_custom_namespace());
+
+    assert!(
+        result.is_err(),
+        "import from unknown namespace 'phantom_host_internal' must be rejected"
+    );
+    // The error is either a SandboxViolation or a generic instantiation error —
+    // both are acceptable as long as the load fails.
+    let err = result.unwrap_err();
+    assert!(
+        !err.to_string().is_empty(),
+        "rejection must include a diagnostic message"
+    );
+}


### PR DESCRIPTION
## Summary
- Adds `tests/wasm_sandbox.rs` with 5 adversarial WASM test scenarios generated inline from WAT via the `wat` crate
- WASI `fd_write` and `sock_open` imports → `Err(SandboxViolation::UnsupportedImport)`
- Custom unknown-namespace imports (`phantom_host_internal`) → rejected
- Registry (host engine) remains stable and usable after a rejection
- Valid plugin (no WASI, exports `init`) loads and executes correctly
- Adds typed `SandboxViolation::UnsupportedImport` error to `wasm_host.rs` for pattern-matchable sandbox denials
- Updates `WasmHost::load` to cover wasmtime ≥44 error message format ("expected N imports, found 0")

## Test plan
- [ ] `cargo test -p phantom-plugins --test wasm_sandbox` passes (5 tests green)
- [ ] `cargo test -p phantom-plugins` passes (96 total tests, no regressions)

Closes #186
🤖 Generated with [Claude Code](https://claude.com/claude-code)