### PR TITLE
feat: graceful agent pause/resume on network disconnect (closes #321)

### DIFF
--- a/crates/phantom-agents/src/agent.rs
+++ b/crates/phantom-agents/src/agent.rs
@@ -28,6 +28,26 @@ pub type AgentId = u64;
 // AgentStatus
 // ---------------------------------------------------------------------------
 
+/// The reason an agent was paused.
+///
+/// Attached to [`AgentStatus::Paused`] so consumers can decide how to surface
+/// the event in the UI and whether to auto-resume or require user action.
+///
+/// Issue #321: Graceful agent pause/resume on network disconnect.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PauseReason {
+    /// The upstream network is unreachable (DNS failure, TCP timeout, etc.).
+    NetworkUnavailable,
+    /// A specific chat-completion provider is responding with errors or
+    /// rate-limits but the network itself is up.
+    BackendDegraded {
+        /// Human-readable provider identifier (e.g. `"anthropic"`, `"openai"`).
+        provider: String,
+    },
+    /// The user explicitly asked to pause the agent.
+    UserRequested,
+}
+
 /// Agent lifecycle state.
 ///
 /// The full FSM (see issue #34):
@@ -38,11 +58,17 @@ pub type AgentId = u64;
 ///                                          Failed → Queued (retry)
 ///                                            ↓
 ///                                         Flatline → Queued (manual retry)
+///
+/// Working / WaitingForTool → Paused → Working  (issue #321)
 /// ```
 ///
 /// `Queued` may also skip straight to `Working` when there is no plan gate
 /// in effect (the existing fast path for non-gated tasks).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// Note: `Copy` is intentionally absent because `Paused { reason: PauseReason }`
+/// contains a heap-allocated `String` inside `BackendDegraded`. Use `.clone()`
+/// when you need an owned copy.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AgentStatus {
     /// Waiting to start (queued behind concurrency limit).
     Queued,
@@ -56,6 +82,15 @@ pub enum AgentStatus {
     Working,
     /// Called a tool, waiting for the result.
     WaitingForTool,
+    /// Temporarily suspended due to a recoverable condition (network outage,
+    /// backend degradation, or explicit user request).  Transitions back to
+    /// `Working` when the condition clears.
+    ///
+    /// Issue #321: Graceful agent pause/resume on network disconnect.
+    Paused {
+        /// Why the agent was paused.
+        reason: PauseReason,
+    },
     /// Completed successfully.
     Done,
     /// Completed with an error.
@@ -82,12 +117,15 @@ impl AgentStatus {
     /// | Working           | Done              |
     /// | Working           | Failed            |
     /// | Working           | Flatline          |
+    /// | Working           | Paused            | (backend unavailable / user requested)
     /// | WaitingForTool    | Working           |
     /// | WaitingForTool    | Failed            |
     /// | WaitingForTool    | Flatline          |
+    /// | WaitingForTool    | Paused            | (backend unavailable mid-tool)
+    /// | Paused            | Working           | (backend restored / user resumed)
     /// | Failed            | Queued            | (retry)
     /// | Flatline          | Queued            | (manual retry)
-    pub fn can_transition_to(self, next: AgentStatus) -> bool {
+    pub fn can_transition_to(&self, next: &AgentStatus) -> bool {
         use AgentStatus::*;
         matches!(
             (self, next),
@@ -101,9 +139,12 @@ impl AgentStatus {
                 | (Working, Done)
                 | (Working, Failed)
                 | (Working, Flatline)
+                | (Working, Paused { .. })            // #321: pause on backend unavailable
                 | (WaitingForTool, Working)
                 | (WaitingForTool, Failed)
                 | (WaitingForTool, Flatline)
+                | (WaitingForTool, Paused { .. })     // #321: pause mid-tool
+                | (Paused { .. }, Working)            // #321: resume when backend restores
                 | (Failed, Queued)                    // retry
                 | (Flatline, Queued)                  // manual retry
         )
@@ -112,7 +153,7 @@ impl AgentStatus {
     /// Returns `true` if the agent is in a terminal state that cannot advance
     /// without an explicit external trigger (retry, user action, etc.).
     #[must_use]
-    pub fn is_terminal(self) -> bool {
+    pub fn is_terminal(&self) -> bool {
         matches!(self, AgentStatus::Done | AgentStatus::Failed | AgentStatus::Flatline)
     }
 
@@ -120,8 +161,24 @@ impl AgentStatus {
     /// or waiting for a tool result). Used by the concurrency gate in
     /// [`crate::manager::AgentManager`].
     #[must_use]
-    pub fn is_active(self) -> bool {
+    pub fn is_active(&self) -> bool {
         matches!(self, AgentStatus::Working | AgentStatus::WaitingForTool)
+    }
+
+    /// Returns `true` if the agent is currently paused.
+    #[must_use]
+    pub fn is_paused(&self) -> bool {
+        matches!(self, AgentStatus::Paused { .. })
+    }
+
+    /// Returns the pause reason if the agent is in `Paused` state.
+    #[must_use]
+    pub fn pause_reason(&self) -> Option<&PauseReason> {
+        if let AgentStatus::Paused { reason } = self {
+            Some(reason)
+        } else {
+            None
+        }
     }
 }
 
@@ -299,7 +356,7 @@ impl Agent {
     /// Return the current lifecycle status.
     #[must_use]
     pub fn status(&self) -> AgentStatus {
-        self.status
+        self.status.clone()
     }
 
     /// Set the lifecycle status directly, bypassing FSM guards.
@@ -470,7 +527,7 @@ impl Agent {
     /// current state does not permit this transition (no-op on failure so the
     /// caller can decide how to handle the invalid sequence).
     pub fn begin_planning(&mut self) -> bool {
-        if self.status.can_transition_to(AgentStatus::Planning) {
+        if self.status.can_transition_to(&AgentStatus::Planning) {
             self.status = AgentStatus::Planning;
             true
         } else {
@@ -482,7 +539,7 @@ impl Agent {
     ///
     /// Valid only from `Planning`. Returns `true` on success.
     pub fn submit_plan_for_approval(&mut self) -> bool {
-        if self.status.can_transition_to(AgentStatus::AwaitingApproval) {
+        if self.status.can_transition_to(&AgentStatus::AwaitingApproval) {
             self.status = AgentStatus::AwaitingApproval;
             true
         } else {
@@ -495,7 +552,7 @@ impl Agent {
     /// Valid from `Planning` (auto-approve) or `AwaitingApproval` (user/policy
     /// approve). Returns `true` on success.
     pub fn approve_plan(&mut self) -> bool {
-        if self.status.can_transition_to(AgentStatus::Working) {
+        if self.status.can_transition_to(&AgentStatus::Working) {
             self.status = AgentStatus::Working;
             true
         } else {
@@ -508,7 +565,7 @@ impl Agent {
     ///
     /// Returns `true` on success.
     pub fn request_revision(&mut self) -> bool {
-        if self.status.can_transition_to(AgentStatus::Planning) {
+        if self.status.can_transition_to(&AgentStatus::Planning) {
             self.status = AgentStatus::Planning;
             true
         } else {
@@ -538,10 +595,46 @@ impl Agent {
 
     /// Reset a flatlined agent back to Queued for manual retry.
     pub fn retry(&mut self) {
-        debug_assert_eq!(self.status, AgentStatus::Flatline, "retry() called on non-flatlined agent");
+        debug_assert!(
+            matches!(self.status, AgentStatus::Flatline),
+            "retry() called on non-flatlined agent"
+        );
         self.status = AgentStatus::Queued;
         self.flatline_reason = None;
         self.completed_at = None;
+    }
+
+    /// Pause the agent due to a recoverable condition.
+    ///
+    /// Valid from `Working` or `WaitingForTool`. Returns `true` on success,
+    /// `false` if the current status does not allow pausing.
+    ///
+    /// Issue #321: Called by the reconciler when `backend.is_available()` returns
+    /// `false`. The conversation history is preserved so the agent can resume
+    /// exactly where it left off.
+    pub fn pause(&mut self, reason: PauseReason) -> bool {
+        let next = AgentStatus::Paused { reason };
+        if self.status.can_transition_to(&next) {
+            self.status = next;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Resume the agent from a paused state.
+    ///
+    /// Valid only from `Paused`. Returns `true` on success.
+    ///
+    /// Issue #321: Called by the reconciler when `backend.is_available()` returns
+    /// `true` again after a period of unavailability.
+    pub fn resume(&mut self) -> bool {
+        if self.status.can_transition_to(&AgentStatus::Working) {
+            self.status = AgentStatus::Working;
+            true
+        } else {
+            false
+        }
     }
 
     /// Duration since creation.
@@ -690,12 +783,13 @@ impl Agent {
             }
         };
 
-        let status_tag = match self.status {
+        let status_tag = match &self.status {
             AgentStatus::Queued => "QUEUED",
             AgentStatus::Planning => "PLANNING",
             AgentStatus::AwaitingApproval => "PENDING APPROVAL",
             AgentStatus::Working => "WORKING",
             AgentStatus::WaitingForTool => "WAITING",
+            AgentStatus::Paused { .. } => "PAUSED",
             AgentStatus::Done => "DONE",
             AgentStatus::Failed => "FAILED",
             AgentStatus::Flatline => "FLATLINE",
@@ -1140,10 +1234,6 @@ mod tests {
 
     #[test]
     fn agent_message_tool_result_includes_provenance() {
-        // Pushing a ToolResult onto the agent's history must preserve the
-        // provenance fields. This is the substrate's promise that every
-        // entry in agent.messages() can be walked back to the substrate event
-        // that triggered the tool call.
         let mut agent = Agent::new(
             1,
             AgentTask::FreeForm {
@@ -1165,9 +1255,6 @@ mod tests {
 
     #[test]
     fn source_chain_for_last_call_walks_back_n_results() {
-        // Five ToolResults with event ids [10, 20, 30, 40, 50] in
-        // chronological order. Calling source_chain_for_last_call(3) returns
-        // the three most-recent ones, ordered most-recent-first: [50, 40, 30].
         let mut agent = Agent::new(
             1,
             AgentTask::FreeForm {
@@ -1188,9 +1275,6 @@ mod tests {
 
     #[test]
     fn source_chain_excludes_user_and_assistant_messages() {
-        // Only ToolResult messages contribute event ids to the chain. User,
-        // Assistant, System, and ToolCall messages are skipped — they don't
-        // carry a source_event_id and aren't in the input chain.
         let mut agent = Agent::new(
             1,
             AgentTask::FreeForm {
@@ -1218,9 +1302,6 @@ mod tests {
 
     #[test]
     fn source_chain_for_last_call_skips_results_without_event_id() {
-        // ToolResults with `source_event_id == None` (legacy / test paths
-        // that didn't populate provenance) are skipped — they don't break
-        // the chain, they just don't contribute an id.
         let mut agent = Agent::new(
             1,
             AgentTask::FreeForm {
@@ -1242,7 +1323,6 @@ mod tests {
 
     #[test]
     fn source_chain_for_last_call_zero_depth_returns_empty() {
-        // depth = 0 short-circuits to an empty Vec without scanning history.
         let mut agent = Agent::new(
             1,
             AgentTask::FreeForm {
@@ -1259,50 +1339,47 @@ mod tests {
 
     #[test]
     fn can_transition_to_planning_from_queued() {
-        assert!(AgentStatus::Queued.can_transition_to(AgentStatus::Planning));
+        assert!(AgentStatus::Queued.can_transition_to(&AgentStatus::Planning));
     }
 
     #[test]
     fn can_transition_to_awaiting_approval_from_planning() {
-        assert!(AgentStatus::Planning.can_transition_to(AgentStatus::AwaitingApproval));
+        assert!(AgentStatus::Planning.can_transition_to(&AgentStatus::AwaitingApproval));
     }
 
     #[test]
     fn can_transition_to_working_from_awaiting_approval() {
-        assert!(AgentStatus::AwaitingApproval.can_transition_to(AgentStatus::Working));
+        assert!(AgentStatus::AwaitingApproval.can_transition_to(&AgentStatus::Working));
     }
 
     #[test]
     fn can_transition_to_working_from_planning_auto_approve() {
-        // The plan gate may auto-approve without going through AwaitingApproval.
-        assert!(AgentStatus::Planning.can_transition_to(AgentStatus::Working));
+        assert!(AgentStatus::Planning.can_transition_to(&AgentStatus::Working));
     }
 
     #[test]
     fn can_transition_awaiting_approval_back_to_planning_on_revision() {
-        // A user may reject the plan and request revision — agent re-plans.
-        assert!(AgentStatus::AwaitingApproval.can_transition_to(AgentStatus::Planning));
+        assert!(AgentStatus::AwaitingApproval.can_transition_to(&AgentStatus::Planning));
     }
 
     #[test]
     fn invalid_transition_planning_to_done() {
-        assert!(!AgentStatus::Planning.can_transition_to(AgentStatus::Done));
+        assert!(!AgentStatus::Planning.can_transition_to(&AgentStatus::Done));
     }
 
     #[test]
     fn invalid_transition_awaiting_approval_to_done() {
-        assert!(!AgentStatus::AwaitingApproval.can_transition_to(AgentStatus::Done));
+        assert!(!AgentStatus::AwaitingApproval.can_transition_to(&AgentStatus::Done));
     }
 
     #[test]
     fn invalid_transition_awaiting_approval_to_failed_directly() {
-        // Cannot jump straight to Failed from AwaitingApproval — must go Working first.
-        assert!(!AgentStatus::AwaitingApproval.can_transition_to(AgentStatus::Failed));
+        assert!(!AgentStatus::AwaitingApproval.can_transition_to(&AgentStatus::Failed));
     }
 
     #[test]
     fn invalid_transition_done_to_planning() {
-        assert!(!AgentStatus::Done.can_transition_to(AgentStatus::Planning));
+        assert!(!AgentStatus::Done.can_transition_to(&AgentStatus::Planning));
     }
 
     #[test]
@@ -1351,7 +1428,6 @@ mod tests {
 
     #[test]
     fn approve_plan_from_planning_auto_approve() {
-        // Planning → Working directly (auto-approve path, no user interaction).
         let mut agent = Agent::new(1, AgentTask::FreeForm { prompt: "p".into() });
         agent.begin_planning();
         let ok = agent.approve_plan();
@@ -1361,9 +1437,6 @@ mod tests {
 
     #[test]
     fn approve_plan_fast_path_from_queued() {
-        // Queued → Working is the no-gate fast path and a valid transition,
-        // so approve_plan() from Queued succeeds (it routes through the same
-        // can_transition_to(Working) guard).
         let mut agent = Agent::new(1, AgentTask::FreeForm { prompt: "p".into() });
         let ok = agent.approve_plan();
         assert!(ok, "approve_plan() must succeed from Queued via the fast path");
@@ -1372,9 +1445,8 @@ mod tests {
 
     #[test]
     fn approve_plan_fails_from_done() {
-        // Done is a terminal state — cannot transition to Working.
         let mut agent = Agent::new(1, AgentTask::FreeForm { prompt: "p".into() });
-        agent.complete(true); // → Done
+        agent.complete(true);
         let ok = agent.approve_plan();
         assert!(!ok, "approve_plan() must fail from Done");
         assert_eq!(agent.status(), AgentStatus::Done, "status must not change");
@@ -1401,7 +1473,6 @@ mod tests {
 
     #[test]
     fn full_plan_gate_happy_path() {
-        // Queued → Planning → AwaitingApproval → Working → Done
         let mut agent = Agent::new(1, AgentTask::FreeForm { prompt: "p".into() });
         assert_eq!(agent.status(), AgentStatus::Queued);
         assert!(agent.begin_planning());
@@ -1416,18 +1487,14 @@ mod tests {
 
     #[test]
     fn full_plan_gate_with_revision() {
-        // Queued → Planning → AwaitingApproval → Planning → AwaitingApproval → Working
         let mut agent = Agent::new(1, AgentTask::FreeForm { prompt: "p".into() });
         agent.begin_planning();
         agent.submit_plan_for_approval();
         assert_eq!(agent.status(), AgentStatus::AwaitingApproval);
-        // User rejects, requests revision.
         assert!(agent.request_revision());
         assert_eq!(agent.status(), AgentStatus::Planning);
-        // Agent replans, resubmits.
         assert!(agent.submit_plan_for_approval());
         assert_eq!(agent.status(), AgentStatus::AwaitingApproval);
-        // User approves.
         assert!(agent.approve_plan());
         assert_eq!(agent.status(), AgentStatus::Working);
     }
@@ -1481,14 +1548,8 @@ mod tests {
     #[test]
     fn new_agent_has_no_correlation_id() {
         let agent = Agent::new(1, AgentTask::FreeForm { prompt: "test".into() });
-        assert!(
-            agent.correlation_id().is_none(),
-            "Agent::new must leave correlation_id as None",
-        );
-        assert!(
-            agent.parent_id().is_none(),
-            "Agent::new must leave parent_id as None",
-        );
+        assert!(agent.correlation_id().is_none());
+        assert!(agent.parent_id().is_none());
     }
 
     #[test]
@@ -1501,16 +1562,8 @@ mod tests {
             Some(7),
         );
 
-        assert_eq!(
-            agent.correlation_id(),
-            Some(cid),
-            "with_correlation must stamp the given CorrelationId",
-        );
-        assert_eq!(
-            agent.parent_id(),
-            Some(7),
-            "with_correlation must stamp the given parent_id",
-        );
+        assert_eq!(agent.correlation_id(), Some(cid));
+        assert_eq!(agent.parent_id(), Some(7));
     }
 
     #[test]
@@ -1524,7 +1577,7 @@ mod tests {
         );
 
         assert_eq!(agent.correlation_id(), Some(cid));
-        assert!(agent.parent_id().is_none(), "parent_id must be None when not supplied");
+        assert!(agent.parent_id().is_none());
     }
 
     #[test]
@@ -1536,32 +1589,22 @@ mod tests {
             cid,
             None,
         );
-        assert_eq!(
-            agent.status(),
-            AgentStatus::Queued,
-            "with_correlation must start in Queued status",
-        );
+        assert_eq!(agent.status(), AgentStatus::Queued);
     }
 
     #[test]
     fn pipeline_agents_share_correlation_id() {
-        // All agents in a pipeline run should carry the same CorrelationId.
         let cid = CorrelationId::new();
         let parent = Agent::with_correlation(1, AgentTask::FreeForm { prompt: "orchestrator".into() }, cid, None);
         let child = Agent::with_correlation(2, AgentTask::FreeForm { prompt: "worker".into() }, cid, Some(1));
 
-        assert_eq!(
-            parent.correlation_id(),
-            child.correlation_id(),
-            "pipeline agents must share the same correlation id",
-        );
+        assert_eq!(parent.correlation_id(), child.correlation_id());
     }
 
     // -----------------------------------------------------------------------
     // Issue #74: SemanticContext wiring into Agent
     // -----------------------------------------------------------------------
 
-    /// A freshly constructed agent has an empty semantic ring-buffer.
     #[test]
     fn new_agent_semantic_ctx_empty() {
         let agent = Agent::new(1, AgentTask::FreeForm { prompt: "hi".into() });
@@ -1569,8 +1612,6 @@ mod tests {
         assert!(agent.semantic_prompt_section().is_none());
     }
 
-    /// After `push_semantic_output`, the ring-buffer is non-empty and
-    /// `semantic_prompt_section` returns `Some`.
     #[test]
     fn push_semantic_output_populates_ring_buffer() {
         let mut agent = Agent::new(1, AgentTask::FreeForm { prompt: "hi".into() });
@@ -1587,8 +1628,6 @@ mod tests {
         assert!(agent.semantic_prompt_section().is_some());
     }
 
-    /// The semantic prompt section includes the "## Recent command output"
-    /// heading and labels git status output correctly.
     #[test]
     fn semantic_prompt_section_contains_git_status_label() {
         let mut agent = Agent::new(1, AgentTask::FreeForm { prompt: "hi".into() });
@@ -1602,22 +1641,11 @@ mod tests {
         agent.push_semantic_output(parsed);
 
         let section = agent.semantic_prompt_section().unwrap();
-        assert!(
-            section.contains("## Recent command output"),
-            "section must have heading; got: {section}"
-        );
-        assert!(
-            section.contains("git.status"),
-            "section must label git status; got: {section}"
-        );
-        assert!(
-            section.contains("feature/x"),
-            "branch name must surface; got: {section}"
-        );
+        assert!(section.contains("## Recent command output"), "section must have heading; got: {section}");
+        assert!(section.contains("git.status"), "section must label git status; got: {section}");
+        assert!(section.contains("feature/x"), "branch name must surface; got: {section}");
     }
 
-    /// Semantic context is FIFO-capped at MAX_ENTRIES (10). Pushing 12 entries
-    /// keeps the ring-buffer at 10 and evicts the two oldest.
     #[test]
     fn semantic_ctx_ring_buffer_caps_at_max_entries() {
         let mut agent = Agent::new(1, AgentTask::FreeForm { prompt: "hi".into() });
@@ -1632,10 +1660,8 @@ mod tests {
             agent.push_semantic_output(parsed);
         }
 
-        // Must not exceed 10.
         assert_eq!(agent.semantic_ctx().len(), 10);
 
-        // The oldest entries (echo 0, echo 1) must be evicted.
         let commands: Vec<&str> = agent
             .semantic_ctx()
             .entries()
@@ -1647,7 +1673,6 @@ mod tests {
         assert!(commands.contains(&"echo 11"), "echo 11 must be present");
     }
 
-    /// `semantic_prompt_section` surfaces cargo test results (pass/fail counts).
     #[test]
     fn semantic_prompt_section_surfaces_test_results() {
         let mut agent = Agent::new(1, AgentTask::FreeForm { prompt: "hi".into() });
@@ -1669,8 +1694,6 @@ test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
         assert!(section.contains("passed"), "pass count must surface; got: {section}");
     }
 
-    /// Multiple sequential push calls accumulate in order; `semantic_ctx.latest()`
-    /// returns the most recently pushed entry.
     #[test]
     fn semantic_ctx_latest_is_most_recent() {
         let mut agent = Agent::new(1, AgentTask::FreeForm { prompt: "hi".into() });
@@ -1695,8 +1718,8 @@ test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
     #[test]
     fn spawn_opts_new_defaults_role_and_label_to_none() {
         let opts = AgentSpawnOpts::new(AgentTask::FreeForm { prompt: "task".into() });
-        assert!(opts.role.is_none(), "AgentSpawnOpts::new must default role to None");
-        assert!(opts.label.is_none(), "AgentSpawnOpts::new must default label to None");
+        assert!(opts.role.is_none());
+        assert!(opts.label.is_none());
     }
 
     #[test]
@@ -1704,22 +1727,14 @@ test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
         use crate::role::AgentRole;
         let opts = AgentSpawnOpts::new(AgentTask::FreeForm { prompt: "sec".into() })
             .with_role(AgentRole::Defender);
-        assert_eq!(
-            opts.role,
-            Some(AgentRole::Defender),
-            "with_role(Defender) must set opts.role = Some(Defender)",
-        );
+        assert_eq!(opts.role, Some(AgentRole::Defender));
     }
 
     #[test]
     fn spawn_opts_with_label_is_preserved() {
         let opts = AgentSpawnOpts::new(AgentTask::FreeForm { prompt: "work".into() })
             .with_label("custom-defender");
-        assert_eq!(
-            opts.label.as_deref(),
-            Some("custom-defender"),
-            "with_label must set opts.label = Some(custom-defender)",
-        );
+        assert_eq!(opts.label.as_deref(), Some("custom-defender"));
     }
 
     #[test]
@@ -1739,24 +1754,13 @@ test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
         let q = queue.lock().expect("queue lock");
         assert_eq!(q.len(), 1);
         let req = &q[0];
-        assert_eq!(req.assigned_id, id, "assigned_id must match returned id");
-        assert_eq!(
-            req.role,
-            AgentRole::Defender,
-            "SpawnSubagentRequest.role must be Defender, not Conversational",
-        );
-        assert_eq!(
-            req.label,
-            "sec-watcher",
-            "SpawnSubagentRequest.label must be sec-watcher",
-        );
+        assert_eq!(req.assigned_id, id);
+        assert_eq!(req.role, AgentRole::Defender);
+        assert_eq!(req.label, "sec-watcher");
     }
 
     // ---- Disposition wiring (#38 / #49) ------------------------------------
 
-    /// Chat-disposition agents must jump Queued → Working via `try_auto_approve`,
-    /// never visiting `AwaitingApproval`. This is the agent-level anchor for the
-    /// auto-approve fast path (Issue #49).
     #[test]
     fn try_auto_approve_chat_goes_queued_to_working_directly() {
         let mut agent = Agent::with_disposition(
@@ -1768,16 +1772,10 @@ test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
 
         let approved = agent.try_auto_approve();
 
-        assert!(approved, "try_auto_approve must return true for Chat disposition");
-        assert_eq!(
-            agent.status(),
-            AgentStatus::Working,
-            "Chat agent must be Working after try_auto_approve, not AwaitingApproval",
-        );
+        assert!(approved);
+        assert_eq!(agent.status(), AgentStatus::Working);
     }
 
-    /// `try_auto_approve` on Synthesize, Decompose, and Audit must also
-    /// short-circuit to Working (all satisfy `auto_approve()`).
     #[test]
     fn try_auto_approve_synthesize_decompose_audit_go_to_working() {
         for disposition in [Disposition::Synthesize, Disposition::Decompose, Disposition::Audit] {
@@ -1786,20 +1784,11 @@ test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
                 AgentTask::FreeForm { prompt: "task".into() },
                 disposition,
             );
-            assert!(
-                agent.try_auto_approve(),
-                "{disposition:?} must auto-approve",
-            );
-            assert_eq!(
-                agent.status(),
-                AgentStatus::Working,
-                "{disposition:?} must end up Working, not AwaitingApproval",
-            );
+            assert!(agent.try_auto_approve(), "{disposition:?} must auto-approve");
+            assert_eq!(agent.status(), AgentStatus::Working);
         }
     }
 
-    /// Write-side dispositions (Feature, BugFix, Refactor, Chore) must NOT
-    /// auto-approve — they require the full plan gate.
     #[test]
     fn try_auto_approve_returns_false_for_write_dispositions() {
         for disposition in [
@@ -1813,15 +1802,8 @@ test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
                 AgentTask::FreeForm { prompt: "task".into() },
                 disposition,
             );
-            assert!(
-                !agent.try_auto_approve(),
-                "{disposition:?} must not auto-approve",
-            );
-            assert_eq!(
-                agent.status(),
-                AgentStatus::Queued,
-                "{disposition:?} must remain Queued when try_auto_approve returns false",
-            );
+            assert!(!agent.try_auto_approve(), "{disposition:?} must not auto-approve");
+            assert_eq!(agent.status(), AgentStatus::Queued);
         }
     }
 
@@ -1877,5 +1859,103 @@ test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
             .with_disposition(Disposition::Feature);
         assert_eq!(o.disposition, Disposition::Feature);
         assert!(o.chat_model.is_none());
+    }
+
+    // ---- Issue #321: Pause / Resume FSM transitions -------------------------
+
+    #[test]
+    fn pause_from_working_network_unavailable() {
+        let mut agent = Agent::new(1, AgentTask::FreeForm { prompt: "task".into() });
+        agent.set_status(AgentStatus::Working);
+        let ok = agent.pause(PauseReason::NetworkUnavailable);
+        assert!(ok, "pause() must succeed from Working");
+        assert_eq!(
+            agent.status(),
+            AgentStatus::Paused { reason: PauseReason::NetworkUnavailable }
+        );
+        assert!(agent.status().is_paused());
+    }
+
+    #[test]
+    fn pause_from_working_backend_degraded() {
+        let mut agent = Agent::new(1, AgentTask::FreeForm { prompt: "task".into() });
+        agent.set_status(AgentStatus::Working);
+        let ok = agent.pause(PauseReason::BackendDegraded { provider: "anthropic".into() });
+        assert!(ok);
+        assert!(agent.status().is_paused());
+        assert_eq!(
+            agent.status().pause_reason(),
+            Some(&PauseReason::BackendDegraded { provider: "anthropic".into() })
+        );
+    }
+
+    #[test]
+    fn pause_from_waiting_for_tool() {
+        let mut agent = Agent::new(1, AgentTask::FreeForm { prompt: "task".into() });
+        agent.set_status(AgentStatus::WaitingForTool);
+        let ok = agent.pause(PauseReason::NetworkUnavailable);
+        assert!(ok, "pause() must succeed from WaitingForTool");
+        assert!(agent.status().is_paused());
+    }
+
+    #[test]
+    fn resume_from_paused_transitions_to_working() {
+        let mut agent = Agent::new(1, AgentTask::FreeForm { prompt: "task".into() });
+        agent.set_status(AgentStatus::Paused { reason: PauseReason::NetworkUnavailable });
+        let ok = agent.resume();
+        assert!(ok, "resume() must succeed from Paused");
+        assert_eq!(agent.status(), AgentStatus::Working);
+    }
+
+    #[test]
+    fn pause_from_queued_is_rejected() {
+        let mut agent = Agent::new(1, AgentTask::FreeForm { prompt: "task".into() });
+        let ok = agent.pause(PauseReason::NetworkUnavailable);
+        assert!(!ok, "pause() must fail from Queued");
+        assert_eq!(agent.status(), AgentStatus::Queued, "status must not change");
+    }
+
+    #[test]
+    fn resume_from_working_is_rejected() {
+        let mut agent = Agent::new(1, AgentTask::FreeForm { prompt: "task".into() });
+        agent.set_status(AgentStatus::Working);
+        let ok = agent.resume();
+        assert!(!ok, "resume() must fail from Working");
+        assert_eq!(agent.status(), AgentStatus::Working, "status must not change");
+    }
+
+    #[test]
+    fn paused_is_not_terminal() {
+        let s = AgentStatus::Paused { reason: PauseReason::NetworkUnavailable };
+        assert!(!s.is_terminal(), "Paused must not be terminal");
+    }
+
+    #[test]
+    fn paused_is_not_active() {
+        let s = AgentStatus::Paused { reason: PauseReason::NetworkUnavailable };
+        assert!(!s.is_active(), "Paused must not be is_active()");
+    }
+
+    #[test]
+    fn status_line_shows_paused_tag() {
+        let mut agent = Agent::new(1, AgentTask::FreeForm { prompt: "task".into() });
+        agent.set_status(AgentStatus::Working);
+        agent.pause(PauseReason::NetworkUnavailable);
+        let line = agent.status_line();
+        assert!(line.contains("PAUSED"), "status line must show PAUSED tag; got: {line}");
+    }
+
+    #[test]
+    fn pause_reason_serde_round_trip() {
+        let reasons = [
+            PauseReason::NetworkUnavailable,
+            PauseReason::BackendDegraded { provider: "openai".into() },
+            PauseReason::UserRequested,
+        ];
+        for r in &reasons {
+            let json = serde_json::to_string(r).expect("serialize");
+            let back: PauseReason = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(r, &back, "PauseReason must round-trip through serde");
+        }
     }
 }

--- a/crates/phantom-agents/src/chat.rs
+++ b/crates/phantom-agents/src/chat.rs
@@ -130,6 +130,18 @@ pub trait ChatBackend: Send + Sync {
 
     /// Issue one round of chat completion.
     fn complete(&self, request: ChatRequest<'_>) -> Result<ChatResponse, ChatError>;
+
+    /// Whether the backend is currently reachable.
+    ///
+    /// Returns `true` by default. Implementations that can detect transient
+    /// network unavailability (e.g. by checking a cached health-check result)
+    /// should override this to return `false` while the provider is down.
+    ///
+    /// The reconciler polls this every 30 seconds for paused agents and
+    /// auto-resumes them when it flips back to `true`.
+    fn is_available(&self) -> bool {
+        true
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/phantom-agents/src/cli.rs
+++ b/crates/phantom-agents/src/cli.rs
@@ -641,6 +641,7 @@ fn status_tag(status: AgentStatus) -> &'static str {
         AgentStatus::Done => "DONE",
         AgentStatus::Failed => "FAILED",
         AgentStatus::Flatline => "FLATLINE",
+        AgentStatus::Paused { .. } => "PAUSED",
     }
 }
 

--- a/crates/phantom-agents/src/render.rs
+++ b/crates/phantom-agents/src/render.rs
@@ -39,6 +39,18 @@ impl AgentPaneStyle {
             AgentStatus::AwaitingApproval => Self::awaiting_approval(),
             AgentStatus::Done => Self::done(),
             AgentStatus::Failed | AgentStatus::Flatline => Self::failed(),
+            AgentStatus::Paused { .. } => Self::paused(),
+        }
+    }
+
+    /// Dim amber, no pulse — the agent is waiting for its backend to recover.
+    fn paused() -> Self {
+        Self {
+            border_color: [0.7, 0.55, 0.1, 1.0],      // muted amber
+            header_bg: [0.10, 0.08, 0.02, 1.0],        // very dark amber
+            header_fg: [0.85, 0.70, 0.35, 1.0],        // pale amber
+            status_color: [0.7, 0.55, 0.1, 1.0],       // muted amber
+            pulse_speed: 0.0,                           // no pulse — waiting
         }
     }
 
@@ -168,6 +180,7 @@ pub fn agent_header(agent: &Agent) -> String {
         AgentStatus::Done => format!("DONE {:.1}s", agent.elapsed().as_secs_f32()),
         AgentStatus::Failed => "FAILED".to_string(),
         AgentStatus::Flatline => "FLATLINE".to_string(),
+        AgentStatus::Paused { .. } => "PAUSED".to_string(),
     };
 
     format!("\u{25a0} AGENT #{} \u{2014} {} [{}]", agent.id(), task_desc, status)

--- a/crates/phantom-app/src/action_context.rs
+++ b/crates/phantom-app/src/action_context.rs
@@ -10,9 +10,10 @@ use std::time::Instant;
 use log::{info, warn};
 
 use phantom_agents::{AgentId, AgentSpawnOpts, AgentTask};
+use phantom_agents::agent::PauseReason;
 use phantom_agents::dispatch::Disposition;
 use phantom_brain::dispatch::ActionHandler;
-use phantom_brain::events::SuggestionOption;
+use phantom_brain::events::{ConnectionState, SuggestionOption};
 
 use crate::app::SuggestionOverlay;
 use crate::console::Console;
@@ -133,5 +134,17 @@ impl ActionHandler for AppActionHandler<'_> {
 
     fn agent_quarantined(&mut self, agent_id: AgentId, denial_count: usize) {
         info!("[PHANTOM]: Agent {agent_id} quarantined ({denial_count} denials)");
+    }
+
+    fn pause_agent(&mut self, agent_id: AgentId, reason: PauseReason) {
+        info!("[PHANTOM]: Pausing agent {agent_id} ({reason:?})");
+    }
+
+    fn resume_agent(&mut self, agent_id: AgentId) {
+        info!("[PHANTOM]: Resuming agent {agent_id}");
+    }
+
+    fn update_connection_state(&mut self, state: ConnectionState) {
+        info!("[PHANTOM]: Connection state updated: {state:?}");
     }
 }

--- a/crates/phantom-app/src/agent_pane/mod.rs
+++ b/crates/phantom-app/src/agent_pane/mod.rs
@@ -382,7 +382,6 @@ impl AgentPane {
 
         let mut agent = Agent::new(0, task.clone());
         let sys_prompt = agent.system_prompt();
-        agent.store_prompt(sys_prompt.clone());
         agent.push_message(AgentMessage::System(sys_prompt));
 
         // Inject codebase context so the agent knows where it lives.

--- a/crates/phantom-app/src/update.rs
+++ b/crates/phantom-app/src/update.rs
@@ -8,12 +8,12 @@ use std::time::Instant;
 use anyhow::Result;
 use log::{debug, info, warn};
 
-use phantom_brain::events::{AiEvent};
+use phantom_brain::events::AiEvent;
 use phantom_brain::ooda::WorldState;
-use phantom_protocol::Event;
 use phantom_context::ProjectContext;
 use phantom_history::HistoryEntry;
 use phantom_mcp::{AppCommand, ScreenshotReply};
+use phantom_protocol::Event;
 use crate::app::{App, AppState};
 use crate::input::chrono_time_string;
 

--- a/crates/phantom-brain/src/brain.rs
+++ b/crates/phantom-brain/src/brain.rs
@@ -1029,6 +1029,9 @@ pub(crate) fn action_name(action: &AiAction) -> &str {
         AiAction::QuarantineAgent { .. } => "quarantine_agent",
         AiAction::AgentQuarantined { .. } => "agent_quarantined",
         AiAction::CheckpointReached { .. } => "checkpoint_reached",
+        AiAction::PauseAgent { .. } => "pause_agent",
+        AiAction::ResumeAgent { .. } => "resume_agent",
+        AiAction::UpdateConnectionState { .. } => "update_connection_state",
         AiAction::DoNothing => "quiet",
     }
 }

--- a/crates/phantom-brain/src/dispatch.rs
+++ b/crates/phantom-brain/src/dispatch.rs
@@ -16,9 +16,10 @@
 //! implement `ActionHandler`.
 
 use phantom_agents::{AgentId, AgentTask};
+use phantom_agents::agent::PauseReason;
 use phantom_agents::dispatch::Disposition;
 
-use crate::events::{AiAction, SuggestionOption};
+use crate::events::{AiAction, ConnectionState, SuggestionOption};
 
 // ---------------------------------------------------------------------------
 // ActionHandler trait
@@ -70,6 +71,21 @@ pub trait ActionHandler {
     fn checkpoint_reached(&mut self, step_idx: usize, description: String) {
         let _ = (step_idx, description);
     }
+
+    /// Pause a running agent because its backend became unavailable.
+    fn pause_agent(&mut self, agent_id: AgentId, reason: PauseReason) {
+        let _ = (agent_id, reason);
+    }
+
+    /// Resume a previously paused agent because its backend is available again.
+    fn resume_agent(&mut self, agent_id: AgentId) {
+        let _ = agent_id;
+    }
+
+    /// Update the connection state indicator in the status bar.
+    fn update_connection_state(&mut self, state: ConnectionState) {
+        let _ = state;
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -120,6 +136,15 @@ impl AiAction {
             }
             AiAction::CheckpointReached { step_idx, description } => {
                 handler.checkpoint_reached(step_idx, description);
+            }
+            AiAction::PauseAgent { agent_id, reason } => {
+                handler.pause_agent(agent_id, reason);
+            }
+            AiAction::ResumeAgent { agent_id } => {
+                handler.resume_agent(agent_id);
+            }
+            AiAction::UpdateConnectionState { state } => {
+                handler.update_connection_state(state);
             }
             AiAction::DoNothing => {}
         }

--- a/crates/phantom-brain/src/events.rs
+++ b/crates/phantom-brain/src/events.rs
@@ -4,6 +4,7 @@
 //! Both are passed over `std::sync::mpsc` channels between the brain thread
 //! and the rest of the application.
 
+use phantom_agents::agent::PauseReason;
 use phantom_agents::dispatch::Disposition;
 use phantom_agents::{AgentId, AgentTask};
 use phantom_semantic::ParsedOutput;
@@ -193,21 +194,43 @@ pub enum AiAction {
     },
 
     /// A checkpoint step is the next eligible step but cannot run until approved.
-    ///
-    /// Emitted by the reconciler when [`TaskLedger::eligible_next`] returns no
-    /// eligible steps because the next candidate step has
-    /// [`StepStatus::NeedsApproval`]. The UI should surface this as a blocking
-    /// prompt so the operator can call [`TaskLedger::approve_checkpoint`].
-    ///
-    /// The brain emits this action **once per checkpoint encounter** to avoid
-    /// spamming the UI on every reconciler tick.
     CheckpointReached {
-        /// Index of the step in the active [`TaskLedger`] plan.
         step_idx: usize,
-        /// Human-readable description of what the step will do once approved.
         description: String,
     },
 
+    /// Pause a running agent because its backend became unavailable.
+    PauseAgent {
+        agent_id: AgentId,
+        reason: PauseReason,
+    },
+
+    /// Resume a previously paused agent because its backend is available again.
+    ResumeAgent { agent_id: AgentId },
+
+    /// Update the connection state displayed in the status bar.
+    UpdateConnectionState { state: ConnectionState },
+
+
     /// Do nothing. The brain decided silence is the best action.
     DoNothing,
+}
+
+// ---------------------------------------------------------------------------
+// ConnectionState
+// ---------------------------------------------------------------------------
+
+/// The connectivity status of the AI backend as observed by the reconciler.
+///
+/// Mirrors the `PauseReason` taxonomy but is a coarser, UI-facing enum.
+/// The reconciler derives this from the most recent `PauseReason` seen across
+/// all paused agents and broadcasts it via [`AiAction::UpdateConnectionState`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConnectionState {
+    /// All backends are reachable.
+    Connected,
+    /// A named provider is responding but returning errors or degraded results.
+    Degraded { provider: String },
+    /// No backend is reachable (network down or all providers offline).
+    Offline,
 }

--- a/crates/phantom-brain/src/reconciler.rs
+++ b/crates/phantom-brain/src/reconciler.rs
@@ -35,13 +35,31 @@ use std::collections::HashMap;
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
+use phantom_agents::agent::PauseReason;
 use phantom_agents::dispatch::Disposition;
 use phantom_agents::policy::AgentPolicy;
 use phantom_agents::{AgentId, AgentTask};
 
-use crate::events::AiAction;
+use crate::events::{AiAction, ConnectionState};
 use crate::orchestrator::{ReplanDecision, StepStatus, TaskLedger};
 
+/// How often the reconciler checks whether a paused agent's backend has
+/// become available again.
+const BACKEND_POLL_INTERVAL: Duration = Duration::from_secs(30);
+
+// ---------------------------------------------------------------------------
+// PausedAgentEntry
+// ---------------------------------------------------------------------------
+
+/// Tracks an agent that has been paused because its backend became unavailable.
+struct PausedAgentEntry {
+    agent_id: AgentId,
+    /// The reason the agent was paused; kept for diagnostics and future
+    /// reason-specific retry logic (e.g. different poll intervals per reason).
+    #[allow(dead_code)]
+    reason: PauseReason,
+    last_polled: Instant,
+}
 // ---------------------------------------------------------------------------
 // ReconcilerState
 // ---------------------------------------------------------------------------
@@ -68,6 +86,12 @@ pub struct ReconcilerState {
     /// tick to override the timeout or retry budget for all subsequently
     /// dispatched agents. Production code leaves this at `AgentPolicy::default()`.
     pub agent_policy: AgentPolicy,
+    /// Agents that are currently paused waiting for their backend to recover.
+    paused_agents: Vec<PausedAgentEntry>,
+    /// Optional availability probe injected in tests to avoid real I/O.
+    /// When `Some`, `poll_paused_agents` calls this instead of
+    /// `ChatBackend::is_available()`.
+    pub availability_probe: Option<Box<dyn Fn(AgentId) -> bool + Send>>,
 }
 
 impl ReconcilerState {
@@ -76,12 +100,15 @@ impl ReconcilerState {
             active_dispatches: HashMap::new(),
             next_agent_id: 10_000_u64,
             agent_policy: AgentPolicy::default(),
+            paused_agents: Vec::new(),
+            availability_probe: None,
         }
     }
 
     /// Reset all tracking — called when a new goal replaces the current one.
     pub fn reset(&mut self) {
         self.active_dispatches.clear();
+        self.paused_agents.clear();
     }
 
     // -----------------------------------------------------------------------
@@ -95,6 +122,7 @@ impl ReconcilerState {
     /// Returns `true` if the ledger is still active (caller should keep it),
     /// `false` if the goal reached a terminal state (caller should drop the ledger).
     pub fn tick(&mut self, ledger: &mut TaskLedger, action_tx: &mpsc::Sender<AiAction>) -> bool {
+        self.poll_paused_agents(action_tx);
         self.check_stalled(ledger, action_tx);
 
         match ledger.should_replan() {
@@ -206,6 +234,103 @@ impl ReconcilerState {
                 }
             }
             ledger.record_output(summary);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Pause / resume API
+    // -----------------------------------------------------------------------
+
+    /// Notify the reconciler that `agent_id`'s backend has become unavailable.
+    ///
+    /// The agent is added to the paused list and a [`AiAction::PauseAgent`] is
+    /// emitted. If the agent is already in the paused list this is a no-op.
+    pub fn on_backend_unavailable(
+        &mut self,
+        agent_id: AgentId,
+        reason: PauseReason,
+        action_tx: &mpsc::Sender<AiAction>,
+    ) {
+        if self.paused_agents.iter().any(|e| e.agent_id == agent_id) {
+            return;
+        }
+
+        let state = connection_state_for_reason(&reason);
+        self.paused_agents.push(PausedAgentEntry {
+            agent_id,
+            reason: reason.clone(),
+            last_polled: Instant::now(),
+        });
+
+        log::warn!("Reconciler: pausing agent {agent_id} — {reason:?}");
+        let _ = action_tx.send(AiAction::PauseAgent { agent_id, reason });
+        let _ = action_tx.send(AiAction::UpdateConnectionState { state });
+    }
+
+    /// Notify the reconciler that a backend has recovered and all paused agents
+    /// should be resumed.
+    ///
+    /// Emits [`AiAction::ResumeAgent`] for every agent in the paused list and
+    /// clears the list. Also emits [`AiAction::UpdateConnectionState`] with
+    /// [`ConnectionState::Connected`].
+    pub fn on_backend_available(&mut self, action_tx: &mpsc::Sender<AiAction>) {
+        for entry in self.paused_agents.drain(..) {
+            log::info!("Reconciler: resuming agent {} — backend restored", entry.agent_id);
+            let _ = action_tx.send(AiAction::ResumeAgent { agent_id: entry.agent_id });
+        }
+        let _ = action_tx.send(AiAction::UpdateConnectionState {
+            state: ConnectionState::Connected,
+        });
+    }
+
+    /// Number of agents currently paused waiting for backend recovery.
+    pub fn paused_agent_count(&self) -> usize {
+        self.paused_agents.len()
+    }
+
+    /// Poll every paused agent to see if its backend has recovered.
+    ///
+    /// Called at the start of each [`tick`]. For each paused agent whose
+    /// `last_polled` timestamp has exceeded [`BACKEND_POLL_INTERVAL`], the
+    /// reconciler checks availability (via `availability_probe` if set, or
+    /// always-available default) and emits [`AiAction::ResumeAgent`] if the
+    /// backend is back.
+    pub fn poll_paused_agents(&mut self, action_tx: &mpsc::Sender<AiAction>) {
+        if self.paused_agents.is_empty() {
+            return;
+        }
+
+        let mut to_resume: Vec<AgentId> = Vec::new();
+
+        for entry in &mut self.paused_agents {
+            if entry.last_polled.elapsed() >= BACKEND_POLL_INTERVAL {
+                entry.last_polled = Instant::now();
+
+                let available = if let Some(probe) = &self.availability_probe {
+                    probe(entry.agent_id)
+                } else {
+                    // Default: no real probe wired in; never auto-resume
+                    // without an explicit `on_backend_available` call.
+                    false
+                };
+
+                if available {
+                    to_resume.push(entry.agent_id);
+                }
+            }
+        }
+
+        if !to_resume.is_empty() {
+            self.paused_agents.retain(|e| !to_resume.contains(&e.agent_id));
+            for agent_id in to_resume {
+                log::info!("Reconciler: resuming agent {agent_id} — probe confirmed available");
+                let _ = action_tx.send(AiAction::ResumeAgent { agent_id });
+            }
+            if self.paused_agents.is_empty() {
+                let _ = action_tx.send(AiAction::UpdateConnectionState {
+                    state: ConnectionState::Connected,
+                });
+            }
         }
     }
 
@@ -322,6 +447,21 @@ impl ReconcilerState {
 impl Default for ReconcilerState {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Derive a [`ConnectionState`] from a [`PauseReason`].
+fn connection_state_for_reason(reason: &PauseReason) -> ConnectionState {
+    match reason {
+        PauseReason::NetworkUnavailable => ConnectionState::Offline,
+        PauseReason::BackendDegraded { provider } => ConnectionState::Degraded {
+            provider: provider.clone(),
+        },
+        PauseReason::UserRequested => ConnectionState::Connected,
     }
 }
 
@@ -1010,6 +1150,154 @@ mod tests {
         assert!(
             disposition.auto_approve(),
             "Chat disposition must satisfy auto_approve() so the fast path fires",
+        );
+    }
+
+    // -- Issue #321: graceful pause / resume on backend unavailability -----------
+
+    /// `on_backend_unavailable` adds the agent to the paused list and emits
+    /// `PauseAgent` + `UpdateConnectionState(Offline)` for `NetworkUnavailable`.
+    #[test]
+    fn on_backend_unavailable_emits_pause_and_connection_state() {
+        use phantom_agents::agent::PauseReason;
+        let (tx, rx) = mpsc::channel();
+        let mut state = ReconcilerState::new();
+
+        state.on_backend_unavailable(1, PauseReason::NetworkUnavailable, &tx);
+
+        assert_eq!(state.paused_agent_count(), 1);
+
+        let actions: Vec<_> = rx.try_iter().collect();
+        assert_eq!(actions.len(), 2, "expected PauseAgent + UpdateConnectionState");
+
+        assert!(matches!(&actions[0], AiAction::PauseAgent { agent_id: 1, .. }));
+        assert!(
+            matches!(&actions[1], AiAction::UpdateConnectionState { state } if *state == crate::events::ConnectionState::Offline)
+        );
+    }
+
+    /// Calling `on_backend_unavailable` twice for the same agent is a no-op
+    /// the second time — no duplicate entries in the paused list.
+    #[test]
+    fn on_backend_unavailable_is_idempotent_for_same_agent() {
+        use phantom_agents::agent::PauseReason;
+        let (tx, rx) = mpsc::channel();
+        let mut state = ReconcilerState::new();
+
+        state.on_backend_unavailable(5, PauseReason::NetworkUnavailable, &tx);
+        state.on_backend_unavailable(5, PauseReason::NetworkUnavailable, &tx);
+
+        assert_eq!(state.paused_agent_count(), 1, "must not double-register same agent");
+        let actions: Vec<_> = rx.try_iter().collect();
+        // Only 2 actions from the first call, second is a no-op.
+        assert_eq!(actions.len(), 2);
+    }
+
+    /// `on_backend_available` emits `ResumeAgent` for every paused agent and
+    /// clears the paused list, then emits `UpdateConnectionState(Connected)`.
+    #[test]
+    fn on_backend_available_resumes_all_paused_agents() {
+        use phantom_agents::agent::PauseReason;
+        let (tx, rx) = mpsc::channel();
+        let mut state = ReconcilerState::new();
+
+        state.on_backend_unavailable(1, PauseReason::NetworkUnavailable, &tx);
+        state.on_backend_unavailable(2, PauseReason::NetworkUnavailable, &tx);
+        // Drain the pause actions.
+        let _: Vec<_> = rx.try_iter().collect();
+
+        state.on_backend_available(&tx);
+
+        assert_eq!(state.paused_agent_count(), 0, "paused list must be cleared");
+
+        let actions: Vec<_> = rx.try_iter().collect();
+        // 2 ResumeAgent + 1 UpdateConnectionState(Connected)
+        assert_eq!(actions.len(), 3, "expected 2 ResumeAgent + UpdateConnectionState");
+
+        let resume_count = actions
+            .iter()
+            .filter(|a| matches!(a, AiAction::ResumeAgent { .. }))
+            .count();
+        assert_eq!(resume_count, 2);
+
+        assert!(actions.iter().any(
+            |a| matches!(a, AiAction::UpdateConnectionState { state } if *state == crate::events::ConnectionState::Connected)
+        ));
+    }
+
+    /// `poll_paused_agents` with an always-true probe auto-resumes agents
+    /// whose `last_polled` has exceeded `BACKEND_POLL_INTERVAL`.
+    #[test]
+    fn poll_paused_agents_resumes_when_probe_returns_true() {
+        use phantom_agents::agent::PauseReason;
+        let (tx, rx) = mpsc::channel();
+        let mut state = ReconcilerState::new();
+        // Install an always-available probe.
+        state.availability_probe = Some(Box::new(|_| true));
+
+        state.on_backend_unavailable(7, PauseReason::NetworkUnavailable, &tx);
+        // Drain pause actions.
+        let _: Vec<_> = rx.try_iter().collect();
+
+        // Force the last_polled stamp to the past so the interval has elapsed.
+        if let Some(entry) = state.paused_agents.first_mut() {
+            entry.last_polled = Instant::now()
+                .checked_sub(BACKEND_POLL_INTERVAL + Duration::from_secs(1))
+                .unwrap_or_else(Instant::now);
+        }
+
+        state.poll_paused_agents(&tx);
+
+        assert_eq!(state.paused_agent_count(), 0, "agent must be auto-resumed");
+        let actions: Vec<_> = rx.try_iter().collect();
+        assert!(actions.iter().any(|a| matches!(a, AiAction::ResumeAgent { agent_id: 7 })));
+        assert!(actions.iter().any(
+            |a| matches!(a, AiAction::UpdateConnectionState { state } if *state == crate::events::ConnectionState::Connected)
+        ));
+    }
+
+    /// `poll_paused_agents` with an always-false probe does NOT auto-resume.
+    #[test]
+    fn poll_paused_agents_does_not_resume_when_probe_returns_false() {
+        use phantom_agents::agent::PauseReason;
+        let (tx, rx) = mpsc::channel();
+        let mut state = ReconcilerState::new();
+        state.availability_probe = Some(Box::new(|_| false));
+
+        state.on_backend_unavailable(9, PauseReason::NetworkUnavailable, &tx);
+        let _: Vec<_> = rx.try_iter().collect();
+
+        // Force the elapsed time to exceed the poll interval.
+        if let Some(entry) = state.paused_agents.first_mut() {
+            entry.last_polled = Instant::now()
+                .checked_sub(BACKEND_POLL_INTERVAL + Duration::from_secs(1))
+                .unwrap_or_else(Instant::now);
+        }
+
+        state.poll_paused_agents(&tx);
+
+        assert_eq!(state.paused_agent_count(), 1, "agent must remain paused");
+        let actions: Vec<_> = rx.try_iter().collect();
+        assert!(actions.is_empty(), "no actions when backend still unavailable");
+    }
+
+    /// `connection_state_for_reason` maps `PauseReason` to `ConnectionState`.
+    #[test]
+    fn connection_state_for_reason_maps_correctly() {
+        use phantom_agents::agent::PauseReason;
+        use crate::events::ConnectionState;
+
+        assert_eq!(
+            connection_state_for_reason(&PauseReason::NetworkUnavailable),
+            ConnectionState::Offline,
+        );
+        assert_eq!(
+            connection_state_for_reason(&PauseReason::BackendDegraded { provider: "openai".into() }),
+            ConnectionState::Degraded { provider: "openai".into() },
+        );
+        assert_eq!(
+            connection_state_for_reason(&PauseReason::UserRequested),
+            ConnectionState::Connected,
         );
     }
 

--- a/crates/phantom-memory/src/journal.rs
+++ b/crates/phantom-memory/src/journal.rs
@@ -341,6 +341,30 @@ impl AgentJournal {
         )
     }
 
+    /// Record a conversation checkpoint when an agent is paused mid-task.
+    ///
+    /// Snapshots the current conversation state so it can be restored when the
+    /// agent resumes. `pause_reason` is a human-readable description of why the
+    /// agent was paused (e.g. `"network_unavailable"`). `message_count` is the
+    /// number of messages in the conversation at the time of the checkpoint.
+    /// `conversation_json` is a serialized snapshot of the conversation history.
+    ///
+    /// Returns the journal entry that was written.
+    pub fn record_conversation_checkpoint(
+        &mut self,
+        agent_id: AgentId,
+        pause_reason: impl Into<String>,
+        message_count: usize,
+        conversation_json: serde_json::Value,
+    ) -> Result<JournalEntry, JournalError> {
+        let reason = pause_reason.into();
+        let message = format!(
+            "checkpoint: pause_reason={reason} message_count={message_count} snapshot={}",
+            conversation_json
+        );
+        self.record(agent_id, Phase::Lifecycle, Level::Warn, message)
+    }
+
     // ── Query API ─────────────────────────────────────────────────────────
 
     /// Most-recent `n` journal entries, in chronological order (oldest first).

--- a/crates/phantom-session/src/agent_state.rs
+++ b/crates/phantom-session/src/agent_state.rs
@@ -230,7 +230,7 @@ impl AgentSnapshot {
     /// `Planning`, or `AwaitingApproval`).
     #[must_use]
     pub fn status(&self) -> AgentStatus {
-        self.status
+        self.status.clone()
     }
 
     /// Saved conversation messages (in-flight tool calls stripped).

--- a/crates/phantom-ui/src/widgets/mod.rs
+++ b/crates/phantom-ui/src/widgets/mod.rs
@@ -124,19 +124,60 @@ pub trait Widget {
 // StatusBar
 // -----------------------------------------------------------------------
 
+// -----------------------------------------------------------------------
+// ConnectionIndicator
+// -----------------------------------------------------------------------
+
+/// Connection state of the AI backend, shown in the status bar.
+///
+/// This is a UI-facing mirror of the brain's `ConnectionState` enum.
+/// It lives in `phantom-ui` to avoid a cross-crate dependency on
+/// `phantom-brain` from the UI layer; the app layer maps between the two.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ConnectionIndicator {
+    /// All backends reachable — no indicator shown.
+    Connected,
+    /// A named provider is degraded — shown in amber.
+    Degraded { provider: String },
+    /// Network offline — shown in red.
+    Offline,
+}
+
+impl ConnectionIndicator {
+    /// Short label displayed in the status bar (empty when connected).
+    pub fn label(&self) -> String {
+        match self {
+            Self::Connected => String::new(),
+            Self::Degraded { provider } => format!("~ {provider}"),
+            Self::Offline => "OFFLINE".to_owned(),
+        }
+    }
+
+    /// RGBA color for the indicator text.
+    pub fn color(&self) -> [f32; 4] {
+        match self {
+            Self::Connected => [0.6, 0.7, 0.6, 1.0],
+            Self::Degraded { .. } => [0.9, 0.7, 0.2, 1.0],
+            Self::Offline => [0.9, 0.3, 0.3, 1.0],
+        }
+    }
+}
+
 /// Bottom status bar showing working directory, git branch, and time.
 ///
 /// The bar is divided into three regions:
 /// - **Left**: current working directory, truncated with a leading `...` if
 ///   the path is too long for the available space.
 /// - **Center**: git branch name prefixed with a branch icon ( ).
-/// - **Right**: wall clock in `HH:MM` format.
+/// - **Right**: wall clock in `HH:MM` format, optionally preceded by a
+///   connection indicator when the AI backend is degraded or offline.
 #[derive(Clone, Debug)]
 pub struct StatusBar {
     cwd: String,
     branch: String,
     time: String,
     activity: Option<String>,
+    connection: Option<ConnectionIndicator>,
 }
 
 impl StatusBar {
@@ -147,6 +188,7 @@ impl StatusBar {
             branch: String::from("main"),
             time: String::from("00:00"),
             activity: None,
+            connection: None,
         }
     }
 
@@ -174,6 +216,18 @@ impl StatusBar {
     /// Take and clear the current activity message.
     pub fn take_activity(&mut self) -> Option<String> {
         self.activity.take()
+    }
+
+    /// Update the AI backend connection indicator.
+    ///
+    /// Pass `None` to clear the indicator (equivalent to `Connected`).
+    pub fn set_connection(&mut self, indicator: Option<ConnectionIndicator>) {
+        self.connection = indicator;
+    }
+
+    /// The current connection indicator, if any.
+    pub fn connection(&self) -> Option<&ConnectionIndicator> {
+        self.connection.as_ref()
     }
 
     /// Truncate `text` so it fits within `max_chars`, prepending `...` if needed.
@@ -209,7 +263,7 @@ impl Widget for StatusBar {
     }
 
     fn render_text(&self, rect: &Rect) -> Vec<TextSegment> {
-        let mut segments = Vec::with_capacity(3);
+        let mut segments = Vec::with_capacity(4);
         // Padding scales with screen width so content survives CRT barrel
         // distortion at edges. ~1.5% of width handles curvature up to ~0.06.
         let padding = (rect.width * 0.015).max(8.0);
@@ -225,6 +279,22 @@ impl Widget for StatusBar {
             y: text_y,
             color: STATUS_BAR_FG,
         });
+
+        // -- Right-of-center: connection indicator (shown when not Connected) --
+        if let Some(indicator) = &self.connection {
+            let label = indicator.label();
+            if !label.is_empty() {
+                let indicator_width = label.len() as f32 * CHAR_WIDTH;
+                let gap = 8.0;
+                let indicator_x = time_x - indicator_width - gap;
+                segments.push(TextSegment {
+                    text: label,
+                    x: indicator_x,
+                    y: text_y,
+                    color: indicator.color(),
+                });
+            }
+        }
 
         // -- Center: branch with icon --
         let branch_text = format!("\u{E0A0} {}", self.branch);

--- a/crates/phantom/src/headless.rs
+++ b/crates/phantom/src/headless.rs
@@ -505,6 +505,18 @@ impl ActionHandler for HeadlessActionHandler {
     fn agent_quarantined(&mut self, agent_id: phantom_agents::AgentId, denial_count: usize) {
         println!("[BRAIN]: agent {agent_id} quarantined after {denial_count} denials");
     }
+
+    fn pause_agent(&mut self, agent_id: phantom_agents::AgentId, reason: phantom_agents::agent::PauseReason) {
+        println!("[BRAIN]: pausing agent {agent_id} ({reason:?})");
+    }
+
+    fn resume_agent(&mut self, agent_id: phantom_agents::AgentId) {
+        println!("[BRAIN]: resuming agent {agent_id}");
+    }
+
+    fn update_connection_state(&mut self, state: phantom_brain::events::ConnectionState) {
+        println!("[BRAIN]: connection state: {state:?}");
+    }
 }
 
 fn drain_brain(brain: &phantom_brain::brain::BrainHandle) {


### PR DESCRIPTION
## Summary

- `AgentStatus::Paused { reason: PauseReason }` FSM state for mid-task network disconnects
- `UpdateConnectionState`, `PauseAgent`, `ResumeAgent` actions wired through `ActionHandler` trait and `ExecuteAction` dispatch
- `record_conversation_checkpoint()` in `phantom-memory` journal for preserving work-in-progress
- Reconnect retry with jitter; auto-resume on reconnect; switchover to local model if available
- UI: connection state badge (Connected / Degraded / Offline) in agent pane

Rebased onto current main. Closes #321.