### PR TITLE
arch: spec gate — mandatory SPEC/PLAN/TASKS before executor spawns (closes #317)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -365,3 +365,5 @@ Rules that govern how autonomous agents coordinate within the Phantom multi-agen
 4. **Long-running agent timeout**: Any implementation agent running for more than 30 minutes without opening a PR should be checked on by sending a status message.
 
 5. **Hot-file tracking**: Before spawning an agent on a crate, check `gh pr list -R jdmiranda/phantom --state open` to confirm no other open PR already modifies the same files.
+
+6. **Spec gate**: Before spawning any executor agent, a spec agent must first produce SPEC.md, PLAN.md, and TASKS.md in the worktree. The executor receives only TASKS.md — not the raw issue. Any issue scoring ≥7/10 on the MAST rubric may skip the spec agent; lower-scoring issues must pass through it.

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -140,6 +140,43 @@ Tier 3 — architectural:
 
 ---
 
+## Agent Pipeline: Three-Artifact Spec Gate
+
+All non-trivial issues (MAST score < 7/10) must pass through a spec agent before an executor agent is spawned. The spec agent produces three artifacts in the worktree root. The executor receives only TASKS.md — not the raw issue.
+
+### SPEC.md
+Answers *what* changes, not *how*:
+- **Behavioral outcome** — observable difference after the change
+- **Current state** — exact file:line references for the code being changed
+- **Acceptance criteria** — each criterion independently testable via `cargo test`
+- **Non-goals** — explicit scope boundaries that keep the PR small
+
+### PLAN.md
+Answers *which files* and *what shape*:
+- List every file that changes
+- For each file: function signatures added/modified, new types, removed items
+- No implementation code — signatures and shapes only
+- Dependency order (which change must land first)
+
+### TASKS.md
+Answers *in what order*:
+- Numbered checklist the executor follows step-by-step
+- Each task is a single atomic action (one function, one struct, one test)
+- Gate check after every 3–5 tasks (`cargo build -p <crate>`)
+- Final acceptance check: exact `cargo test` command that must pass before PR opens
+
+### MAST Rubric
+Issues are scored 1–10. Score ≥ 7 may skip the spec agent (well-scoped, clear acceptance criteria, single crate). Score < 7 requires a spec pass.
+
+| Dimension | Weight |
+|-----------|--------|
+| **M**odularity — change confined to ≤ 2 crates | 3 |
+| **A**cceptability — acceptance criteria stated in issue | 3 |
+| **S**cope — estimated LoC change < 200 | 2 |
+| **T**estability — existing test harness covers the area | 2 |
+
+---
+
 ## Architecture Decision Records
 
 | ADR | Title | Status |


### PR DESCRIPTION
## Summary
- Adds CLAUDE.md Rule 6: spec gate requiring SPEC/PLAN/TASKS artifacts before executor spawns
- Creates `~/.claude/skills/plan-issue/SKILL.md` global skill for producing the three artifacts
- Documents three-artifact pipeline (SPEC/PLAN/TASKS) and MAST rubric in docs/PLAN.md
- Executor receives TASKS.md only (not raw issue), reducing vague-spec rework

## Test plan
- [ ] `~/.claude/skills/plan-issue/SKILL.md` exists and is loadable
- [ ] `CLAUDE.md` Rule 6 (spec gate) is present
- [ ] `docs/PLAN.md` documents the three-artifact pipeline and MAST rubric

Closes #317
🤖 Generated with [Claude Code](https://claude.com/claude-code)