### PR TITLE
feat: plan extraction via sentinel heading extract_section() (closes #43)

### DIFF
--- a/crates/phantom-agents/src/lib.rs
+++ b/crates/phantom-agents/src/lib.rs
@@ -28,6 +28,7 @@ pub mod inspector;
 pub mod manager;
 pub mod mcp_tools;
 pub mod permissions;
+pub mod plan;
 pub mod quarantine;
 pub mod render;
 pub mod role;

--- a/crates/phantom-agents/src/plan.rs
+++ b/crates/phantom-agents/src/plan.rs
@@ -1,0 +1,160 @@
+//! Plan extraction helpers for LLM output parsing.
+//!
+//! Agents running in planning dispositions (Feature, BugFix, Refactor) are
+//! instructed to emit sentinel markdown sections — `## Tech Spec` and
+//! `## Implementation Plan` — inside their response text. This module
+//! provides [`extract_section`] to pull those bodies out for downstream
+//! processing (approval gates, display, archiving).
+
+/// Extract the body of a sentinel markdown section from LLM output.
+///
+/// Scans `text` for a line exactly matching `## {heading}` and returns
+/// everything until the next `## ` heading or end of string, trimmed.
+/// Returns `None` if the heading is not found.
+///
+/// # Examples
+///
+/// ```
+/// use phantom_agents::plan::extract_section;
+///
+/// let text = "## Tech Spec\nUse Rust.\n\n## Implementation Plan\nStep 1.";
+/// assert_eq!(extract_section(text, "Tech Spec"), Some("Use Rust.".to_string()));
+/// assert_eq!(extract_section(text, "Implementation Plan"), Some("Step 1.".to_string()));
+/// assert_eq!(extract_section(text, "Missing"), None);
+/// ```
+pub fn extract_section(text: &str, heading: &str) -> Option<String> {
+    let marker = format!("## {heading}");
+    let start = text.find(&marker)? + marker.len();
+    let rest = &text[start..];
+    let end = rest.find("\n## ").unwrap_or(rest.len());
+    Some(rest[..end].trim().to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- present -----------------------------------------------------------
+
+    #[test]
+    fn present_section_returns_body() {
+        let text = "## Tech Spec\nUse Rust.\n\n## Implementation Plan\nStep 1.\nStep 2.";
+        assert_eq!(
+            extract_section(text, "Tech Spec"),
+            Some("Use Rust.".to_string())
+        );
+    }
+
+    #[test]
+    fn second_section_returns_correct_body() {
+        let text = "## Tech Spec\nUse Rust.\n\n## Implementation Plan\nStep 1.\nStep 2.";
+        assert_eq!(
+            extract_section(text, "Implementation Plan"),
+            Some("Step 1.\nStep 2.".to_string())
+        );
+    }
+
+    // --- absent -----------------------------------------------------------
+
+    #[test]
+    fn absent_heading_returns_none() {
+        let text = "## Tech Spec\nSome content here.";
+        assert_eq!(extract_section(text, "Missing"), None);
+    }
+
+    #[test]
+    fn empty_text_returns_none() {
+        assert_eq!(extract_section("", "Tech Spec"), None);
+    }
+
+    // --- last section (no following ##) -----------------------------------
+
+    #[test]
+    fn last_section_no_following_heading_returns_body() {
+        let text = "## Preamble\nIgnore this.\n\n## Implementation Plan\nFinal step here.";
+        assert_eq!(
+            extract_section(text, "Implementation Plan"),
+            Some("Final step here.".to_string())
+        );
+    }
+
+    #[test]
+    fn heading_at_end_of_string_returns_empty_string() {
+        // Heading exists but has no body after it.
+        let text = "## Tech Spec";
+        assert_eq!(
+            extract_section(text, "Tech Spec"),
+            Some(String::new())
+        );
+    }
+
+    // --- leading / trailing whitespace ------------------------------------
+
+    #[test]
+    fn body_is_trimmed_of_leading_trailing_whitespace() {
+        let text = "## Tech Spec\n\n   Use Rust.   \n\n## Implementation Plan\nStep 1.";
+        assert_eq!(
+            extract_section(text, "Tech Spec"),
+            Some("Use Rust.".to_string())
+        );
+    }
+
+    #[test]
+    fn body_with_only_whitespace_returns_empty_string() {
+        let text = "## Tech Spec\n   \n\n## Next\nOther content.";
+        assert_eq!(
+            extract_section(text, "Tech Spec"),
+            Some(String::new())
+        );
+    }
+
+    // --- multiple sections ------------------------------------------------
+
+    #[test]
+    fn multiple_sections_each_returns_own_body() {
+        let text = "\
+## Overview\n\
+Background here.\n\
+\n\
+## Tech Spec\n\
+Use async Rust.\n\
+\n\
+## Implementation Plan\n\
+1. Write code.\n\
+2. Test it.\n\
+\n\
+## Risks\n\
+Low risk.";
+
+        assert_eq!(
+            extract_section(text, "Overview"),
+            Some("Background here.".to_string())
+        );
+        assert_eq!(
+            extract_section(text, "Tech Spec"),
+            Some("Use async Rust.".to_string())
+        );
+        assert_eq!(
+            extract_section(text, "Implementation Plan"),
+            Some("1. Write code.\n2. Test it.".to_string())
+        );
+        assert_eq!(
+            extract_section(text, "Risks"),
+            Some("Low risk.".to_string())
+        );
+    }
+
+    #[test]
+    fn first_occurrence_is_used_when_heading_duplicated() {
+        // find() returns the first match — this is documented behaviour.
+        let text = "## Tech Spec\nFirst.\n\n## Tech Spec\nSecond.";
+        assert_eq!(
+            extract_section(text, "Tech Spec"),
+            Some("First.".to_string())
+        );
+    }
+}

--- a/crates/phantom-agents/src/system_prompt.rs
+++ b/crates/phantom-agents/src/system_prompt.rs
@@ -35,6 +35,21 @@ const BOUNDARY_LINE: &str =
     "If you need a capability you don't have, say so and request escalation \
      — do NOT invent tool calls.";
 
+/// Planning-disposition sentinel instruction. Injected for agents whose
+/// disposition `requires_plan_gate()` (Feature, BugFix, Refactor). The
+/// downstream approval gate and [`crate::plan::extract_section`] both key on
+/// these exact headings, so the wording must not be paraphrased.
+const PLANNING_SENTINEL_INSTRUCTION: &str = "\
+Structure your response with these two sentinel sections so the approval gate \
+can parse and display your plan:\n\
+\n\
+## Tech Spec\n\
+Describe the technical design: data structures, interfaces, invariants, \
+and any trade-offs.\n\
+\n\
+## Implementation Plan\n\
+List the concrete steps you will take, in order, to complete the task.";
+
 /// Composer-only protocol addendum. Pinned verbatim — the dispatcher,
 /// recipient agents, and the user-facing report all parse for the
 /// AGREE/DISAGREE/PARTIAL tokens, so paraphrasing this paragraph would
@@ -87,6 +102,10 @@ pub struct SystemPromptBuilder {
     /// rendered under `## Recent command output` so the agent can reason
     /// about prior command results without re-reading raw terminal text.
     pub semantic_context: Option<String>,
+    /// When `true`, the planning-disposition sentinel instruction is appended
+    /// so the model knows to produce `## Tech Spec` and `## Implementation
+    /// Plan` sections. Set via [`SystemPromptBuilder::with_planning_sentinels`].
+    pub planning_sentinels: bool,
 }
 
 impl SystemPromptBuilder {
@@ -101,6 +120,7 @@ impl SystemPromptBuilder {
             tool_summary: None,
             other_agents: None,
             semantic_context: None,
+            planning_sentinels: false,
         }
     }
 
@@ -156,6 +176,18 @@ impl SystemPromptBuilder {
         self
     }
 
+    /// Enable the planning-disposition sentinel instruction.
+    ///
+    /// Call this for agents whose [`crate::dispatch::Disposition`] returns
+    /// `true` from `requires_plan_gate()` (i.e. Feature, BugFix, Refactor).
+    /// The instruction tells the model to emit `## Tech Spec` and
+    /// `## Implementation Plan` sections that [`crate::plan::extract_section`]
+    /// can parse at the approval gate.
+    pub fn with_planning_sentinels(mut self) -> Self {
+        self.planning_sentinels = true;
+        self
+    }
+
     /// Materialize the final system prompt.
     ///
     /// Sections are emitted in this fixed order, separated by blank lines:
@@ -167,7 +199,10 @@ impl SystemPromptBuilder {
     /// 5. `## Workspace inventory` (if set).
     /// 6. `## Tools you can call` (if set).
     /// 7. `## Recent command output` (if semantic context is set and non-empty).
-    /// 8. Closing pane-id citation rule (always present).
+    /// 8. Planning sentinel instruction (if [`with_planning_sentinels`] was called).
+    /// 9. Closing pane-id citation rule (always present).
+    ///
+    /// [`with_planning_sentinels`]: SystemPromptBuilder::with_planning_sentinels
     ///
     /// When `agent.role == AgentRole::Composer`, the role-specific
     /// debate/critique protocol is appended after the boundary line so it
@@ -241,7 +276,16 @@ impl SystemPromptBuilder {
             sections.push(ctx_section.clone());
         }
 
-        // 8. Closing line.
+        // 8. Planning-disposition sentinel instruction.
+        // Injected when the disposition requires a plan gate (Feature /
+        // BugFix / Refactor) so the model structures its response with the
+        // ## Tech Spec and ## Implementation Plan sections that the approval
+        // gate and `plan::extract_section` expect.
+        if self.planning_sentinels {
+            sections.push(PLANNING_SENTINEL_INSTRUCTION.to_string());
+        }
+
+        // 9. Closing line.
         sections.push(CLOSING_LINE.to_string());
 
         sections.join("\n\n")
@@ -537,5 +581,64 @@ mod tests {
         let task_idx = prompt.find("## Task").expect("task heading");
         assert!(boundary_idx < peers_idx, "peers must follow boundary");
         assert!(peers_idx < task_idx, "peers must precede task");
+    }
+
+    // --- planning sentinels -----------------------------------------------
+
+    #[test]
+    fn planning_sentinels_absent_by_default() {
+        let prompt = SystemPromptBuilder::new(agent(AgentRole::Actor, "act", 1)).build();
+        assert!(
+            !prompt.contains("## Tech Spec"),
+            "sentinel ## Tech Spec must not appear without with_planning_sentinels; got:\n{prompt}",
+        );
+        assert!(
+            !prompt.contains("## Implementation Plan"),
+            "sentinel ## Implementation Plan must not appear without with_planning_sentinels; \
+             got:\n{prompt}",
+        );
+    }
+
+    #[test]
+    fn planning_sentinels_present_when_enabled() {
+        let prompt = SystemPromptBuilder::new(agent(AgentRole::Actor, "act", 1))
+            .with_planning_sentinels()
+            .build();
+        assert!(
+            prompt.contains("## Tech Spec"),
+            "## Tech Spec sentinel must appear when with_planning_sentinels is set; got:\n{prompt}",
+        );
+        assert!(
+            prompt.contains("## Implementation Plan"),
+            "## Implementation Plan sentinel must appear when with_planning_sentinels is set; \
+             got:\n{prompt}",
+        );
+    }
+
+    #[test]
+    fn planning_sentinels_appear_before_closing_line() {
+        let prompt = SystemPromptBuilder::new(agent(AgentRole::Actor, "act", 1))
+            .with_planning_sentinels()
+            .build();
+        let sentinel_idx = prompt.find("## Tech Spec").expect("Tech Spec sentinel");
+        let closing_idx = prompt.find(CLOSING_LINE).expect("closing line");
+        assert!(
+            sentinel_idx < closing_idx,
+            "planning sentinel instruction must precede the closing line",
+        );
+    }
+
+    #[test]
+    fn planning_sentinels_appear_after_task_section() {
+        let prompt = SystemPromptBuilder::new(agent(AgentRole::Actor, "act", 1))
+            .with_task("Implement the feature".to_string())
+            .with_planning_sentinels()
+            .build();
+        let task_idx = prompt.find("## Task").expect("## Task heading");
+        let sentinel_idx = prompt.find("## Tech Spec").expect("Tech Spec sentinel");
+        assert!(
+            task_idx < sentinel_idx,
+            "planning sentinel instruction must follow the task section",
+        );
     }
 }


### PR DESCRIPTION
## Summary
- New `crates/phantom-agents/src/plan.rs` with `extract_section(text, heading) -> Option<String>`
- Scans LLM output for `## {heading}` sentinel sections used by planning dispositions
- 10 unit tests covering normal extraction, multi-section, missing heading, edge cases

## Test plan
- [ ] `cargo test -p phantom-agents` passes

Closes #43
🤖 Generated with [Claude Code](https://claude.com/claude-code)