### PR TITLE
infra: enforce branch-from-tag, add pre-pr-check.sh (closes #126)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -366,4 +366,6 @@ Rules that govern how autonomous agents coordinate within the Phantom multi-agen
 
 5. **Hot-file tracking**: Before spawning an agent on a crate, check `gh pr list -R jdmiranda/phantom --state open` to confirm no other open PR already modifies the same files.
 
-6. **Spec gate**: Before spawning any executor agent, a spec agent must first produce SPEC.md, PLAN.md, and TASKS.md in the worktree. The executor receives only TASKS.md — not the raw issue. Any issue scoring ≥7/10 on the MAST rubric may skip the spec agent; lower-scoring issues must pass through it.
+6. **Branch hygiene**: All agent worktrees MUST branch from the most recent clean baseline tag, not from HEAD of main. Spawn command: `git checkout $(git describe --tags --match 'v*.baseline' --abbrev=0 2>/dev/null || git rev-parse --short origin/main) -b <branch-name>`. Never: `git checkout main -b <branch>`.
+
+7. **Spec gate**: Before spawning any executor agent, a spec agent must first produce SPEC.md, PLAN.md, and TASKS.md in the worktree. The executor receives only TASKS.md — not the raw issue. Any issue scoring ≥7/10 on the MAST rubric may skip the spec agent; lower-scoring issues must pass through it.

--- a/docs/PHASE1-EXECUTION.md
+++ b/docs/PHASE1-EXECUTION.md
@@ -455,6 +455,20 @@ impl TerminalAdapter {
 
 ## 6. Agent Pipeline: Build → Review → Merge
 
+### Worktree Spawn Convention
+
+All agent worktrees MUST branch from the most recent clean baseline tag, not from HEAD of main.
+
+```bash
+# Correct — branch from baseline tag
+git checkout $(git describe --tags --match 'v*.baseline' --abbrev=0 2>/dev/null || git rev-parse --short origin/main) -b <branch-name>
+
+# Wrong — never do this
+git checkout main -b <branch-name>
+```
+
+The baseline tag marks a commit where `cargo build --workspace` and `cargo test --workspace --no-run` passed cleanly. Branching from it prevents agents from inheriting mid-stream work-in-progress from main that hasn't been gated. Current baseline: `v0.2.0-phase1.baseline`.
+
 ### Stage 0: Trait Split (Wave 0)
 
 **Agent Z — Trait Split** (WU-0)

--- a/scripts/pre-pr-check.sh
+++ b/scripts/pre-pr-check.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
 # Pre-PR health check — runs fast local gates before opening a pull request.
-# Usage: ./scripts/pre-pr-check.sh [--fast]
 #
-# Gates (in order):
+# Usage:
+#   ./scripts/pre-pr-check.sh <crate-name>   # per-crate mode (required by orchestration rule #2)
+#   ./scripts/pre-pr-check.sh [--fast]       # workspace mode (default; --fast skips clippy)
+#
+# Per-crate mode gates (in order):
+#   1. cargo build -p <crate>
+#   2. cargo test  -p <crate>
+#   3. cargo clippy -p <crate> -- -D warnings
+#
+# Workspace mode gates (in order):
 #   1. cargo check (type-check all workspace crates, no codegen)
 #   2. cargo fmt --check (formatting)
 #   3. cargo clippy (lints, warnings-as-errors)
@@ -15,7 +23,6 @@ set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
-FAST="${1:-}"
 FAILURES=0
 
 run_gate() {
@@ -30,6 +37,28 @@ run_gate() {
         FAILURES=$((FAILURES + 1))
     fi
 }
+
+# Per-crate mode: first arg is a crate name (not a flag)
+FIRST="${1:-}"
+if [[ -n "$FIRST" && "$FIRST" != "--fast" ]]; then
+    CRATE="$FIRST"
+    echo "pre-pr-check: per-crate mode for '$CRATE'"
+    run_gate "build ($CRATE)"   cargo build  -p "$CRATE"
+    run_gate "test ($CRATE)"    cargo test   -p "$CRATE"
+    run_gate "clippy ($CRATE)"  cargo clippy -p "$CRATE" -- -D warnings
+    echo ""
+    if [[ "$FAILURES" -eq 0 ]]; then
+        echo "pre-pr-check passed for $CRATE"
+        exit 0
+    else
+        echo "$FAILURES gate(s) failed for $CRATE"
+        exit 1
+    fi
+fi
+
+# Workspace mode
+FAST="${FIRST:-}"
+echo "pre-pr-check: workspace mode"
 
 # Gate 1: type-check
 run_gate "cargo check (phantom-ui)" cargo check -p phantom-ui


### PR DESCRIPTION
## Summary

- Rebased after #339 (spec gate) added Rule #6 to CLAUDE.md — conflict resolved
- Both rules preserved with correct numbering: **Rule #6** = branch hygiene, **Rule #7** = spec gate
- Adds `./scripts/pre-pr-check.sh` for agent self-check before PR creation
- Enforces branch-from-baseline-tag policy for all agent worktrees

## Changes

- `CLAUDE.md`: Rule #6 (branch hygiene) and Rule #7 (spec gate) both present, no numbering collision
- `scripts/pre-pr-check.sh`: new script enforcing pre-PR crate build/test gate

## Test plan

- [ ] Verify `grep -n "Rule\|spec gate\|branch" CLAUDE.md` shows rules 1–7 with no gaps or duplicates
- [ ] Run `./scripts/pre-pr-check.sh phantom-agents` on a clean checkout — expect pass
- [ ] Run `./scripts/pre-pr-check.sh` on a crate with test failures — expect non-zero exit

Closes #126.