### PR TITLE
feat(#323): v1 alt-screen split-pane — smoke & mirrors

### DIFF
--- a/crates/phantom-adapter/src/adapter.rs
+++ b/crates/phantom-adapter/src/adapter.rs
@@ -67,6 +67,24 @@ pub trait AppCore: Send {
     fn output_buf_snapshot(&self) -> Option<String> {
         None
     }
+
+    /// Wire a shared render-snapshot Arc into this adapter.
+    ///
+    /// Called by `App::split_for_alt_screen` when the layout is split so that
+    /// the alt-screen view sibling can receive rendered grid data each frame.
+    /// Terminal adapters store the Arc and write into it during `update()`.
+    ///
+    /// The default no-op means all non-terminal adapters compile unchanged.
+    fn attach_alt_screen_snapshot(
+        &mut self,
+        _snapshot: std::sync::Arc<std::sync::Mutex<Option<RenderOutput>>>,
+    ) {
+    }
+
+    /// Remove the shared render-snapshot Arc previously set by
+    /// `attach_alt_screen_snapshot`.  Called when the secondary pane is
+    /// collapsed.  The default is a no-op.
+    fn detach_alt_screen_snapshot(&mut self) {}
 }
 
 /// Visual adapters that render into a rect.
@@ -188,7 +206,13 @@ pub trait AppAdapter:
 }
 
 impl<T> AppAdapter for T where
-    T: AppCore + Renderable + InputHandler + Commandable + BusParticipant + Lifecycled + Permissioned
+    T: AppCore
+        + Renderable
+        + InputHandler
+        + Commandable
+        + BusParticipant
+        + Lifecycled
+        + Permissioned
 {
 }
 

--- a/crates/phantom-adapter/src/bus.rs
+++ b/crates/phantom-adapter/src/bus.rs
@@ -78,12 +78,7 @@ impl EventBus {
     }
 
     /// Register a new topic. Returns the assigned `TopicId`.
-    pub fn create_topic(
-        &mut self,
-        publisher: AppId,
-        name: &str,
-        data_type: DataType,
-    ) -> TopicId {
+    pub fn create_topic(&mut self, publisher: AppId, name: &str, data_type: DataType) -> TopicId {
         let id = self.next_topic_id;
         self.next_topic_id += 1;
         self.topics.push(Topic {
@@ -258,14 +253,23 @@ mod tests {
         bus.emit(BusMessage {
             topic_id: t_output,
             sender: 0,
-            event: Event::TerminalOutput { app_id: 0, bytes: 2 },
+            event: Event::TerminalOutput {
+                app_id: 0,
+                bytes: 2,
+            },
             frame: 0,
             timestamp: 42,
         });
 
         let msgs = bus.drain_for(brain_id);
         assert_eq!(msgs.len(), 1);
-        assert!(matches!(msgs[0].event, Event::TerminalOutput { app_id: 0, bytes: 2 }));
+        assert!(matches!(
+            msgs[0].event,
+            Event::TerminalOutput {
+                app_id: 0,
+                bytes: 2
+            }
+        ));
         assert_eq!(msgs[0].timestamp, 42);
     }
 
@@ -283,7 +287,10 @@ mod tests {
         bus.emit(BusMessage {
             topic_id: t_error,
             sender: 0,
-            event: Event::Custom { kind: "error".into(), data: "has_errors".into() },
+            event: Event::Custom {
+                kind: "error".into(),
+                data: "has_errors".into(),
+            },
             frame: 0,
             timestamp: 1,
         });
@@ -339,7 +346,10 @@ mod tests {
             bus.emit(BusMessage {
                 topic_id: t_output,
                 sender: 0,
-                event: Event::TerminalOutput { app_id: 0, bytes: ts },
+                event: Event::TerminalOutput {
+                    app_id: 0,
+                    bytes: ts,
+                },
                 frame: ts,
                 timestamp: ts,
             });
@@ -361,7 +371,10 @@ mod tests {
             bus.emit(BusMessage {
                 topic_id: tid,
                 sender: 0,
-                event: Event::Custom { kind: "spam".into(), data: i.to_string() },
+                event: Event::Custom {
+                    kind: "spam".into(),
+                    data: i.to_string(),
+                },
                 frame: i,
                 timestamp: i,
             });
@@ -387,7 +400,10 @@ mod tests {
         bus.emit(BusMessage {
             topic_id: tid,
             sender: 0,
-            event: Event::Custom { kind: "test".into(), data: "first".into() },
+            event: Event::Custom {
+                kind: "test".into(),
+                data: "first".into(),
+            },
             frame: 0,
             timestamp: 1,
         });

--- a/crates/phantom-adapter/src/lib.rs
+++ b/crates/phantom-adapter/src/lib.rs
@@ -17,15 +17,15 @@ pub use adapter::{
     AppAdapter, AppCore, BusParticipant, Commandable, InputHandler, Lifecycled, Permissioned,
     Renderable,
 };
-pub use adapter::{AppId, CursorData, CursorShape, GridData, QuadData, Rect, RenderOutput, TerminalCell, TextData};
-pub use bus::{BusMessage, DataType, EventBus, Topic, TopicDeclaration, TopicId};
-pub use phantom_protocol::Event;
-pub use lifecycle::AppState;
-pub use protocol::{AdapterId, AdapterEvent, AdapterIdGen, EventStream};
-pub use registry::{AppRegistry, RegisteredApp};
-pub use spatial::{
-    Direction, InternalLayout, NegotiationResult, ResizeResult, SpatialPreference,
+pub use adapter::{
+    AppId, CursorData, CursorShape, GridData, QuadData, Rect, RenderOutput, TerminalCell, TextData,
 };
+pub use bus::{BusMessage, DataType, EventBus, Topic, TopicDeclaration, TopicId};
+pub use lifecycle::AppState;
+pub use phantom_protocol::Event;
+pub use protocol::{AdapterEvent, AdapterId, AdapterIdGen, EventStream};
+pub use registry::{AppRegistry, RegisteredApp};
+pub use spatial::{Direction, InternalLayout, NegotiationResult, ResizeResult, SpatialPreference};
 
 #[cfg(test)]
 mod tests {
@@ -388,7 +388,10 @@ mod tests {
         bus.emit(BusMessage {
             topic_id: tid,
             sender: 1,
-            event: Event::Custom { kind: "test".into(), data: "value".into() },
+            event: Event::Custom {
+                kind: "test".into(),
+                data: "value".into(),
+            },
             frame: 0,
             timestamp: 100,
         });
@@ -412,14 +415,20 @@ mod tests {
         bus.emit(BusMessage {
             topic_id: t1,
             sender: 1,
-            event: Event::Custom { kind: "audio".into(), data: "audio_data".into() },
+            event: Event::Custom {
+                kind: "audio".into(),
+                data: "audio_data".into(),
+            },
             frame: 0,
             timestamp: 1,
         });
         bus.emit(BusMessage {
             topic_id: t2,
             sender: 1,
-            event: Event::Custom { kind: "text".into(), data: "text_data".into() },
+            event: Event::Custom {
+                kind: "text".into(),
+                data: "text_data".into(),
+            },
             frame: 0,
             timestamp: 2,
         });
@@ -442,7 +451,10 @@ mod tests {
         bus.emit(BusMessage {
             topic_id: tid,
             sender: 1,
-            event: Event::Custom { kind: "test".into(), data: "hello".into() },
+            event: Event::Custom {
+                kind: "test".into(),
+                data: "hello".into(),
+            },
             frame: 0,
             timestamp: 1,
         });
@@ -506,7 +518,10 @@ mod tests {
         bus.emit(BusMessage {
             topic_id: tid,
             sender: 1,
-            event: Event::Custom { kind: "test".into(), data: "will be removed".into() },
+            event: Event::Custom {
+                kind: "test".into(),
+                data: "will be removed".into(),
+            },
             frame: 0,
             timestamp: 1,
         });
@@ -613,8 +628,16 @@ mod tests {
     fn grid_data_with_cells() {
         let grid = GridData {
             cells: vec![
-                TerminalCell { ch: 'H', fg: [1.0, 1.0, 1.0, 1.0], bg: [0.0, 0.0, 0.0, 1.0] },
-                TerminalCell { ch: 'i', fg: [0.0, 1.0, 0.0, 1.0], bg: [0.0, 0.0, 0.0, 1.0] },
+                TerminalCell {
+                    ch: 'H',
+                    fg: [1.0, 1.0, 1.0, 1.0],
+                    bg: [0.0, 0.0, 0.0, 1.0],
+                },
+                TerminalCell {
+                    ch: 'i',
+                    fg: [0.0, 1.0, 0.0, 1.0],
+                    bg: [0.0, 0.0, 0.0, 1.0],
+                },
             ],
             cols: 2,
             rows: 1,
@@ -816,8 +839,8 @@ mod tests {
     #[test]
     fn adapter_id_is_copy_at_registration_boundary() {
         let id = AdapterId::new(7);
-        let stored = id;     // copy #1 — coordinator stores this
-        let returned = id;   // copy #2 — adapter returns from adapter_id()
+        let stored = id; // copy #1 — coordinator stores this
+        let returned = id; // copy #2 — adapter returns from adapter_id()
         assert_eq!(stored, returned);
     }
 

--- a/crates/phantom-adapter/src/protocol.rs
+++ b/crates/phantom-adapter/src/protocol.rs
@@ -381,7 +381,9 @@ mod tests {
             .map(|_| {
                 let id_gen = Arc::clone(&id_gen);
                 std::thread::spawn(move || {
-                    (0..IDS_PER_THREAD).map(|_| id_gen.next().get()).collect::<Vec<u64>>()
+                    (0..IDS_PER_THREAD)
+                        .map(|_| id_gen.next().get())
+                        .collect::<Vec<u64>>()
                 })
             })
             .collect();
@@ -475,10 +477,18 @@ mod tests {
     #[test]
     fn adapter_event_non_exhaustive_match_all_variants() {
         let events = vec![
-            AdapterEvent::Spawned { id: AdapterId::new(1) },
-            AdapterEvent::Closed { id: AdapterId::new(2) },
-            AdapterEvent::Focused { id: AdapterId::new(3) },
-            AdapterEvent::ContentChanged { id: AdapterId::new(4) },
+            AdapterEvent::Spawned {
+                id: AdapterId::new(1),
+            },
+            AdapterEvent::Closed {
+                id: AdapterId::new(2),
+            },
+            AdapterEvent::Focused {
+                id: AdapterId::new(3),
+            },
+            AdapterEvent::ContentChanged {
+                id: AdapterId::new(4),
+            },
         ];
         for ev in events {
             // Every variant is handled — proof of coverage.
@@ -562,7 +572,9 @@ mod tests {
         let mut stream = EventStream::new();
         // Fill to capacity with Spawned events tagged with sequential ids.
         for i in 0..MAX_STREAM_CAPACITY as u64 {
-            stream.push(AdapterEvent::Spawned { id: AdapterId::new(i) });
+            stream.push(AdapterEvent::Spawned {
+                id: AdapterId::new(i),
+            });
         }
         // Push one more Closed event — this should evict the oldest Spawned.
         let newest_id = AdapterId::new(9999);
@@ -571,12 +583,16 @@ mod tests {
         let events = stream.drain();
         // The newest event must be present.
         assert!(
-            events.iter().any(|e| matches!(e, AdapterEvent::Closed { id } if *id == newest_id)),
+            events
+                .iter()
+                .any(|e| matches!(e, AdapterEvent::Closed { id } if *id == newest_id)),
             "newest event must survive capacity eviction",
         );
         // The very first Spawned (id=0) must have been evicted.
         assert!(
-            !events.iter().any(|e| matches!(e, AdapterEvent::Spawned { id } if id.get() == 0)),
+            !events
+                .iter()
+                .any(|e| matches!(e, AdapterEvent::Spawned { id } if id.get() == 0)),
             "oldest event (id=0) must have been evicted at capacity",
         );
     }

--- a/crates/phantom-adapter/src/registry.rs
+++ b/crates/phantom-adapter/src/registry.rs
@@ -112,8 +112,7 @@ impl AppRegistry {
 
     /// Borrow the adapter for `id`.
     pub fn get_adapter(&self, id: AppId) -> Option<&dyn AppAdapter> {
-        self.index_of(id)
-            .and_then(|i| self.adapters[i].as_deref())
+        self.index_of(id).and_then(|i| self.adapters[i].as_deref())
     }
 
     /// Mutably borrow the adapter for `id`.

--- a/crates/phantom-app/src/adapters/agent.rs
+++ b/crates/phantom-app/src/adapters/agent.rs
@@ -155,7 +155,10 @@ impl AppCore for AgentAdapter {
         //   total_lines.saturating_sub(output_max_lines)
         // Using cached_output_max_lines keeps this consistent so that
         // mouse.rs click-jump math doesn't overshoot by up to output_max_lines.
-        let history_size = self.pane.cached_lines().len()
+        let history_size = self
+            .pane
+            .cached_lines()
+            .len()
             .saturating_sub(self.cached_output_max_lines.get());
         json!({
             "type": "agent",
@@ -375,9 +378,7 @@ impl Commandable for AgentAdapter {
                 // Scrollbar click-jump: {"offset": N}
                 // Clamp to max_offset so an oversized click-jump cannot leave the
                 // thumb stuck past the end of the history.
-                let offset = args.get("offset")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0) as usize;
+                let offset = args.get("offset").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
                 let total_lines = self.pane.cached_lines().len();
                 let max_offset = total_lines.saturating_sub(self.cached_output_max_lines.get());
                 self.scroll_offset = offset.min(max_offset);

--- a/crates/phantom-app/src/adapters/alt_screen_view.rs
+++ b/crates/phantom-app/src/adapters/alt_screen_view.rs
@@ -1,0 +1,262 @@
+//! Alt-screen view adapter — read-only mirror of a primary terminal's
+//! alt-screen render output.
+//!
+//! Used by issue #323: when a terminal enters alt-screen mode (vim, htop,
+//! less), the primary pane renders the normal-screen history while a sibling
+//! `AltScreenViewAdapter` renders the alt-screen program. Both share the same
+//! `Arc<Mutex<Option<RenderOutput>>>` snapshot that the primary writes each
+//! frame via its `update()` override.
+//!
+//! The view adapter is intentionally minimal: no PTY, no input, no commands.
+//! It exists only to give the coordinator a second pane slot so the layout
+//! engine creates a visual split.
+
+use std::sync::{Arc, Mutex};
+
+use phantom_adapter::adapter::{Rect, RenderOutput};
+use phantom_adapter::spatial::{InternalLayout, SpatialPreference};
+use phantom_adapter::{
+    AppCore, BusParticipant, Commandable, InputHandler, Lifecycled, Permissioned, Renderable,
+};
+use serde_json::json;
+
+/// A shared render-snapshot handle passed between the primary terminal adapter
+/// and its alt-screen view sibling.
+///
+/// The primary calls `write()` each frame; the view adapter calls `read()`
+/// in its `render()` implementation.
+pub type AltScreenSnapshot = Arc<Mutex<Option<RenderOutput>>>;
+
+/// Create a new empty snapshot handle.
+pub fn new_snapshot() -> AltScreenSnapshot {
+    Arc::new(Mutex::new(None))
+}
+
+/// Read-only adapter that mirrors an alt-screen program's grid into a sibling pane.
+pub struct AltScreenViewAdapter {
+    snapshot: AltScreenSnapshot,
+    app_id: u32,
+    /// Human-readable label of the foreground program (e.g. "vim", "htop").
+    label: String,
+}
+
+impl AltScreenViewAdapter {
+    /// Create a new view adapter backed by `snapshot`.
+    pub fn new(snapshot: AltScreenSnapshot, label: String) -> Self {
+        Self {
+            snapshot,
+            app_id: 0,
+            label,
+        }
+    }
+
+    /// The shared snapshot handle (hand this to the primary adapter).
+    pub fn snapshot_arc(&self) -> AltScreenSnapshot {
+        Arc::clone(&self.snapshot)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sub-trait implementations
+// ---------------------------------------------------------------------------
+
+impl AppCore for AltScreenViewAdapter {
+    fn app_type(&self) -> &str {
+        "alt_screen_view"
+    }
+
+    fn is_alive(&self) -> bool {
+        true
+    }
+
+    fn update(&mut self, _dt: f32) {}
+
+    fn get_state(&self) -> serde_json::Value {
+        json!({
+            "type": "alt_screen_view",
+            "label": self.label,
+        })
+    }
+
+    fn title(&self) -> &str {
+        &self.label
+    }
+}
+
+impl Renderable for AltScreenViewAdapter {
+    fn render(&self, rect: &Rect) -> RenderOutput {
+        // Attempt to read the latest snapshot pushed by the primary terminal.
+        if let Ok(guard) = self.snapshot.lock() {
+            if let Some(mut output) = guard.clone() {
+                // Re-anchor the grid origin to this adapter's rect, since the
+                // primary may have been positioned differently.
+                if let Some(ref mut grid) = output.grid {
+                    grid.origin = (rect.x, rect.y);
+                }
+                return output;
+            }
+        }
+        // No snapshot yet — return empty output.
+        RenderOutput::default()
+    }
+
+    fn is_visual(&self) -> bool {
+        true
+    }
+
+    fn spatial_preference(&self) -> Option<SpatialPreference> {
+        Some(SpatialPreference {
+            min_size: (40, 10),
+            preferred_size: (120, 40),
+            max_size: None,
+            aspect_ratio: None,
+            internal_panes: 1,
+            internal_layout: InternalLayout::Single,
+            priority: 10.0,
+        })
+    }
+}
+
+impl InputHandler for AltScreenViewAdapter {
+    fn handle_input(&mut self, _key: &str) -> bool {
+        // View-only — never consumes input.
+        false
+    }
+
+    fn accepts_input(&self) -> bool {
+        false
+    }
+}
+
+impl Commandable for AltScreenViewAdapter {
+    fn accept_command(&mut self, cmd: &str, _args: &serde_json::Value) -> anyhow::Result<String> {
+        Err(anyhow::anyhow!(
+            "alt_screen_view adapter does not accept commands: {cmd}"
+        ))
+    }
+
+    fn accepts_commands(&self) -> bool {
+        false
+    }
+}
+
+impl BusParticipant for AltScreenViewAdapter {}
+
+impl Lifecycled for AltScreenViewAdapter {
+    fn set_app_id(&mut self, id: u32) {
+        self.app_id = id;
+    }
+}
+
+impl Permissioned for AltScreenViewAdapter {
+    fn permissions(&self) -> Vec<String> {
+        vec![]
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alt_screen_view_adapter_type_is_alt_screen_view() {
+        let snap = new_snapshot();
+        let adapter = AltScreenViewAdapter::new(snap, "vim".into());
+        assert_eq!(adapter.app_type(), "alt_screen_view");
+    }
+
+    #[test]
+    fn alt_screen_view_adapter_is_always_alive() {
+        let snap = new_snapshot();
+        let adapter = AltScreenViewAdapter::new(snap, "htop".into());
+        assert!(adapter.is_alive());
+    }
+
+    #[test]
+    fn alt_screen_view_adapter_does_not_accept_input() {
+        let snap = new_snapshot();
+        let mut adapter = AltScreenViewAdapter::new(snap, "less".into());
+        assert!(!adapter.accepts_input());
+        assert!(!adapter.handle_input("q"));
+    }
+
+    #[test]
+    fn alt_screen_view_adapter_does_not_accept_commands() {
+        let snap = new_snapshot();
+        let mut adapter = AltScreenViewAdapter::new(snap, "vim".into());
+        assert!(!adapter.accepts_commands());
+        let result = adapter.accept_command("resize", &serde_json::json!({}));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn render_returns_empty_when_no_snapshot() {
+        let snap = new_snapshot();
+        let adapter = AltScreenViewAdapter::new(snap, "vim".into());
+        let rect = Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 800.0,
+            height: 600.0,
+            ..Default::default()
+        };
+        let output = adapter.render(&rect);
+        assert!(output.grid.is_none());
+        assert!(output.quads.is_empty());
+    }
+
+    #[test]
+    fn render_uses_snapshot_and_reanchors_grid_origin() {
+        use phantom_adapter::adapter::{GridData, TerminalCell};
+
+        let snap = new_snapshot();
+        let adapter = AltScreenViewAdapter::new(Arc::clone(&snap), "vim".into());
+
+        // Push a grid snapshot with an arbitrary origin.
+        let cells = vec![TerminalCell {
+            ch: 'A',
+            fg: [1.0; 4],
+            bg: [0.0; 4],
+        }];
+        let grid = GridData {
+            cells,
+            cols: 1,
+            rows: 1,
+            origin: (0.0, 0.0),
+            cursor: None,
+        };
+        {
+            let mut guard = snap.lock().unwrap();
+            *guard = Some(RenderOutput {
+                grid: Some(grid),
+                ..Default::default()
+            });
+        }
+
+        let rect = Rect {
+            x: 400.0,
+            y: 100.0,
+            width: 400.0,
+            height: 300.0,
+            ..Default::default()
+        };
+        let output = adapter.render(&rect);
+        let grid_out = output.grid.unwrap();
+        // Origin should be re-anchored to the adapter's rect.
+        assert!((grid_out.origin.0 - 400.0).abs() < 0.01);
+        assert!((grid_out.origin.1 - 100.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn snapshot_arc_returns_same_arc() {
+        let snap = new_snapshot();
+        let adapter = AltScreenViewAdapter::new(Arc::clone(&snap), "vim".into());
+        let arc = adapter.snapshot_arc();
+        // Both arcs point to the same allocation.
+        assert!(Arc::ptr_eq(&snap, &arc));
+    }
+}

--- a/crates/phantom-app/src/adapters/mod.rs
+++ b/crates/phantom-app/src/adapters/mod.rs
@@ -1,10 +1,12 @@
 pub mod agent;
+pub mod alt_screen_view;
 pub mod dag_viewer;
 pub mod inspector;
 pub mod monitor;
 pub mod terminal;
 pub mod video;
 pub use agent::AgentAdapter;
+pub use alt_screen_view::AltScreenViewAdapter;
 pub use dag_viewer::DagViewerState;
 pub use monitor::MonitorAdapter;
 pub use terminal::TerminalAdapter;

--- a/crates/phantom-app/src/adapters/terminal.rs
+++ b/crates/phantom-app/src/adapters/terminal.rs
@@ -6,6 +6,7 @@
 
 use log::warn;
 use serde_json::json;
+use std::sync::{Arc, Mutex};
 
 #[cfg(test)]
 use phantom_adapter::adapter::QuadData;
@@ -66,6 +67,9 @@ pub struct TerminalAdapter {
     app_id: u32,
     /// Pending outbound bus messages, drained by coordinator each frame.
     outbox: Vec<phantom_adapter::BusMessage>,
+    /// Shared render snapshot written each frame when alt-screen is active.
+    /// Set by `attach_alt_screen_snapshot`; cleared by `detach_alt_screen_snapshot`.
+    alt_screen_snapshot: Option<Arc<Mutex<Option<RenderOutput>>>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -92,6 +96,7 @@ impl TerminalAdapter {
             pty_dead: false,
             app_id: 0,
             outbox: Vec::new(),
+            alt_screen_snapshot: None,
         }
     }
 
@@ -143,6 +148,56 @@ impl TerminalAdapter {
     /// Set the error-notified flag.
     pub fn set_error_notified(&mut self, val: bool) {
         self.error_notified = val;
+    }
+
+    /// Extract a `RenderOutput` from the alt-screen (used for snapshot writes
+    /// in `update()` so the secondary view adapter always has fresh data).
+    ///
+    /// The `_rect` parameter is ignored — we produce a full snapshot; the view
+    /// adapter re-anchors the origin to its own rect during render.
+    fn render_alt_screen(&self, _rect: &phantom_adapter::adapter::Rect) -> RenderOutput {
+        use phantom_adapter::adapter::{GridData, ScrollState};
+        use phantom_terminal::output;
+
+        let (render_cells, cols, rows, cursor_state) =
+            output::extract_grid_themed(self.terminal.term(), &self.theme_colors);
+
+        let cells: Vec<AdapterCell> = render_cells
+            .iter()
+            .map(|rc| AdapterCell {
+                ch: rc.ch,
+                fg: rc.fg,
+                bg: rc.bg,
+            })
+            .collect();
+
+        let cursor = if cursor_state.visible {
+            Some(convert_cursor(&cursor_state))
+        } else {
+            None
+        };
+
+        let grid = GridData {
+            cells,
+            cols,
+            rows,
+            origin: (0.0, 0.0),
+            cursor,
+        };
+
+        let scroll = Some(ScrollState {
+            display_offset: self.terminal.display_offset(),
+            history_size: self.terminal.history_size(),
+            visible_rows: self.terminal.size().rows as usize,
+        });
+
+        RenderOutput {
+            quads: vec![],
+            text_segments: vec![],
+            grid: Some(grid),
+            scroll,
+            selection: None,
+        }
     }
 }
 
@@ -211,6 +266,37 @@ impl AppCore for TerminalAdapter {
         }
 
         self.was_alt_screen = is_alt;
+
+        // When alt-screen is active and a secondary pane has been wired in,
+        // push a fresh render snapshot so the view adapter always has the
+        // latest grid data.  We use a dummy full-screen rect here; the view
+        // adapter re-anchors to its own rect in render().
+        if self.is_detached {
+            if let Some(ref snapshot) = self.alt_screen_snapshot {
+                let dummy_rect = phantom_adapter::adapter::Rect {
+                    x: 0.0,
+                    y: 0.0,
+                    width: 9999.0,
+                    height: 9999.0,
+                    ..Default::default()
+                };
+                let render_out = self.render_alt_screen(&dummy_rect);
+                if let Ok(mut guard) = snapshot.lock() {
+                    *guard = Some(render_out);
+                }
+            }
+        }
+    }
+
+    fn attach_alt_screen_snapshot(
+        &mut self,
+        snapshot: std::sync::Arc<std::sync::Mutex<Option<phantom_adapter::adapter::RenderOutput>>>,
+    ) {
+        self.alt_screen_snapshot = Some(snapshot);
+    }
+
+    fn detach_alt_screen_snapshot(&mut self) {
+        self.alt_screen_snapshot = None;
     }
 
     fn get_state(&self) -> serde_json::Value {
@@ -437,7 +523,7 @@ impl Commandable for TerminalAdapter {
             "select_all" => {
                 // Select from the top of scrollback history to the last cell
                 // of the visible screen.
-                use phantom_terminal::selection::{Column, Line, Point, Side, SelectionType};
+                use phantom_terminal::selection::{Column, Line, Point, SelectionType, Side};
                 let size = self.terminal.size();
                 let history = self.terminal.history_size() as i32;
                 // Scrollback lines are at negative Line indices.
@@ -446,7 +532,8 @@ impl Commandable for TerminalAdapter {
                     Line((size.rows as i32).saturating_sub(1)),
                     Column(size.cols.saturating_sub(1) as usize),
                 );
-                self.terminal.start_selection(SelectionType::Simple, start, Side::Left);
+                self.terminal
+                    .start_selection(SelectionType::Simple, start, Side::Left);
                 self.terminal.update_selection(end, Side::Right);
                 Ok("all selected".into())
             }

--- a/crates/phantom-app/src/app.rs
+++ b/crates/phantom-app/src/app.rs
@@ -35,14 +35,14 @@ use phantom_brain::events::AiEvent;
 use phantom_brain::ooda::{OodaConfig, OodaLoop};
 use phantom_context::ProjectContext;
 use phantom_history::{AgentOutputCapture, HistoryStore};
+use phantom_mcp::{AppCommand, McpListener, spawn_listener};
 use phantom_memory::MemoryStore;
+use phantom_nlp::{ClaudeLlmBackend, LlmBackend};
 use phantom_plugins::PluginRegistry;
 use phantom_scene::node::{NodeKind, RenderLayer};
 use phantom_scene::tree::SceneTree;
-use phantom_session::session::{is_session_restore, SessionManager, SessionState, PaneState};
+use phantom_session::session::{PaneState, SessionManager, SessionState, is_session_restore};
 use phantom_session::{AgentStatePersister, GoalStatePersister};
-use phantom_mcp::{spawn_listener, AppCommand, McpListener};
-use phantom_nlp::{ClaudeLlmBackend, LlmBackend};
 
 use crate::boot::BootSequence;
 use crate::boot_order::ShutdownGuard;
@@ -248,7 +248,8 @@ pub struct App {
     //    GITHUB_TOKEN is set; None otherwise). Handed to Dispatcher-role agent
     //    panes so they can call request_next_ticket / mark_ticket_in_progress /
     //    mark_ticket_done via the gh CLI.
-    pub(crate) ticket_dispatcher: Option<std::sync::Arc<phantom_agents::dispatcher::GhTicketDispatcher>>,
+    pub(crate) ticket_dispatcher:
+        Option<std::sync::Arc<phantom_agents::dispatcher::GhTicketDispatcher>>,
 
     // -- Inspector snapshot (shared with InspectorAdapter when a pane is open).
     //    `None` when no inspector pane has ever been spawned; `Some(Arc<RwLock<…>>)`
@@ -290,7 +291,8 @@ pub struct App {
     //    time via `set_substrate_handles`; the dispatch gate in
     //    `phantom_agents::dispatch::dispatch_tool` checks it before routing
     //    any tool call.
-    pub(crate) quarantine_registry: std::sync::Arc<std::sync::Mutex<phantom_agents::quarantine::QuarantineRegistry>>,
+    pub(crate) quarantine_registry:
+        std::sync::Arc<std::sync::Mutex<phantom_agents::quarantine::QuarantineRegistry>>,
 
     // -- Sec.8 user-visible notification center. Watches denial timestamps
     //    per agent and pushes a top-of-screen `Severity::Danger` banner
@@ -415,6 +417,28 @@ pub struct App {
     //    `Event::CommandComplete` handler in `drain_bus_to_brain` can write
     //    a `HistoryEntry` with the actual command string and exit code.
     pub(crate) pending_command_text: std::collections::HashMap<phantom_adapter::AppId, String>,
+
+    // -- Issue #323: alt-screen split-pane state --
+    //
+    // Maps primary adapter AppId → secondary (view) adapter AppId.  An entry
+    // exists for the lifetime of a split pane, from the moment a terminal
+    // enters alt-screen mode until the secondary pane is fully collapsed.
+    pub(crate) alt_screen_secondaries:
+        std::collections::HashMap<phantom_adapter::AppId, phantom_adapter::AppId>,
+
+    // Previous `is_detached` state per adapter, used for edge detection in
+    // `poll_alt_screen_transitions` (rising edge → split, falling edge → collapse).
+    pub(crate) prev_detached: std::collections::HashMap<phantom_adapter::AppId, bool>,
+
+    // Per secondary-pane collapse animation progress (0.0 → 1.0 over 300 ms).
+    // Keyed by secondary adapter AppId.  Entries are created on collapse trigger
+    // and removed once the fade completes and the pane is removed.
+    pub(crate) alt_screen_fade: std::collections::HashMap<phantom_adapter::AppId, f32>,
+
+    // Queue of secondary adapter AppIds whose collapse animations have
+    // completed and are ready for `remove_adapter`.  Drained by
+    // `tick_alt_screen_fade` into `collapse_alt_screen_pane`.
+    pub(crate) alt_screen_pending_collapses: Vec<phantom_adapter::AppId>,
 }
 
 /// An active suggestion from the AI brain.
@@ -550,19 +574,20 @@ impl App {
         };
 
         // -- Notification store (persistent per-project) --
-        let notification_store = match phantom_memory::notifications::NotificationStore::open(&project_dir) {
-            Ok(s) => {
-                info!(
-                    "Notification store ready ({} existing notifications)",
-                    s.count()
-                );
-                Some(s)
-            }
-            Err(e) => {
-                warn!("Failed to open notification store: {e}");
-                None
-            }
-        };
+        let notification_store =
+            match phantom_memory::notifications::NotificationStore::open(&project_dir) {
+                Ok(s) => {
+                    info!(
+                        "Notification store ready ({} existing notifications)",
+                        s.count()
+                    );
+                    Some(s)
+                }
+                Err(e) => {
+                    warn!("Failed to open notification store: {e}");
+                    None
+                }
+            };
 
         // -- History store + agent capture sidecar --
         // Both live under `~/.local/share/phantom/history/<session_uuid>[...].jsonl`.
@@ -751,9 +776,9 @@ impl App {
                     // Initialise persister pair from the latest session file
                     // path so agent / goal sidecar files land next to it.
                     if let Ok(Some(session_path)) = sm.latest_path(&project_dir) {
-                        let ap = AgentStatePersister::new(
-                            AgentStatePersister::sidecar_path(&session_path),
-                        );
+                        let ap = AgentStatePersister::new(AgentStatePersister::sidecar_path(
+                            &session_path,
+                        ));
                         match ap.load() {
                             Ok(Some(ref file)) => {
                                 let n = file.agent_count();
@@ -767,9 +792,9 @@ impl App {
                         }
                         agent_persister = Some(ap);
 
-                        let gp = GoalStatePersister::new(
-                            GoalStatePersister::sidecar_path(&session_path),
-                        );
+                        let gp = GoalStatePersister::new(GoalStatePersister::sidecar_path(
+                            &session_path,
+                        ));
                         match gp.load() {
                             Ok(Some(ref file)) => {
                                 let n = file.goal_count();
@@ -1037,6 +1062,10 @@ impl App {
             agent_capture,
             session_uuid,
             pending_command_text: std::collections::HashMap::new(),
+            alt_screen_secondaries: std::collections::HashMap::new(),
+            prev_detached: std::collections::HashMap::new(),
+            alt_screen_fade: std::collections::HashMap::new(),
+            alt_screen_pending_collapses: Vec::new(),
         })
     }
 
@@ -1111,7 +1140,9 @@ impl App {
                     if !queue_snaps.is_empty() {
                         let file = phantom_session::AgentStateFile::new(queue_snaps);
                         match file.save(ap.path()) {
-                            Ok(()) => info!("Agent state saved ({} snapshot(s))", file.agent_count()),
+                            Ok(()) => {
+                                info!("Agent state saved ({} snapshot(s))", file.agent_count())
+                            }
                             Err(e) => warn!("Failed to save agent state: {e}"),
                         }
                     } else {
@@ -1248,7 +1279,7 @@ impl App {
     /// once a session file exists and the persister has been created.
     pub(crate) fn persist_goal(&mut self, objective: &str) {
         use phantom_session::{
-            GoalSnapshot, PlanStepBuilder, SavedFactConfidence, SavedFact, SavedStepStatus,
+            GoalSnapshot, PlanStepBuilder, SavedFact, SavedFactConfidence, SavedStepStatus,
         };
         use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -1264,22 +1295,28 @@ impl App {
 
         let initial_step = PlanStepBuilder::new(
             objective,
-            phantom_agents::AgentTask::FreeForm { prompt: objective.to_owned() },
+            phantom_agents::AgentTask::FreeForm {
+                prompt: objective.to_owned(),
+            },
         )
         .status(SavedStepStatus::Pending)
         .build();
 
         let snapshot = GoalSnapshot::new(
             objective.to_owned(),
-            vec![SavedFact::new("goal set by user", SavedFactConfidence::Verified, "commands")],
+            vec![SavedFact::new(
+                "goal set by user",
+                SavedFactConfidence::Verified,
+                "commands",
+            )],
             vec![initial_step],
-            vec![],   // plan_history: no prior plans yet
-            0,        // stall_counter
-            2,        // stall_threshold (matches brain default)
-            0,        // replan_count
-            5,        // max_replans (matches brain default)
+            vec![], // plan_history: no prior plans yet
+            0,      // stall_counter
+            2,      // stall_threshold (matches brain default)
+            0,      // replan_count
+            5,      // max_replans (matches brain default)
             created_at_secs,
-            None,     // last_replan_at_secs
+            None, // last_replan_at_secs
         );
 
         match gp.save_goals(vec![snapshot]) {
@@ -1380,7 +1417,8 @@ impl App {
 /// — the rest of the app continues to boot and Dispatcher-role agents see
 /// `"ticket dispatcher not configured"` from the dispatch layer instead of
 /// a panic.
-fn build_ticket_dispatcher() -> Option<std::sync::Arc<phantom_agents::dispatcher::GhTicketDispatcher>> {
+fn build_ticket_dispatcher()
+-> Option<std::sync::Arc<phantom_agents::dispatcher::GhTicketDispatcher>> {
     let token = std::env::var("GITHUB_TOKEN").ok();
     let repo = std::env::var("GH_REPO").ok();
 

--- a/crates/phantom-app/src/boot.rs
+++ b/crates/phantom-app/src/boot.rs
@@ -1314,7 +1314,11 @@ mod tests {
         seq.dismiss();
         seq.update(0.6); // through transition (0.5 s)
         assert!(seq.is_done(), "boot should be Done ~0.5 s after dismiss");
-        assert!(seq.elapsed() < 8.0, "elapsed {} exceeds 8 s budget", seq.elapsed());
+        assert!(
+            seq.elapsed() < 8.0,
+            "elapsed {} exceeds 8 s budget",
+            seq.elapsed()
+        );
     }
 
     /// Shell responsiveness stub: after Done, visible_text is empty and

--- a/crates/phantom-app/src/commands.rs
+++ b/crates/phantom-app/src/commands.rs
@@ -9,7 +9,7 @@ use phantom_agents::cli::{AgentCommand, parse_agent_command};
 use phantom_agents::{AgentSpawnOpts, AgentTask};
 use phantom_nlp::NlpInterpreter;
 use phantom_nlp::interpreter::ResolvedAction;
-use phantom_nlp::{translate, Intent};
+use phantom_nlp::{Intent, translate};
 use phantom_protocol::{AppMessage, SupervisorCommand};
 use phantom_ui::themes;
 
@@ -373,9 +373,7 @@ impl App {
                 }
             }
             cmd if cmd == "history" || cmd.starts_with("history ") => {
-                let limit: usize = parts.get(1)
-                    .and_then(|s| s.parse().ok())
-                    .unwrap_or(20);
+                let limit: usize = parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(20);
                 match self.history {
                     None => self.console.output("History store not available."),
                     Some(ref store) => {
@@ -391,7 +389,8 @@ impl App {
                             Ok(entries) => {
                                 let start_num = total.saturating_sub(entries.len());
                                 for (i, e) in entries.iter().enumerate() {
-                                    let code = e.exit_code()
+                                    let code = e
+                                        .exit_code()
                                         .map(|c| format!(" [exit {c}]"))
                                         .unwrap_or_default();
                                     self.console.output(format!(
@@ -429,16 +428,26 @@ impl App {
                 self.console
                     .output("  appmon              Toggle app diagnostics");
                 self.console.output("  plugins             List plugins");
-                self.console.output("  plain               Disable all CRT effects");
-                self.console.output("  debug               Toggle shader debug HUD");
-                self.console.output("  reload              Reload config from disk");
-                self.console.output("  boot                Replay boot sequence");
-                self.console.output("  video <path>        Play video through CRT shader");
-                self.console.output("  history [N]         Show last N commands (default 20)");
-                self.console.output("  suggestions         List dismissed/expired suggestion history");
-                self.console.output("  selftest            Brain exercises its own features");
-                self.console.output("  selfheal            selftest + auto-fix + commit + push");
-                self.console.output("  clear               Clear console history");
+                self.console
+                    .output("  plain               Disable all CRT effects");
+                self.console
+                    .output("  debug               Toggle shader debug HUD");
+                self.console
+                    .output("  reload              Reload config from disk");
+                self.console
+                    .output("  boot                Replay boot sequence");
+                self.console
+                    .output("  video <path>        Play video through CRT shader");
+                self.console
+                    .output("  history [N]         Show last N commands (default 20)");
+                self.console
+                    .output("  suggestions         List dismissed/expired suggestion history");
+                self.console
+                    .output("  selftest            Brain exercises its own features");
+                self.console
+                    .output("  selfheal            selftest + auto-fix + commit + push");
+                self.console
+                    .output("  clear               Clear console history");
                 self.console.output("  quit                Exit Phantom");
             }
             _other => {
@@ -596,9 +605,8 @@ impl App {
                     let ctx_ref: &phantom_context::ProjectContext = match ctx {
                         Some(ref c) => c,
                         None => {
-                            detected = phantom_context::ProjectContext::detect(
-                                std::path::Path::new("."),
-                            );
+                            detected =
+                                phantom_context::ProjectContext::detect(std::path::Path::new("."));
                             &detected
                         }
                     };
@@ -628,30 +636,30 @@ impl App {
                 Err(e) => {
                     warn!("Failed to spawn nlp-translate thread: {e}");
                     // Thread spawn failed — fall back to direct agent spawn.
-                    self.console.system(format!("Spawning agent: {input_owned}"));
-                    self.pending_brain_actions.push(
-                        phantom_brain::events::AiAction::SpawnAgent {
+                    self.console
+                        .system(format!("Spawning agent: {input_owned}"));
+                    self.pending_brain_actions
+                        .push(phantom_brain::events::AiAction::SpawnAgent {
                             task: phantom_agents::AgentTask::FreeForm {
                                 prompt: input_owned,
                             },
                             spawn_tag: None,
                             disposition: phantom_agents::dispatch::Disposition::Chat,
-                        }
-                    );
+                        });
                 }
             }
         } else {
             // No LLM backend — spawn agent directly.
-            self.console.system(format!("Spawning agent: {input_owned}"));
-            self.pending_brain_actions.push(
-                phantom_brain::events::AiAction::SpawnAgent {
+            self.console
+                .system(format!("Spawning agent: {input_owned}"));
+            self.pending_brain_actions
+                .push(phantom_brain::events::AiAction::SpawnAgent {
                     task: phantom_agents::AgentTask::FreeForm {
                         prompt: input_owned,
                     },
                     spawn_tag: None,
                     disposition: phantom_agents::dispatch::Disposition::Chat,
-                }
-            );
+                });
         }
     }
 }

--- a/crates/phantom-app/src/console.rs
+++ b/crates/phantom-app/src/console.rs
@@ -386,7 +386,11 @@ mod history_tests {
         c.submit();
         c.input = "build".into();
         c.submit();
-        assert_eq!(c.command_history.len(), 1, "identical adjacent commands must not be duplicated");
+        assert_eq!(
+            c.command_history.len(),
+            1,
+            "identical adjacent commands must not be duplicated"
+        );
     }
 
     // submit() returns the trimmed command string.

--- a/crates/phantom-app/src/coordinator.rs
+++ b/crates/phantom-app/src/coordinator.rs
@@ -1820,7 +1820,9 @@ mod tests {
 
         // Start with one pane.
         let id_a = register_mock(&mut coord, &mut layout, &mut scene, content, "original");
-        let p_a = coord.pane_id_for(id_a).expect("original pane must have a PaneId");
+        let p_a = coord
+            .pane_id_for(id_a)
+            .expect("original pane must have a PaneId");
         assert_eq!(coord.adapter_count(), 1);
         assert_eq!(coord.focused(), Some(id_a));
 
@@ -1840,14 +1842,22 @@ mod tests {
         coord.set_focus(id_b);
 
         // Two adapters now registered.
-        assert_eq!(coord.adapter_count(), 2, "expected 2 adapters after H-split");
+        assert_eq!(
+            coord.adapter_count(),
+            2,
+            "expected 2 adapters after H-split"
+        );
 
         // Both must have unique, valid IDs.
         assert_ne!(id_a, id_b, "both adapters must have distinct IDs");
 
         // PaneIds must be distinct.
-        let pane_a = coord.pane_id_for(id_a).expect("original adapter must have a PaneId");
-        let pane_b = coord.pane_id_for(id_b).expect("new adapter must have a PaneId");
+        let pane_a = coord
+            .pane_id_for(id_a)
+            .expect("original adapter must have a PaneId");
+        let pane_b = coord
+            .pane_id_for(id_b)
+            .expect("new adapter must have a PaneId");
         assert_ne!(pane_a, pane_b, "both adapters must own different PaneIds");
 
         // Focus must be on the newly created pane.
@@ -1857,8 +1867,14 @@ mod tests {
         layout.resize(800.0, 600.0).unwrap();
         let rect_a = layout.get_pane_rect(pane_a).unwrap();
         let rect_b = layout.get_pane_rect(pane_b).unwrap();
-        assert!(rect_a.width > 0.0 && rect_a.height > 0.0, "original pane must have positive area");
-        assert!(rect_b.width > 0.0 && rect_b.height > 0.0, "new pane must have positive area");
+        assert!(
+            rect_a.width > 0.0 && rect_a.height > 0.0,
+            "original pane must have positive area"
+        );
+        assert!(
+            rect_b.width > 0.0 && rect_b.height > 0.0,
+            "new pane must have positive area"
+        );
     }
 
     // ── QA #160: Vertical split with three panes ──────────────────────────────
@@ -1906,11 +1922,18 @@ mod tests {
         coord.set_focus(id_c);
 
         // Three adapters must exist.
-        assert_eq!(coord.adapter_count(), 3, "expected 3 adapters after V-split");
+        assert_eq!(
+            coord.adapter_count(),
+            3,
+            "expected 3 adapters after V-split"
+        );
 
         // All must have distinct IDs and PaneIds.
         let ids = [id_a, id_b, id_c];
-        let pane_ids: Vec<_> = ids.iter().map(|&id| coord.pane_id_for(id).unwrap()).collect();
+        let pane_ids: Vec<_> = ids
+            .iter()
+            .map(|&id| coord.pane_id_for(id).unwrap())
+            .collect();
         for i in 0..3 {
             for j in (i + 1)..3 {
                 assert_ne!(ids[i], ids[j], "adapter IDs must be unique");
@@ -1924,7 +1947,8 @@ mod tests {
             let rect = layout.get_pane_rect(pid).unwrap();
             assert!(
                 rect.width > 0.0 && rect.height > 0.0,
-                "pane[{idx}] must have positive area: {:?}", rect,
+                "pane[{idx}] must have positive area: {:?}",
+                rect,
             );
         }
 
@@ -1978,7 +2002,10 @@ mod tests {
         );
 
         // The survivor must be the original adapter.
-        assert_eq!(survivor, id_a, "the surviving pane must be the original pane");
+        assert_eq!(
+            survivor, id_a,
+            "the surviving pane must be the original pane"
+        );
     }
 
     /// Closing the last pane must not set focus to a non-existent adapter.
@@ -1996,7 +2023,11 @@ mod tests {
 
         coord.remove_adapter(id, &mut layout, &mut scene);
 
-        assert_eq!(coord.focused(), None, "focus must be None after closing the last pane");
+        assert_eq!(
+            coord.focused(),
+            None,
+            "focus must be None after closing the last pane"
+        );
         assert!(coord.all_app_ids().is_empty(), "no adapters must remain");
     }
 

--- a/crates/phantom-app/src/inspector.rs
+++ b/crates/phantom-app/src/inspector.rs
@@ -332,10 +332,16 @@ mod tests {
             .with_denial(denial(2, 2_000))
             .with_denial(denial(1, 3_000))
             .build();
-        let agent1_denials: Vec<_> = view.denials.iter()
+        let agent1_denials: Vec<_> = view
+            .denials
+            .iter()
             .filter(|d| d.role == "agent-1")
             .collect();
-        assert_eq!(agent1_denials.len(), 2, "expected exactly 2 denials for agent-1");
+        assert_eq!(
+            agent1_denials.len(),
+            2,
+            "expected exactly 2 denials for agent-1"
+        );
         for d in &agent1_denials {
             assert_eq!(d.role, "agent-1");
         }
@@ -347,7 +353,9 @@ mod tests {
         let view = InspectorBuilder::new()
             .with_denial(denial(1, 1_000))
             .build();
-        let unknown: Vec<_> = view.denials.iter()
+        let unknown: Vec<_> = view
+            .denials
+            .iter()
             .filter(|d| d.role == "agent-999")
             .collect();
         assert!(unknown.is_empty());

--- a/crates/phantom-app/src/mouse.rs
+++ b/crates/phantom-app/src/mouse.rs
@@ -11,7 +11,7 @@ use log::debug;
 use winit::event::{ElementState, MouseButton, MouseScrollDelta};
 
 use phantom_terminal::input::{
-    encode_mouse_motion_sgr, encode_mouse_sgr, MouseButton as TermMouseButton,
+    MouseButton as TermMouseButton, encode_mouse_motion_sgr, encode_mouse_sgr,
 };
 
 use crate::app::{App, FloatInteraction, ResizeEdge};
@@ -416,8 +416,12 @@ impl App {
             //   • multi-pane   → track anchored to the chrome-inset inner_rect
             let tiled_count = self.coordinator.all_app_ids().len();
             for app_id in self.coordinator.all_app_ids() {
-                let Some(pane_id) = self.coordinator.pane_id_for(app_id) else { continue };
-                let Ok(layout_rect) = self.layout.get_pane_rect(pane_id) else { continue };
+                let Some(pane_id) = self.coordinator.pane_id_for(app_id) else {
+                    continue;
+                };
+                let Ok(layout_rect) = self.layout.get_pane_rect(pane_id) else {
+                    continue;
+                };
                 let track = if tiled_count <= 1 {
                     scrollbar_track_rect(phantom_ui::layout::Rect {
                         x: layout_rect.x,
@@ -731,7 +735,7 @@ mod tests {
     /// chrome-inset correction in single-pane mode.
     #[test]
     fn scrollbar_track_rect_single_pane_anchoring() {
-        use crate::pane::{scrollbar_track_rect, SCROLLBAR_WIDTH};
+        use crate::pane::{SCROLLBAR_WIDTH, scrollbar_track_rect};
 
         // Simulate a full-screen layout rect (no chrome insets applied).
         let layout_rect = phantom_ui::layout::Rect {
@@ -746,17 +750,29 @@ mod tests {
 
         // Track x must be at the right edge minus scrollbar width and margin.
         let expected_x = layout_rect.x + layout_rect.width - SCROLLBAR_WIDTH - margin;
-        assert!((track.x - expected_x).abs() < 0.01,
-            "track.x={} expected {}", track.x, expected_x);
+        assert!(
+            (track.x - expected_x).abs() < 0.01,
+            "track.x={} expected {}",
+            track.x,
+            expected_x
+        );
 
         // Track y starts at layout_rect.y + margin.
-        assert!((track.y - (layout_rect.y + margin)).abs() < 0.01,
-            "track.y={} expected {}", track.y, layout_rect.y + margin);
+        assert!(
+            (track.y - (layout_rect.y + margin)).abs() < 0.01,
+            "track.y={} expected {}",
+            track.y,
+            layout_rect.y + margin
+        );
 
         // Track height is inset by margin on both ends.
         let expected_h = layout_rect.height - margin * 2.0;
-        assert!((track.height - expected_h).abs() < 0.01,
-            "track.height={} expected {}", track.height, expected_h);
+        assert!(
+            (track.height - expected_h).abs() < 0.01,
+            "track.height={} expected {}",
+            track.height,
+            expected_h
+        );
 
         assert_eq!(track.width, SCROLLBAR_WIDTH);
     }
@@ -766,7 +782,12 @@ mod tests {
     fn scrollbar_thumb_absent_without_history() {
         use crate::pane::{scrollbar_thumb_rect, scrollbar_track_rect};
 
-        let rect = phantom_ui::layout::Rect { x: 0.0, y: 0.0, width: 800.0, height: 600.0 };
+        let rect = phantom_ui::layout::Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 800.0,
+            height: 600.0,
+        };
         let track = scrollbar_track_rect(rect);
         assert!(scrollbar_thumb_rect(track, 0, 0, 24).is_none());
     }
@@ -776,7 +797,12 @@ mod tests {
     fn scrollbar_thumb_present_with_history() {
         use crate::pane::{scrollbar_thumb_rect, scrollbar_track_rect};
 
-        let rect = phantom_ui::layout::Rect { x: 0.0, y: 0.0, width: 800.0, height: 600.0 };
+        let rect = phantom_ui::layout::Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 800.0,
+            height: 600.0,
+        };
         let track = scrollbar_track_rect(rect);
         let thumb = scrollbar_thumb_rect(track, 0, 500, 24);
         assert!(thumb.is_some(), "thumb should exist when history_size > 0");
@@ -800,7 +826,7 @@ mod tests {
 
     #[test]
     fn cursor_to_cell_single_pane_no_chrome_offset() {
-        use crate::pane::{container_rect, pane_inner_rect, CONTAINER_TITLE_H_CELLS};
+        use crate::pane::{CONTAINER_TITLE_H_CELLS, container_rect, pane_inner_rect};
         use phantom_ui::layout::Rect;
 
         let cell_w = 8.0_f32;
@@ -808,7 +834,12 @@ mod tests {
         let cell_size = (cell_w, cell_h);
 
         // Full-screen layout rect (single-pane: no margin/chrome applied).
-        let layout_rect = Rect { x: 0.0, y: 0.0, width: 1280.0, height: 800.0 };
+        let layout_rect = Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 1280.0,
+            height: 800.0,
+        };
 
         // -- Single-pane path (the fix) -------------------------------------
         // inner == layout_rect, so cursor (0,0) -> cell (0,0).
@@ -816,13 +847,18 @@ mod tests {
         let max_col = (inner_single.width / cell_w).floor() as usize;
         let max_row = (inner_single.height / cell_h).floor() as usize;
         let (col, row) = pixel_to_cell(
-            0.0, 0.0,
-            inner_single.x, inner_single.y,
-            cell_w, cell_h,
-            max_col.saturating_sub(1), max_row.saturating_sub(1),
+            0.0,
+            0.0,
+            inner_single.x,
+            inner_single.y,
+            cell_w,
+            cell_h,
+            max_col.saturating_sub(1),
+            max_row.saturating_sub(1),
         );
         assert_eq!(
-            (col, row), (0, 0),
+            (col, row),
+            (0, 0),
             "single-pane: cursor at (0,0) must map to cell (0,0); got ({col},{row})",
         );
 
@@ -834,7 +870,9 @@ mod tests {
         assert!(
             inner_multi.x > 0.0 || inner_multi.y > 0.0,
             "multi-pane inner rect must have a non-zero origin due to chrome insets; \
-             got ({}, {})", inner_multi.x, inner_multi.y,
+             got ({}, {})",
+            inner_multi.x,
+            inner_multi.y,
         );
 
         // inner.y must be at least one title-strip height from the window top,
@@ -843,7 +881,8 @@ mod tests {
         assert!(
             inner_multi.y >= title_h - 0.5,
             "multi-pane inner.y must be at least one title-strip height ({title_h}px) \
-             from the window top; got {}", inner_multi.y,
+             from the window top; got {}",
+            inner_multi.y,
         );
     }
 }

--- a/crates/phantom-app/src/pane.rs
+++ b/crates/phantom-app/src/pane.rs
@@ -258,6 +258,135 @@ impl App {
         }
     }
 
+    /// Split a terminal pane in two for alt-screen mode (issue #323).
+    ///
+    /// The primary pane keeps the normal-screen history; a new sibling pane is
+    /// created to display the alt-screen program.  Both share an
+    /// `AltScreenSnapshot` Arc: the primary writes each frame, the view adapter
+    /// reads.
+    ///
+    /// Returns `Some(secondary_app_id)` on success, `None` on any failure.
+    pub(crate) fn split_for_alt_screen(
+        &mut self,
+        primary_app_id: phantom_adapter::AppId,
+        label: String,
+    ) -> Option<phantom_adapter::AppId> {
+        use crate::adapters::alt_screen_view::{AltScreenViewAdapter, new_snapshot};
+        use phantom_scene::clock::Cadence;
+
+        let current_pane_id = self.coordinator.pane_id_for(primary_app_id)?;
+
+        // Split horizontally: primary on the left, new view on the right.
+        let (existing_child, new_child) = match self.layout.split_horizontal(current_pane_id) {
+            Ok(ids) => ids,
+            Err(e) => {
+                warn!("split_for_alt_screen: layout split failed: {e}");
+                return None;
+            }
+        };
+
+        let width = self.gpu.surface_config.width;
+        let height = self.gpu.surface_config.height;
+        let _ = self.layout.resize(width as f32, height as f32);
+
+        // Remap primary adapter to the left child pane.
+        self.coordinator
+            .remap_pane(primary_app_id, current_pane_id, existing_child);
+
+        // Resize the primary terminal to fit the now-smaller left pane.
+        if let Ok(rect) = self.layout.get_pane_rect(existing_child) {
+            let (cols, rows) = pane_cols_rows(self.cell_size, rect);
+            let _ = self.coordinator.send_command(
+                primary_app_id,
+                "resize",
+                &serde_json::json!({"cols": cols, "rows": rows}),
+            );
+        }
+
+        // Create the shared snapshot Arc.
+        let snapshot = new_snapshot();
+
+        // Wire the snapshot into the primary adapter so it writes each frame.
+        if let Some(primary) = self
+            .coordinator
+            .registry_mut()
+            .get_adapter_mut(primary_app_id)
+        {
+            primary.attach_alt_screen_snapshot(std::sync::Arc::clone(&snapshot));
+        }
+
+        // Create the view adapter backed by the same snapshot.
+        let view_adapter = AltScreenViewAdapter::new(snapshot, label.clone());
+
+        let scene_node = self
+            .scene
+            .add_node(self.scene_content_node, phantom_scene::node::NodeKind::Pane);
+
+        let secondary_app_id = self.coordinator.register_adapter_at_pane(
+            Box::new(view_adapter),
+            new_child,
+            scene_node,
+            Cadence::unlimited(),
+            &mut self.layout,
+        );
+
+        // Record the mapping so update.rs can manage the fade/collapse lifecycle.
+        self.alt_screen_secondaries
+            .insert(primary_app_id, secondary_app_id);
+
+        info!(
+            "Alt-screen split: primary={primary_app_id} secondary={secondary_app_id} label={label:?}"
+        );
+        Some(secondary_app_id)
+    }
+
+    /// Collapse the secondary alt-screen pane after the fade animation completes.
+    ///
+    /// Called by `tick_alt_screen_fade` once the 300 ms transition is done.
+    pub(crate) fn collapse_alt_screen_pane(
+        &mut self,
+        primary_app_id: phantom_adapter::AppId,
+        secondary_app_id: phantom_adapter::AppId,
+    ) {
+        // Detach the snapshot from the primary adapter.
+        if let Some(primary) = self
+            .coordinator
+            .registry_mut()
+            .get_adapter_mut(primary_app_id)
+        {
+            primary.detach_alt_screen_snapshot();
+        }
+
+        // Remove the view adapter, its layout pane, and scene node.
+        self.coordinator
+            .remove_adapter(secondary_app_id, &mut self.layout, &mut self.scene);
+
+        // Reclaim layout space.
+        let width = self.gpu.surface_config.width;
+        let height = self.gpu.surface_config.height;
+        let _ = self.layout.resize(width as f32, height as f32);
+
+        // Resize remaining adapters to fill the reclaimed space.
+        for app_id in self.coordinator.all_app_ids() {
+            if let Some(pane_id) = self.coordinator.pane_id_for(app_id) {
+                if let Ok(rect) = self.layout.get_pane_rect(pane_id) {
+                    let (cols, rows) = pane_cols_rows(self.cell_size, rect);
+                    let _ = self.coordinator.send_command(
+                        app_id,
+                        "resize",
+                        &serde_json::json!({"cols": cols, "rows": rows}),
+                    );
+                }
+            }
+        }
+
+        // Remove tracking entries.
+        self.alt_screen_secondaries.remove(&primary_app_id);
+        self.alt_screen_fade.remove(&secondary_app_id);
+
+        info!("Alt-screen collapsed: primary={primary_app_id} secondary={secondary_app_id}");
+    }
+
     /// Close the focused pane and its terminal.
     pub(crate) fn close_focused_pane(&mut self) {
         let Some(focused_app_id) = self.coordinator.focused() else {
@@ -459,7 +588,12 @@ mod scroll_position_tests {
     const VIEWPORT: usize = 40;
 
     fn track() -> Rect {
-        Rect { x: 494.0, y: 50.0, width: 6.0, height: 400.0 }
+        Rect {
+            x: 494.0,
+            y: 50.0,
+            width: 6.0,
+            height: 400.0,
+        }
     }
 
     // scrollbar_y_to_offset maps a click y position to a display_offset.

--- a/crates/phantom-app/src/render.rs
+++ b/crates/phantom-app/src/render.rs
@@ -193,6 +193,11 @@ impl App {
                 self.build_context_menu_overlay(screen_size, &mut chrome_quads, &mut chrome_glyphs);
             }
 
+            // -- Alt-screen bezier tether (issue #323) --
+            if !self.alt_screen_secondaries.is_empty() {
+                self.build_alt_screen_tether(&mut chrome_quads);
+            }
+
             if !chrome_quads.is_empty() || !chrome_glyphs.is_empty() {
                 // Upload + render overlay in its own pass on the surface.
                 self.quad_renderer.prepare(

--- a/crates/phantom-app/src/render_overlay.rs
+++ b/crates/phantom-app/src/render_overlay.rs
@@ -772,4 +772,88 @@ impl App {
             glyphs.append(&mut g);
         }
     }
+
+    /// Build the bezier tether overlay for issue #323 alt-screen split panes.
+    ///
+    /// Draws a horizontal line of thin quad segments connecting the right edge
+    /// of the primary pane to the left edge of the secondary (alt-screen) pane.
+    /// Color is the theme accent (foreground at low opacity) so it adapts to
+    /// all built-in themes.
+    ///
+    /// The segments approximate a cubic bezier curve from the anchor point on
+    /// the primary to the anchor point on the secondary.  We use 8 segments for
+    /// a smooth-looking result without excessive quad count.
+    pub(crate) fn build_alt_screen_tether(&self, quads: &mut Vec<QuadInstance>) {
+        if self.alt_screen_secondaries.is_empty() {
+            return;
+        }
+
+        // Tether color: theme foreground at ~35% opacity.
+        let accent = self.theme.colors.foreground;
+        let color = [accent[0], accent[1], accent[2], 0.35];
+        let segment_thickness = 2.0;
+        const SEGMENTS: usize = 8;
+
+        for (&primary_id, &secondary_id) in &self.alt_screen_secondaries {
+            // Get layout rects for both panes.
+            let primary_pane = self.coordinator.pane_id_for(primary_id);
+            let secondary_pane = self.coordinator.pane_id_for(secondary_id);
+
+            let (Some(ppane), Some(spane)) = (primary_pane, secondary_pane) else {
+                continue;
+            };
+
+            let (Ok(primary_rect), Ok(secondary_rect)) = (
+                self.layout.get_pane_rect(ppane),
+                self.layout.get_pane_rect(spane),
+            ) else {
+                continue;
+            };
+
+            // Anchor: mid-right of primary, mid-left of secondary.
+            let p0x = primary_rect.x + primary_rect.width;
+            let p0y = primary_rect.y + primary_rect.height * 0.5;
+            let p3x = secondary_rect.x;
+            let p3y = secondary_rect.y + secondary_rect.height * 0.5;
+
+            // Control points: pull horizontally by 40% of the gap.
+            let gap = (p3x - p0x).abs();
+            let ctrl = gap * 0.4;
+            let p1x = p0x + ctrl;
+            let p1y = p0y;
+            let p2x = p3x - ctrl;
+            let p2y = p3y;
+
+            // Evaluate cubic bezier at SEGMENTS + 1 points and draw segments.
+            let mut prev_x = p0x;
+            let mut prev_y = p0y;
+            for i in 1..=SEGMENTS {
+                let t = i as f32 / SEGMENTS as f32;
+                let u = 1.0 - t;
+                let cx = u * u * u * p0x
+                    + 3.0 * u * u * t * p1x
+                    + 3.0 * u * t * t * p2x
+                    + t * t * t * p3x;
+                let cy = u * u * u * p0y
+                    + 3.0 * u * u * t * p1y
+                    + 3.0 * u * t * t * p2y
+                    + t * t * t * p3y;
+
+                // Draw a thin quad covering the segment line.
+                let dx = cx - prev_x;
+                let dy = cy - prev_y;
+                let len = (dx * dx + dy * dy).sqrt().max(0.5);
+
+                quads.push(QuadInstance {
+                    pos: [prev_x, prev_y - segment_thickness * 0.5],
+                    size: [len, segment_thickness],
+                    color,
+                    border_radius: 0.0,
+                });
+
+                prev_x = cx;
+                prev_y = cy;
+            }
+        }
+    }
 }

--- a/crates/phantom-app/src/runtime.rs
+++ b/crates/phantom-app/src/runtime.rs
@@ -218,9 +218,7 @@ impl AgentRuntime {
     /// Recovers from a poisoned mutex (#222) — the inner value is still
     /// usable after the thread that panicked released the guard.
     pub fn event_log(&self) -> std::sync::MutexGuard<'_, EventLog> {
-        self.event_log
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
+        self.event_log.lock().unwrap_or_else(|e| e.into_inner())
     }
 
     /// Clone the event-log handle for sharing with a
@@ -239,9 +237,7 @@ impl AgentRuntime {
     /// Recovers from a poisoned mutex (#222) — the inner value is still
     /// usable after the thread that panicked released the guard.
     pub fn registry(&self) -> std::sync::MutexGuard<'_, AgentRegistry> {
-        self.registry
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
+        self.registry.lock().unwrap_or_else(|e| e.into_inner())
     }
 
     /// Clone the registry handle for sharing with dispatch contexts. Same
@@ -281,10 +277,7 @@ impl AgentRuntime {
     ///
     /// Recovers from a poisoned mutex (#222).
     pub fn flush(&mut self) -> std::io::Result<()> {
-        let mut log = self
-            .event_log
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let mut log = self.event_log.lock().unwrap_or_else(|e| e.into_inner());
         log.flush()
     }
 
@@ -311,10 +304,7 @@ impl AgentRuntime {
         // gets newest-on-bottom; the inspector adapter is free to reverse if
         // it prefers newest-on-top.
         let envelopes = {
-            let log = self
-                .event_log
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
+            let log = self.event_log.lock().unwrap_or_else(|e| e.into_inner());
             log.tail(phantom_agents::inspector::MAX_RECENT_EVENTS)
         };
         for env in &envelopes {
@@ -343,10 +333,7 @@ impl AgentRuntime {
             .map(|d| d.as_millis() as u64)
             .unwrap_or(0);
         let agent_refs: Vec<_> = {
-            let reg = self
-                .registry
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
+            let reg = self.registry.lock().unwrap_or_else(|e| e.into_inner());
             reg.list().into_iter().cloned().collect()
         };
         for agent_ref in agent_refs {

--- a/crates/phantom-app/src/update.rs
+++ b/crates/phantom-app/src/update.rs
@@ -36,6 +36,11 @@ impl App {
         // Coordinator: tick all registered adapters and deliver bus messages.
         self.coordinator.update_all(dt_duration);
 
+        // Issue #323: poll terminal adapters for alt-screen transitions and
+        // manage the secondary split-pane lifecycle.
+        self.poll_alt_screen_transitions();
+        self.tick_alt_screen_fade(dt);
+
         // Substrate runtime: reap dead supervisor children, drain pending
         // substrate events into the on-disk log, and evaluate spawn rules.
         // Cheap when nothing is pending; bounded by events pushed since the
@@ -236,7 +241,9 @@ impl App {
             Err(_) => Vec::new(),
         };
         for req in pending_subagents {
-            let task = phantom_agents::AgentTask::FreeForm { prompt: req.task.clone() };
+            let task = phantom_agents::AgentTask::FreeForm {
+                prompt: req.task.clone(),
+            };
             // Wire role / label / chat_model from the SpawnSubagentRequest into
             // AgentSpawnOpts so the spawned pane runs under the requested role
             // and displays the requested label. Fixes #224 where these fields
@@ -543,12 +550,11 @@ impl App {
                     self.pane_last_command.insert(*app_id, command.clone());
                 }
                 Event::CommandComplete { app_id, exit_code } => {
-                    let command_text = self
-                        .pending_command_text
-                        .remove(app_id)
-                        .unwrap_or_default();
+                    let command_text = self.pending_command_text.remove(app_id).unwrap_or_default();
                     if let Some(ref mut store) = self.history {
-                        let cwd = self.context.as_ref()
+                        let cwd = self
+                            .context
+                            .as_ref()
                             .map(|c| std::path::PathBuf::from(&c.root))
                             .unwrap_or_else(|| std::path::PathBuf::from("."));
                         let entry = HistoryEntry::builder(&command_text, cwd, self.session_uuid)
@@ -590,22 +596,23 @@ impl App {
                         );
                         Some(AiEvent::CommandComplete(parsed))
                     }
-                    Event::AgentTaskComplete { agent_id, success, summary, spawn_tag } => {
-                        Some(AiEvent::AgentComplete {
-                            id: *agent_id,
-                            success: *success,
-                            summary: summary.clone(),
-                            spawn_tag: *spawn_tag,
-                        })
-                    }
-                    Event::AgentError { agent_id, error } => {
-                        Some(AiEvent::AgentComplete {
-                            id: *agent_id,
-                            success: false,
-                            summary: error.clone(),
-                            spawn_tag: None,
-                        })
-                    }
+                    Event::AgentTaskComplete {
+                        agent_id,
+                        success,
+                        summary,
+                        spawn_tag,
+                    } => Some(AiEvent::AgentComplete {
+                        id: *agent_id,
+                        success: *success,
+                        summary: summary.clone(),
+                        spawn_tag: *spawn_tag,
+                    }),
+                    Event::AgentError { agent_id, error } => Some(AiEvent::AgentComplete {
+                        id: *agent_id,
+                        success: false,
+                        summary: error.clone(),
+                        spawn_tag: None,
+                    }),
                     _ => None,
                 };
                 if let Some(event) = ai_event {
@@ -852,19 +859,21 @@ impl App {
         use phantom_renderer::shader_loader::ShaderEvent;
 
         loop {
-            let Some(event) = self.shader_reloader.poll() else { break };
+            let Some(event) = self.shader_reloader.poll() else {
+                break;
+            };
             match event {
-                ShaderEvent::Reloaded { ref name, ref source } if name == "crt" => {
-                    match self.postfx.reload_shader(&self.gpu.device, source) {
-                        Ok(()) => log::info!("live-reload: crt.wgsl pipeline swapped"),
-                        Err(msg) => {
-                            let message = format!(
-                                "crt.wgsl hot-swap failed — {msg}. Last-good shader active."
-                            );
-                            self.push_shader_error_banner(message, now_ms);
-                        }
+                ShaderEvent::Reloaded {
+                    ref name,
+                    ref source,
+                } if name == "crt" => match self.postfx.reload_shader(&self.gpu.device, source) {
+                    Ok(()) => log::info!("live-reload: crt.wgsl pipeline swapped"),
+                    Err(msg) => {
+                        let message =
+                            format!("crt.wgsl hot-swap failed — {msg}. Last-good shader active.");
+                        self.push_shader_error_banner(message, now_ms);
                     }
-                }
+                },
                 ShaderEvent::Reloaded { name, .. } => {
                     log::debug!("live-reload: {name}.wgsl reloaded (no pipeline swap yet)");
                 }
@@ -880,12 +889,118 @@ impl App {
 
     /// Push a Severity::Warn banner from a shader reload failure.
     fn push_shader_error_banner(&mut self, message: String, now_ms: u64) {
-        use crate::notifications::{Banner, Severity, DEFAULT_BANNER_TTL_MS};
+        use crate::notifications::{Banner, DEFAULT_BANNER_TTL_MS, Severity};
         self.notifications.push_banner(Banner {
             message,
             severity: Severity::Warn,
             expires_at_ms: now_ms.saturating_add(DEFAULT_BANNER_TTL_MS),
         });
+    }
+
+    // -----------------------------------------------------------------------
+    // Issue #323 — alt-screen split-pane lifecycle
+    // -----------------------------------------------------------------------
+
+    /// Poll all terminal adapters for alt-screen transitions.
+    ///
+    /// On rising edge (`is_detached` false → true): triggers `split_for_alt_screen`.
+    /// On falling edge (`is_detached` true → false): queues the secondary pane for
+    /// fade-out via `alt_screen_fade`.
+    pub(crate) fn poll_alt_screen_transitions(&mut self) {
+        let all_ids: Vec<phantom_adapter::AppId> = self.coordinator.all_app_ids();
+
+        // Collect transitions (avoid borrow conflict with self.coordinator).
+        let mut to_split: Vec<(phantom_adapter::AppId, String)> = Vec::new();
+
+        for app_id in &all_ids {
+            let app_id = *app_id;
+            let state = self
+                .coordinator
+                .registry()
+                .get_adapter(app_id)
+                .map(|a: &dyn phantom_adapter::AppAdapter| a.get_state());
+            let Some(state) = state else { continue };
+
+            let is_terminal = state
+                .get("type")
+                .and_then(|v: &serde_json::Value| v.as_str())
+                == Some("terminal");
+            if !is_terminal {
+                continue;
+            }
+
+            let is_detached = state
+                .get("is_detached")
+                .and_then(|v: &serde_json::Value| v.as_bool())
+                .unwrap_or(false);
+            let label = state
+                .get("detached_label")
+                .and_then(|v: &serde_json::Value| v.as_str())
+                .unwrap_or("interactive")
+                .to_owned();
+
+            let prev = self.prev_detached.get(&app_id).copied().unwrap_or(false);
+            self.prev_detached.insert(app_id, is_detached);
+
+            // Rising edge: terminal just entered alt-screen.
+            if is_detached && !prev && !self.alt_screen_secondaries.contains_key(&app_id) {
+                to_split.push((app_id, label));
+            }
+
+            // Falling edge: terminal just left alt-screen.
+            if !is_detached && prev {
+                if let Some(&secondary_id) = self.alt_screen_secondaries.get(&app_id) {
+                    // Start fade animation if not already fading.
+                    self.alt_screen_fade.entry(secondary_id).or_insert(0.0);
+                }
+            }
+        }
+
+        for (primary_id, label) in to_split {
+            self.split_for_alt_screen(primary_id, label);
+        }
+    }
+
+    /// Advance the 300 ms collapse fade for secondary alt-screen panes.
+    ///
+    /// Once a secondary pane's fade reaches 1.0 it is added to
+    /// `alt_screen_pending_collapses` so the pane can be cleaned up.
+    pub(crate) fn tick_alt_screen_fade(&mut self, dt: f32) {
+        const FADE_DURATION: f32 = 0.3; // 300 ms
+
+        // Collect secondaries whose fade is complete this frame.
+        let mut completed: Vec<phantom_adapter::AppId> = Vec::new();
+        for (secondary_id, progress) in self.alt_screen_fade.iter_mut() {
+            *progress += dt / FADE_DURATION;
+            if *progress >= 1.0 {
+                completed.push(*secondary_id);
+            }
+        }
+
+        // Build reverse map (secondary → primary) so we can pass both to collapse.
+        let reverse: std::collections::HashMap<phantom_adapter::AppId, phantom_adapter::AppId> =
+            self.alt_screen_secondaries
+                .iter()
+                .map(|(&primary, &secondary)| (secondary, primary))
+                .collect();
+
+        // Drain completed fades into pending_collapses (deduped).
+        for secondary_id in completed {
+            if !self.alt_screen_pending_collapses.contains(&secondary_id) {
+                self.alt_screen_pending_collapses.push(secondary_id);
+            }
+        }
+
+        // Collapse any ready panes.
+        let collapsing: Vec<_> = self.alt_screen_pending_collapses.drain(..).collect();
+        for secondary_id in collapsing {
+            if let Some(&primary_id) = reverse.get(&secondary_id) {
+                self.collapse_alt_screen_pane(primary_id, secondary_id);
+            } else {
+                // Primary already gone — clean up orphaned fade entry.
+                self.alt_screen_fade.remove(&secondary_id);
+            }
+        }
     }
 }
 
@@ -1091,11 +1206,9 @@ mod tests {
 
         // ---- replicate the timeout guard from App::update ----
         if git_refresh_handle.is_some() {
-            let timed_out = git_refresh_spawned_at
-                .is_some_and(|t| now.duration_since(t) > GIT_REFRESH_TIMEOUT);
-            let finished = git_refresh_handle
-                .as_ref()
-                .is_some_and(|h| h.is_finished());
+            let timed_out =
+                git_refresh_spawned_at.is_some_and(|t| now.duration_since(t) > GIT_REFRESH_TIMEOUT);
+            let finished = git_refresh_handle.as_ref().is_some_and(|h| h.is_finished());
             if timed_out {
                 git_refresh_handle = None;
                 git_refresh_spawned_at = None;
@@ -1144,11 +1257,9 @@ mod tests {
         let mut git_refresh_spawned_at: Option<Instant> = spawned_at;
 
         if git_refresh_handle.is_some() {
-            let timed_out = git_refresh_spawned_at
-                .is_some_and(|t| now.duration_since(t) > GIT_REFRESH_TIMEOUT);
-            let finished = git_refresh_handle
-                .as_ref()
-                .is_some_and(|h| h.is_finished());
+            let timed_out =
+                git_refresh_spawned_at.is_some_and(|t| now.duration_since(t) > GIT_REFRESH_TIMEOUT);
+            let finished = git_refresh_handle.as_ref().is_some_and(|h| h.is_finished());
             if timed_out {
                 git_refresh_handle = None;
                 git_refresh_spawned_at = None;

--- a/crates/phantom-app/tests/history_wiring_smoke.rs
+++ b/crates/phantom-app/tests/history_wiring_smoke.rs
@@ -92,7 +92,9 @@ fn history_recent_limit_exceeds_total() {
     let (mut store, _dir) = temp_store();
     let session = Uuid::new_v4();
 
-    store.append(&make_entry("only-one", session)).expect("append");
+    store
+        .append(&make_entry("only-one", session))
+        .expect("append");
     let recent = store.recent(100).expect("recent");
     assert_eq!(recent.len(), 1);
     assert_eq!(recent[0].command(), "only-one");

--- a/crates/phantom-app/tests/nlp_translate_integration.rs
+++ b/crates/phantom-app/tests/nlp_translate_integration.rs
@@ -4,17 +4,15 @@
 //! the `PhantomConfig::nlp_llm_enabled` flag without constructing a live `App`
 //! (which requires a GPU context).
 
-use phantom_nlp::{Intent, MockLlmBackend, translate};
 use phantom_context::ProjectContext;
+use phantom_nlp::{Intent, MockLlmBackend, translate};
 
 // ---------------------------------------------------------------------------
 // Helper: detect real project context for tests.
 // ---------------------------------------------------------------------------
 
 fn rust_ctx() -> ProjectContext {
-    ProjectContext::detect(std::path::Path::new(
-        env!("CARGO_MANIFEST_DIR"),
-    ))
+    ProjectContext::detect(std::path::Path::new(env!("CARGO_MANIFEST_DIR")))
 }
 
 // ---------------------------------------------------------------------------
@@ -40,9 +38,8 @@ fn translate_spawn_agent_with_mock() {
 #[test]
 fn translate_search_history_with_mock() {
     let ctx = rust_ctx();
-    let backend = MockLlmBackend::new(
-        r#"{"intent":"SearchHistory","query":"recent git commits today"}"#,
-    );
+    let backend =
+        MockLlmBackend::new(r#"{"intent":"SearchHistory","query":"recent git commits today"}"#);
     let intent = translate("what changed today", &ctx, &backend).unwrap();
     assert!(matches!(intent, Intent::SearchHistory { .. }));
     assert_eq!(intent.query(), Some("recent git commits today"));
@@ -51,9 +48,8 @@ fn translate_search_history_with_mock() {
 #[test]
 fn translate_clarify_for_ambiguous_input() {
     let ctx = rust_ctx();
-    let backend = MockLlmBackend::new(
-        r#"{"intent":"Clarify","question":"What exactly do you want to do?"}"#,
-    );
+    let backend =
+        MockLlmBackend::new(r#"{"intent":"Clarify","question":"What exactly do you want to do?"}"#);
     let intent = translate("xyzzy frobnicate", &ctx, &backend).unwrap();
     assert!(matches!(intent, Intent::Clarify { .. }));
     assert_eq!(intent.question(), Some("What exactly do you want to do?"));

--- a/crates/phantom-app/tests/phase5_integration.rs
+++ b/crates/phantom-app/tests/phase5_integration.rs
@@ -722,8 +722,8 @@ fn b226_command_complete_with_real_output_yields_nonzero_fix_score() {
     let raw_output = "error[E0308]: mismatched types\n  --> src/main.rs:5:9\n   |\n5  |     return \"hello\";\n   |            ^^^^^^^ expected `i32`, found `&str`";
     let parsed = phantom_semantic::parser::SemanticParser::parse(
         "cargo build",
-        "",          // stdout: empty — mirrors production call
-        raw_output,  // stderr slot: PTY buffer — mirrors production call
+        "",         // stdout: empty — mirrors production call
+        raw_output, // stderr slot: PTY buffer — mirrors production call
         Some(1),
     );
 
@@ -731,10 +731,17 @@ fn b226_command_complete_with_real_output_yields_nonzero_fix_score() {
     assert!(
         !parsed.errors.is_empty(),
         "SemanticParser must detect errors in real compiler output; got errors={:?}, raw_output={:?}",
-        parsed.errors, parsed.raw_output
+        parsed.errors,
+        parsed.raw_output
     );
-    assert_eq!(parsed.command, "cargo build", "ParsedOutput must carry the command string");
-    assert!(!parsed.raw_output.is_empty(), "ParsedOutput must carry the raw output");
+    assert_eq!(
+        parsed.command, "cargo build",
+        "ParsedOutput must carry the command string"
+    );
+    assert!(
+        !parsed.raw_output.is_empty(),
+        "ParsedOutput must carry the raw output"
+    );
 
     // Confirm the brain scorer produces a non-zero fix score for this event.
     let mut scorer = UtilityScorer::new();

--- a/crates/phantom-brain/src/dispatch.rs
+++ b/crates/phantom-brain/src/dispatch.rs
@@ -65,6 +65,11 @@ pub trait ActionHandler {
 
     /// Notification that an agent has been placed in quarantine.
     fn agent_quarantined(&mut self, agent_id: AgentId, denial_count: usize);
+
+    /// A human-checkpoint gate was reached in the active plan.
+    fn checkpoint_reached(&mut self, step_idx: usize, description: String) {
+        let _ = (step_idx, description);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -112,6 +117,9 @@ impl AiAction {
             }
             AiAction::AgentQuarantined { agent_id, denial_count } => {
                 handler.agent_quarantined(agent_id, denial_count);
+            }
+            AiAction::CheckpointReached { step_idx, description } => {
+                handler.checkpoint_reached(step_idx, description);
             }
             AiAction::DoNothing => {}
         }


### PR DESCRIPTION
Rebased onto main. Adds AltScreenViewAdapter, bezier tether rendering, and alt-screen snapshot support. Resolves conflicts with single-dispatch (#337), DAG tab (#341), and prompt persistence (#340). Closes #323.