### PR TITLE
feat: complete Ollama backend wiring (closes #320)

### DIFF
--- a/crates/phantom-app/src/app.rs
+++ b/crates/phantom-app/src/app.rs
@@ -37,7 +37,7 @@ use phantom_context::ProjectContext;
 use phantom_history::{AgentOutputCapture, HistoryStore};
 use phantom_mcp::{AppCommand, McpListener, spawn_listener};
 use phantom_memory::MemoryStore;
-use phantom_nlp::{ClaudeLlmBackend, LlmBackend};
+use phantom_nlp::{ClaudeLlmBackend, LlmBackend, OllamaLlmBackend};
 use phantom_plugins::PluginRegistry;
 use phantom_scene::node::{NodeKind, RenderLayer};
 use phantom_scene::tree::SceneTree;
@@ -630,6 +630,7 @@ impl App {
             std::sync::mpsc::sync_channel::<NlpTranslateResult>(8);
 
         // Build the LLM backend only when the feature is enabled and the key is present.
+        // Priority: ClaudeLlmBackend (cloud) → OllamaLlmBackend (local, if daemon reachable).
         let nlp_backend: Option<std::sync::Arc<dyn LlmBackend + Send + Sync>> =
             if config.nlp_llm_enabled {
                 match ClaudeLlmBackend::from_env() {
@@ -638,8 +639,15 @@ impl App {
                         Some(std::sync::Arc::new(backend))
                     }
                     Err(e) => {
-                        debug!("NLP LLM backend: disabled ({e})");
-                        None
+                        debug!("NLP LLM backend: Claude unavailable ({e}), probing Ollama");
+                        let ollama = OllamaLlmBackend::from_env();
+                        if ollama.is_available() {
+                            info!("NLP LLM backend: OllamaLlmBackend ({})", ollama.model());
+                            Some(std::sync::Arc::new(ollama))
+                        } else {
+                            debug!("NLP LLM backend: disabled (Ollama daemon not reachable)");
+                            None
+                        }
                     }
                 }
             } else {

--- a/crates/phantom-brain/src/claude.rs
+++ b/crates/phantom-brain/src/claude.rs
@@ -42,13 +42,9 @@ pub fn is_available() -> bool {
 /// Generate a response from Claude.
 ///
 /// Returns `(response_text, latency_ms)` on success.
-pub fn generate(
-    model: &str,
-    prompt: &str,
-    max_tokens: u32,
-) -> Result<(String, f32), String> {
-    let api_key = std::env::var("ANTHROPIC_API_KEY")
-        .map_err(|_| "ANTHROPIC_API_KEY not set".to_string())?;
+pub fn generate(model: &str, prompt: &str, max_tokens: u32) -> Result<(String, f32), String> {
+    let api_key =
+        std::env::var("ANTHROPIC_API_KEY").map_err(|_| "ANTHROPIC_API_KEY not set".to_string())?;
 
     let start = std::time::Instant::now();
 
@@ -141,20 +137,17 @@ pub fn build_error_analysis_prompt(
 ///
 /// Blocks until done — the brain thread is dedicated and doesn't share
 /// work with the render loop.
-pub fn investigate(
-    prompt: &str,
-    working_dir: &str,
-    max_rounds: u32,
-) -> Result<String, String> {
-    use phantom_agents::api::{ApiEvent, ClaudeConfig, send_message};
+pub fn investigate(prompt: &str, working_dir: &str, max_rounds: u32) -> Result<String, String> {
     use phantom_agents::agent::{Agent, AgentMessage, AgentTask};
+    use phantom_agents::api::{ApiEvent, ClaudeConfig, send_message};
     use phantom_agents::role::AgentRole;
     use phantom_agents::tools::{available_tools, execute_tool};
 
-    let config = ClaudeConfig::from_env()
-        .ok_or("ANTHROPIC_API_KEY not set")?;
+    let config = ClaudeConfig::from_env().ok_or("ANTHROPIC_API_KEY not set")?;
 
-    let task = AgentTask::FreeForm { prompt: prompt.to_string() };
+    let task = AgentTask::FreeForm {
+        prompt: prompt.to_string(),
+    };
     let mut agent = Agent::new(0, task);
     let sys = agent.system_prompt();
     agent.push_message(AgentMessage::System(sys));

--- a/crates/phantom-brain/src/curriculum.rs
+++ b/crates/phantom-brain/src/curriculum.rs
@@ -49,10 +49,10 @@ pub struct WarmUpGate {
 impl Default for WarmUpGate {
     fn default() -> Self {
         Self {
-            git_context: 0,     // always available
-            memory_context: 3,  // after 3 tasks
-            failed_context: 5,  // after 5 tasks
-            skill_context: 8,   // after 8 tasks
+            git_context: 0,    // always available
+            memory_context: 3, // after 3 tasks
+            failed_context: 5, // after 5 tasks
+            skill_context: 8,  // after 8 tasks
         }
     }
 }
@@ -180,9 +180,15 @@ impl CurriculumGenerator {
         // -- Project commands --
         let cmds = &context.commands;
         let mut cmd_parts = Vec::new();
-        if let Some(ref b) = cmds.build { cmd_parts.push(format!("build: {b}")); }
-        if let Some(ref t) = cmds.test { cmd_parts.push(format!("test: {t}")); }
-        if let Some(ref l) = cmds.lint { cmd_parts.push(format!("lint: {l}")); }
+        if let Some(ref b) = cmds.build {
+            cmd_parts.push(format!("build: {b}"));
+        }
+        if let Some(ref t) = cmds.test {
+            cmd_parts.push(format!("test: {t}"));
+        }
+        if let Some(ref l) = cmds.lint {
+            cmd_parts.push(format!("lint: {l}"));
+        }
         if !cmd_parts.is_empty() {
             sections.push(format!("Commands: {}", cmd_parts.join(", ")));
         }
@@ -197,7 +203,8 @@ impl CurriculumGenerator {
 
         // -- Completed tasks --
         if !self.completed_tasks.is_empty() {
-            let recent: Vec<&str> = self.completed_tasks
+            let recent: Vec<&str> = self
+                .completed_tasks
                 .iter()
                 .rev()
                 .take(10)
@@ -206,13 +213,18 @@ impl CurriculumGenerator {
             sections.push(format!(
                 "Completed tasks (recent {}):\n{}",
                 recent.len(),
-                recent.iter().map(|t| format!("  - {t}")).collect::<Vec<_>>().join("\n")
+                recent
+                    .iter()
+                    .map(|t| format!("  - {t}"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
             ));
         }
 
         // -- Failed tasks (gated) --
         if progress >= self.warm_up.failed_context && !self.failed_tasks.is_empty() {
-            let recent_fails: Vec<&str> = self.failed_tasks
+            let recent_fails: Vec<&str> = self
+                .failed_tasks
                 .iter()
                 .rev()
                 .take(5)
@@ -220,7 +232,11 @@ impl CurriculumGenerator {
                 .collect();
             sections.push(format!(
                 "Failed tasks (avoid similar):\n{}",
-                recent_fails.iter().map(|t| format!("  - {t}")).collect::<Vec<_>>().join("\n")
+                recent_fails
+                    .iter()
+                    .map(|t| format!("  - {t}"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
             ));
         }
 
@@ -229,10 +245,7 @@ impl CurriculumGenerator {
             let skill_names = skill_store.list_skill_names();
             if !skill_names.is_empty() {
                 let display: Vec<&str> = skill_names.iter().take(10).map(|s| s.as_str()).collect();
-                sections.push(format!(
-                    "Known skills: {}",
-                    display.join(", ")
-                ));
+                sections.push(format!("Known skills: {}", display.join(", ")));
             }
         }
 
@@ -318,14 +331,19 @@ impl CurriculumGenerator {
 
         // Ordered list of bootstrap tasks -- propose the first one not yet completed.
         let bootstrap_sequence: Vec<(&str, &str)> = vec![
-            ("Detect project structure and record conventions to memory",
-             "First contact: learn the project layout"),
-            ("Run the build command and verify it compiles cleanly",
-             "Verify the project builds"),
-            ("Run the test suite and summarize results",
-             "Verify tests pass"),
-            ("Check for common linting issues",
-             "Code quality baseline"),
+            (
+                "Detect project structure and record conventions to memory",
+                "First contact: learn the project layout",
+            ),
+            (
+                "Run the build command and verify it compiles cleanly",
+                "Verify the project builds",
+            ),
+            (
+                "Run the test suite and summarize results",
+                "Verify tests pass",
+            ),
+            ("Check for common linting issues", "Code quality baseline"),
         ];
 
         for (task, reasoning) in bootstrap_sequence {
@@ -431,7 +449,10 @@ mod tests {
         let mut curriculum = CurriculumGenerator::new();
         curriculum.record_success("run tests");
         curriculum.record_failure("run tests");
-        assert!(curriculum.failed_tasks.is_empty(), "should not add completed task to failures");
+        assert!(
+            curriculum.failed_tasks.is_empty(),
+            "should not add completed task to failures"
+        );
     }
 
     #[test]
@@ -483,13 +504,21 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut memory = phantom_memory::MemoryStore::open_in("/tmp/test", dir.path()).unwrap();
         memory
-            .set("test_key", "test_value", phantom_memory::MemoryCategory::Convention, phantom_memory::MemorySource::Auto)
+            .set(
+                "test_key",
+                "test_value",
+                phantom_memory::MemoryCategory::Convention,
+                phantom_memory::MemorySource::Auto,
+            )
             .unwrap();
         let skill_store = SkillStore::new();
 
         // At progress 0, memory should NOT be included (gate = 3).
         let prompt = curriculum.build_prompt(&ctx, &memory, &skill_store);
-        assert!(!prompt.contains("test_key"), "memory should be gated at progress 0");
+        assert!(
+            !prompt.contains("test_key"),
+            "memory should be gated at progress 0"
+        );
     }
 }
 
@@ -582,7 +611,12 @@ mod hook_tests {
     use super::*;
 
     fn outcome(success: bool) -> TaskOutcome {
-        TaskOutcome { task_id: 0, difficulty: 1, success, duration_ms: 100 }
+        TaskOutcome {
+            task_id: 0,
+            difficulty: 1,
+            success,
+            duration_ms: 100,
+        }
     }
 
     #[test]

--- a/crates/phantom-brain/src/curves.rs
+++ b/crates/phantom-brain/src/curves.rs
@@ -91,9 +91,7 @@ pub enum ResponseCurve {
     /// `score = value` regardless of input.
     ///
     /// Use for: baseline behaviors (DA:I's "follow the leader" at score 0).
-    Constant {
-        value: f32,
-    },
+    Constant { value: f32 },
 }
 
 impl ResponseCurve {
@@ -101,18 +99,34 @@ impl ResponseCurve {
     pub fn evaluate(&self, input: f32) -> f32 {
         let input = input.clamp(0.0, 1.0);
         match self {
-            Self::Linear { slope, intercept, max_score } => {
-                (slope * input + intercept).clamp(0.0, *max_score)
-            }
-            Self::Polynomial { exponent, coefficient, max_score } => {
-                (coefficient * input.powf(*exponent)).clamp(0.0, *max_score)
-            }
-            Self::Logistic { midpoint, steepness, max_score } => {
+            Self::Linear {
+                slope,
+                intercept,
+                max_score,
+            } => (slope * input + intercept).clamp(0.0, *max_score),
+            Self::Polynomial {
+                exponent,
+                coefficient,
+                max_score,
+            } => (coefficient * input.powf(*exponent)).clamp(0.0, *max_score),
+            Self::Logistic {
+                midpoint,
+                steepness,
+                max_score,
+            } => {
                 let exp = (-steepness * (input - midpoint)).exp();
                 (max_score / (1.0 + exp)).clamp(0.0, *max_score)
             }
-            Self::Step { threshold, on_value, off_value } => {
-                if input >= *threshold { *on_value } else { *off_value }
+            Self::Step {
+                threshold,
+                on_value,
+                off_value,
+            } => {
+                if input >= *threshold {
+                    *on_value
+                } else {
+                    *off_value
+                }
             }
             Self::Constant { value } => *value,
         }
@@ -363,11 +377,7 @@ impl Behavior {
         let base = self.class.base_score();
         let max_add = self.class.dynamic_range();
 
-        let consideration_total: f32 = self
-            .considerations
-            .iter()
-            .map(|c| c.evaluate(ctx))
-            .sum();
+        let consideration_total: f32 = self.considerations.iter().map(|c| c.evaluate(ctx)).sum();
 
         // Clamp the consideration contribution to the class dynamic range.
         base + consideration_total.min(max_add)
@@ -602,7 +612,7 @@ pub fn build_default_behaviors() -> Vec<Behavior> {
                     name: "chattiness_penalty".into(),
                     filter: None,
                     input_fn: Box::new(|ctx| ctx.chattiness / 0.5), // normalize to [0, 1]
-                    curve: ResponseCurve::linear(9.0), // up to 9 more points
+                    curve: ResponseCurve::linear(9.0),              // up to 9 more points
                 },
             ],
         },
@@ -654,7 +664,9 @@ pub fn build_default_behaviors() -> Vec<Behavior> {
         Behavior {
             id: "explain_error".into(),
             class: ActionClass::Support,
-            viable: Some(Box::new(|ctx| ctx.has_errors && ctx.idle_secs > 5.0 && !ctx.in_repl)),
+            viable: Some(Box::new(|ctx| {
+                ctx.has_errors && ctx.idle_secs > 5.0 && !ctx.in_repl
+            })),
             considerations: vec![
                 // User must have been idle after an error.
                 Consideration {
@@ -677,18 +689,18 @@ pub fn build_default_behaviors() -> Vec<Behavior> {
         Behavior {
             id: "offer_help".into(),
             class: ActionClass::Support,
-            viable: Some(Box::new(|ctx| !ctx.has_errors && ctx.idle_secs > 30.0 && !ctx.in_repl)),
-            considerations: vec![
-                Consideration {
-                    name: "long_idle_no_errors".into(),
-                    filter: Some(Filter {
-                        name: "idle_gt_30_no_errors".into(),
-                        gate: Box::new(|ctx| !ctx.has_errors && ctx.idle_secs > 30.0 && !ctx.in_repl),
-                    }),
-                    input_fn: Box::new(|ctx| ((ctx.idle_secs - 30.0) / 60.0).clamp(0.0, 1.0)),
-                    curve: ResponseCurve::linear(10.0),
-                },
-            ],
+            viable: Some(Box::new(|ctx| {
+                !ctx.has_errors && ctx.idle_secs > 30.0 && !ctx.in_repl
+            })),
+            considerations: vec![Consideration {
+                name: "long_idle_no_errors".into(),
+                filter: Some(Filter {
+                    name: "idle_gt_30_no_errors".into(),
+                    gate: Box::new(|ctx| !ctx.has_errors && ctx.idle_secs > 30.0 && !ctx.in_repl),
+                }),
+                input_fn: Box::new(|ctx| ((ctx.idle_secs - 30.0) / 60.0).clamp(0.0, 1.0)),
+                curve: ResponseCurve::linear(10.0),
+            }],
         },
         // -- Update memory (Proactive class: 20-40) --
         // Viable only when a new pattern was detected.
@@ -696,17 +708,15 @@ pub fn build_default_behaviors() -> Vec<Behavior> {
             id: "update_memory".into(),
             class: ActionClass::Proactive,
             viable: Some(Box::new(|ctx| ctx.new_pattern_detected)),
-            considerations: vec![
-                Consideration {
-                    name: "new_pattern".into(),
-                    filter: Some(Filter {
-                        name: "new_pattern_detected".into(),
-                        gate: Box::new(|ctx| ctx.new_pattern_detected),
-                    }),
-                    input_fn: Box::new(|_| 1.0),
-                    curve: ResponseCurve::Constant { value: 15.0 },
-                },
-            ],
+            considerations: vec![Consideration {
+                name: "new_pattern".into(),
+                filter: Some(Filter {
+                    name: "new_pattern_detected".into(),
+                    gate: Box::new(|ctx| ctx.new_pattern_detected),
+                }),
+                input_fn: Box::new(|_| 1.0),
+                curve: ResponseCurve::Constant { value: 15.0 },
+            }],
         },
         // -- Watch build (Proactive class: 20-40) --
         // Viable only while an active process is running.
@@ -714,17 +724,15 @@ pub fn build_default_behaviors() -> Vec<Behavior> {
             id: "watch_build".into(),
             class: ActionClass::Proactive,
             viable: Some(Box::new(|ctx| ctx.has_active_process)),
-            considerations: vec![
-                Consideration {
-                    name: "active_process".into(),
-                    filter: Some(Filter {
-                        name: "has_active_process".into(),
-                        gate: Box::new(|ctx| ctx.has_active_process),
-                    }),
-                    input_fn: Box::new(|_| 1.0),
-                    curve: ResponseCurve::Constant { value: 10.0 },
-                },
-            ],
+            considerations: vec![Consideration {
+                name: "active_process".into(),
+                filter: Some(Filter {
+                    name: "has_active_process".into(),
+                    gate: Box::new(|ctx| ctx.has_active_process),
+                }),
+                input_fn: Box::new(|_| 1.0),
+                curve: ResponseCurve::Constant { value: 10.0 },
+            }],
         },
         // -- Notification: agent complete (Reaction class: 50-70) --
         // Viable only when an agent just completed.
@@ -732,17 +740,15 @@ pub fn build_default_behaviors() -> Vec<Behavior> {
             id: "notify_agent_complete".into(),
             class: ActionClass::Reaction,
             viable: Some(Box::new(|ctx| ctx.agent_just_completed)),
-            considerations: vec![
-                Consideration {
-                    name: "agent_completed".into(),
-                    filter: Some(Filter {
-                        name: "agent_just_completed".into(),
-                        gate: Box::new(|ctx| ctx.agent_just_completed),
-                    }),
-                    input_fn: Box::new(|_| 1.0),
-                    curve: ResponseCurve::Constant { value: 15.0 },
-                },
-            ],
+            considerations: vec![Consideration {
+                name: "agent_completed".into(),
+                filter: Some(Filter {
+                    name: "agent_just_completed".into(),
+                    gate: Box::new(|ctx| ctx.agent_just_completed),
+                }),
+                input_fn: Box::new(|_| 1.0),
+                curve: ResponseCurve::Constant { value: 15.0 },
+            }],
         },
         // -- Notification: file/git change (Proactive class: 20-40) --
         // Viable only when a file or git change was detected this frame.
@@ -750,17 +756,15 @@ pub fn build_default_behaviors() -> Vec<Behavior> {
             id: "notify_change".into(),
             class: ActionClass::Proactive,
             viable: Some(Box::new(|ctx| ctx.file_or_git_changed)),
-            considerations: vec![
-                Consideration {
-                    name: "file_or_git_changed".into(),
-                    filter: Some(Filter {
-                        name: "change_detected".into(),
-                        gate: Box::new(|ctx| ctx.file_or_git_changed),
-                    }),
-                    input_fn: Box::new(|_| 1.0),
-                    curve: ResponseCurve::Constant { value: 8.0 },
-                },
-            ],
+            considerations: vec![Consideration {
+                name: "file_or_git_changed".into(),
+                filter: Some(Filter {
+                    name: "change_detected".into(),
+                    gate: Box::new(|ctx| ctx.file_or_git_changed),
+                }),
+                input_fn: Box::new(|_| 1.0),
+                curve: ResponseCurve::Constant { value: 8.0 },
+            }],
         },
     ]
 }
@@ -868,7 +872,9 @@ pub struct ExponentialCurve {
 impl ExponentialCurve {
     /// Create a power-law curve with exponent `k`.
     pub fn new(k: f32) -> Self {
-        Self { k: k.max(f32::EPSILON) }
+        Self {
+            k: k.max(f32::EPSILON),
+        }
     }
 
     /// Quadratic ramp (`k = 2`): accelerating urgency.
@@ -922,17 +928,26 @@ pub struct LogisticCurve {
 impl LogisticCurve {
     /// Create a logistic curve with custom midpoint and steepness.
     pub fn new(midpoint: f32, steepness: f32) -> Self {
-        Self { midpoint, steepness }
+        Self {
+            midpoint,
+            steepness,
+        }
     }
 
     /// Standard sigmoid centered at 0.5 with moderate steepness (10).
     pub fn standard() -> Self {
-        Self { midpoint: 0.5, steepness: 10.0 }
+        Self {
+            midpoint: 0.5,
+            steepness: 10.0,
+        }
     }
 
     /// Sharp transition (steepness = 20) centered at 0.5.
     pub fn sharp() -> Self {
-        Self { midpoint: 0.5, steepness: 20.0 }
+        Self {
+            midpoint: 0.5,
+            steepness: 20.0,
+        }
     }
 }
 
@@ -975,24 +990,41 @@ pub struct StepCurve {
 impl StepCurve {
     /// Create a step with custom threshold and values.
     pub fn new(threshold: f32, on_value: f32, off_value: f32) -> Self {
-        Self { threshold, on_value: on_value.clamp(0.0, 1.0), off_value: off_value.clamp(0.0, 1.0) }
+        Self {
+            threshold,
+            on_value: on_value.clamp(0.0, 1.0),
+            off_value: off_value.clamp(0.0, 1.0),
+        }
     }
 
     /// Binary 0/1 step that activates at `threshold`.
     pub fn on_at(threshold: f32) -> Self {
-        Self { threshold, on_value: 1.0, off_value: 0.0 }
+        Self {
+            threshold,
+            on_value: 1.0,
+            off_value: 0.0,
+        }
     }
 
     /// Always-on constant (threshold = 0).
     pub fn always_on() -> Self {
-        Self { threshold: 0.0, on_value: 1.0, off_value: 1.0 }
+        Self {
+            threshold: 0.0,
+            on_value: 1.0,
+            off_value: 1.0,
+        }
     }
 }
 
 impl UtilityCurve for StepCurve {
     fn score(&self, x: f32) -> f32 {
         let x = x.clamp(0.0, 1.0);
-        if x >= self.threshold { self.on_value } else { self.off_value }.clamp(0.0, 1.0)
+        if x >= self.threshold {
+            self.on_value
+        } else {
+            self.off_value
+        }
+        .clamp(0.0, 1.0)
     }
 }
 
@@ -1021,7 +1053,9 @@ pub struct InvertedCurve {
 impl InvertedCurve {
     /// Wrap `curve` and invert its output.
     pub fn of<C: UtilityCurve + 'static>(curve: C) -> Self {
-        Self { inner: Box::new(curve) }
+        Self {
+            inner: Box::new(curve),
+        }
     }
 }
 
@@ -1294,14 +1328,12 @@ mod tests {
             id: "test".into(),
             class: ActionClass::Proactive, // base=20, range=20, max=40
             viable: None,
-            considerations: vec![
-                Consideration {
-                    name: "huge".into(),
-                    filter: None,
-                    input_fn: Box::new(|_| 1.0),
-                    curve: ResponseCurve::Constant { value: 100.0 }, // way over range
-                },
-            ],
+            considerations: vec![Consideration {
+                name: "huge".into(),
+                filter: None,
+                input_fn: Box::new(|_| 1.0),
+                curve: ResponseCurve::Constant { value: 100.0 }, // way over range
+            }],
         };
         let ctx = ScoringContext::default();
         // Clamped to 20 + 20 = 40.
@@ -1555,7 +1587,10 @@ mod tests {
         let falling = LinearCurve::falling();
         for x in [0.0f32, 0.25, 0.5, 0.75, 1.0] {
             let sum = rising.score(x) + falling.score(x);
-            assert!((sum - 1.0).abs() < 1e-6, "rising + falling should sum to 1 at x={x}, got {sum}");
+            assert!(
+                (sum - 1.0).abs() < 1e-6,
+                "rising + falling should sum to 1 at x={x}, got {sum}"
+            );
         }
     }
 
@@ -1589,7 +1624,10 @@ mod tests {
     fn exponential_quadratic_at_half_is_below_linear() {
         let c = ExponentialCurve::quadratic();
         // x^2 at 0.5 = 0.25, which is less than linear 0.5
-        assert!(c.score(0.5) < 0.5, "quadratic should score below linear midpoint");
+        assert!(
+            c.score(0.5) < 0.5,
+            "quadratic should score below linear midpoint"
+        );
         assert!((c.score(0.5) - 0.25).abs() < 1e-6);
     }
 
@@ -1597,7 +1635,10 @@ mod tests {
     fn exponential_sqrt_at_half_is_above_linear() {
         let c = ExponentialCurve::sqrt();
         // sqrt(0.5) ≈ 0.707 > 0.5
-        assert!(c.score(0.5) > 0.5, "sqrt should score above linear midpoint");
+        assert!(
+            c.score(0.5) > 0.5,
+            "sqrt should score above linear midpoint"
+        );
     }
 
     #[test]
@@ -1618,20 +1659,32 @@ mod tests {
     #[test]
     fn logistic_at_zero_is_low() {
         let c = LogisticCurve::standard();
-        assert!(c.score(0.0) < 0.1, "logistic at x=0 should be < 0.1, got {}", c.score(0.0));
+        assert!(
+            c.score(0.0) < 0.1,
+            "logistic at x=0 should be < 0.1, got {}",
+            c.score(0.0)
+        );
     }
 
     #[test]
     fn logistic_at_half_is_midpoint() {
         let c = LogisticCurve::standard();
         // Sigmoid(0) = 0.5 exactly.
-        assert!((c.score(0.5) - 0.5).abs() < 1e-5, "logistic at midpoint should be 0.5, got {}", c.score(0.5));
+        assert!(
+            (c.score(0.5) - 0.5).abs() < 1e-5,
+            "logistic at midpoint should be 0.5, got {}",
+            c.score(0.5)
+        );
     }
 
     #[test]
     fn logistic_at_one_is_high() {
         let c = LogisticCurve::standard();
-        assert!(c.score(1.0) > 0.9, "logistic at x=1 should be > 0.9, got {}", c.score(1.0));
+        assert!(
+            c.score(1.0) > 0.9,
+            "logistic at x=1 should be > 0.9, got {}",
+            c.score(1.0)
+        );
     }
 
     #[test]
@@ -1643,7 +1696,8 @@ mod tests {
             assert!(
                 c.score(hi) > c.score(lo),
                 "LogisticCurve should be strictly increasing: score({hi})={} < score({lo})={}",
-                c.score(hi), c.score(lo)
+                c.score(hi),
+                c.score(lo)
             );
         }
     }
@@ -1653,7 +1707,10 @@ mod tests {
         let c = LogisticCurve::new(0.5, 50.0); // very steep
         for x in [0.0f32, 0.499, 0.5, 0.501, 1.0] {
             let s = c.score(x);
-            assert!(s >= 0.0 && s <= 1.0, "logistic output {s} out of [0,1] at x={x}");
+            assert!(
+                s >= 0.0 && s <= 1.0,
+                "logistic output {s} out of [0,1] at x={x}"
+            );
         }
     }
 
@@ -1711,7 +1768,10 @@ mod tests {
         let c = InvertedCurve::of(LogisticCurve::sharp());
         for x in [0.0f32, 0.25, 0.5, 0.75, 1.0] {
             let s = c.score(x);
-            assert!(s >= 0.0 && s <= 1.0, "inverted output {s} out of [0,1] at x={x}");
+            assert!(
+                s >= 0.0 && s <= 1.0,
+                "inverted output {s} out of [0,1] at x={x}"
+            );
         }
     }
 
@@ -1722,7 +1782,8 @@ mod tests {
         let c = CompositeCurve::build(vec![
             (Box::new(LinearCurve::rising()), 0.5),
             (Box::new(LogisticCurve::standard()), 0.5),
-        ]).unwrap();
+        ])
+        .unwrap();
         // Both curves score ~0 at x=0; weighted avg is also ~0.
         assert!(c.score(0.0) < 0.1);
     }
@@ -1730,9 +1791,10 @@ mod tests {
     #[test]
     fn composite_at_half() {
         let c = CompositeCurve::build(vec![
-            (Box::new(LinearCurve::rising()), 1.0),  // 0.5
-            (Box::new(LinearCurve::rising()), 1.0),  // 0.5
-        ]).unwrap();
+            (Box::new(LinearCurve::rising()), 1.0), // 0.5
+            (Box::new(LinearCurve::rising()), 1.0), // 0.5
+        ])
+        .unwrap();
         assert!((c.score(0.5) - 0.5).abs() < 1e-6);
     }
 
@@ -1741,7 +1803,8 @@ mod tests {
         let c = CompositeCurve::build(vec![
             (Box::new(LinearCurve::rising()), 0.6),
             (Box::new(ExponentialCurve::quadratic()), 0.4),
-        ]).unwrap();
+        ])
+        .unwrap();
         // Both score 1.0 at x=1; composite should also be 1.0.
         assert!((c.score(1.0) - 1.0).abs() < 1e-6);
     }
@@ -1750,9 +1813,12 @@ mod tests {
     fn composite_weights_sum_guard_rejects_negative() {
         let result = CompositeCurve::build(vec![
             (Box::new(LinearCurve::rising()), 0.6),
-            (Box::new(LinearCurve::rising()), -0.1),  // negative weight
+            (Box::new(LinearCurve::rising()), -0.1), // negative weight
         ]);
-        assert!(result.is_err(), "CompositeCurve::build should reject negative weights");
+        assert!(
+            result.is_err(),
+            "CompositeCurve::build should reject negative weights"
+        );
     }
 
     #[test]
@@ -1761,10 +1827,14 @@ mod tests {
             (Box::new(LinearCurve::rising()), 0.3),
             (Box::new(LogisticCurve::standard()), 0.4),
             (Box::new(ExponentialCurve::sqrt()), 0.3),
-        ]).unwrap();
+        ])
+        .unwrap();
         for x in [0.0f32, 0.1, 0.25, 0.5, 0.75, 0.9, 1.0] {
             let s = c.score(x);
-            assert!(s >= 0.0 && s <= 1.0, "composite output {s} out of [0,1] at x={x}");
+            assert!(
+                s >= 0.0 && s <= 1.0,
+                "composite output {s} out of [0,1] at x={x}"
+            );
         }
     }
 
@@ -1775,7 +1845,8 @@ mod tests {
         let c = CompositeCurve::build(vec![
             (Box::new(StepCurve::always_on()), 0.9),
             (Box::new(LinearCurve::rising()), 0.1),
-        ]).unwrap();
+        ])
+        .unwrap();
         let score = c.score(0.5);
         // weighted avg = (0.9 * 1.0 + 0.1 * 0.5) / 1.0 = 0.95
         assert!((score - 0.95).abs() < 1e-6, "expected 0.95, got {score}");
@@ -1792,7 +1863,8 @@ mod tests {
         let c = CompositeCurve::build(vec![
             (Box::new(LinearCurve::rising()), 0.5),
             (Box::new(ExponentialCurve::quadratic()), 0.5),
-        ]).unwrap();
+        ])
+        .unwrap();
         let samples = [0.0, 0.1, 0.3, 0.5, 0.7, 0.9, 1.0];
         for window in samples.windows(2) {
             let (lo, hi) = (window[0], window[1]);

--- a/crates/phantom-brain/src/decompose.rs
+++ b/crates/phantom-brain/src/decompose.rs
@@ -76,7 +76,12 @@ impl DecompositionStep {
 
     // -- Constructors (crate-private so tests can build them) ----------------
 
-    fn new(description: impl Into<String>, tool: Option<String>, priority: f32, cost_ms: u32) -> Self {
+    fn new(
+        description: impl Into<String>,
+        tool: Option<String>,
+        priority: f32,
+        cost_ms: u32,
+    ) -> Self {
         Self {
             description: description.into(),
             tool,
@@ -215,9 +220,16 @@ impl GoalDecomposer {
             .collect();
 
         // Sort descending by priority (highest first).
-        steps.sort_by(|a, b| b.priority.partial_cmp(&a.priority).unwrap_or(std::cmp::Ordering::Equal));
+        steps.sort_by(|a, b| {
+            b.priority
+                .partial_cmp(&a.priority)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
 
-        let estimated_total_ms = steps.iter().map(|s| s.cost_ms).fold(0u32, u32::saturating_add);
+        let estimated_total_ms = steps
+            .iter()
+            .map(|s| s.cost_ms)
+            .fold(0u32, u32::saturating_add);
 
         DecompositionResult {
             goal: goal_str.to_string(),
@@ -239,15 +251,54 @@ impl GoalDecomposer {
 
         // Keyword → category mapping (ordered from most specific to least).
         let keywords: &[(&[&str], SubGoalCategory)] = &[
-            (&["deploy", "release", "ship", "publish", "push"], SubGoalCategory::Deploy),
-            (&["document", "docs", "readme", "comment"], SubGoalCategory::Document),
-            (&["refactor", "restructure", "reorganize", "cleanup", "clean up"], SubGoalCategory::Refactor),
+            (
+                &["deploy", "release", "ship", "publish", "push"],
+                SubGoalCategory::Deploy,
+            ),
+            (
+                &["document", "docs", "readme", "comment"],
+                SubGoalCategory::Document,
+            ),
+            (
+                &[
+                    "refactor",
+                    "restructure",
+                    "reorganize",
+                    "cleanup",
+                    "clean up",
+                ],
+                SubGoalCategory::Refactor,
+            ),
             (&["lint", "clippy", "fmt", "format"], SubGoalCategory::Lint),
-            (&["fix", "repair", "resolve", "patch", "debug", "correct"], SubGoalCategory::Fix),
-            (&["test", "tests", "spec", "coverage", "check"], SubGoalCategory::Test),
-            (&["build", "compile", "cargo", "make", "assemble"], SubGoalCategory::Build),
-            (&["investigate", "explore", "research", "analyse", "analyze", "understand", "review", "look"], SubGoalCategory::Investigate),
-            (&["implement", "add", "create", "write", "new", "feature"], SubGoalCategory::Generic),
+            (
+                &["fix", "repair", "resolve", "patch", "debug", "correct"],
+                SubGoalCategory::Fix,
+            ),
+            (
+                &["test", "tests", "spec", "coverage", "check"],
+                SubGoalCategory::Test,
+            ),
+            (
+                &["build", "compile", "cargo", "make", "assemble"],
+                SubGoalCategory::Build,
+            ),
+            (
+                &[
+                    "investigate",
+                    "explore",
+                    "research",
+                    "analyse",
+                    "analyze",
+                    "understand",
+                    "review",
+                    "look",
+                ],
+                SubGoalCategory::Investigate,
+            ),
+            (
+                &["implement", "add", "create", "write", "new", "feature"],
+                SubGoalCategory::Generic,
+            ),
         ];
 
         for (kws, category) in keywords {
@@ -327,14 +378,12 @@ impl GoalDecomposer {
             }
 
             SubGoalCategory::Build => {
-                vec![
-                    DecompositionStep::new(
-                        "run build command and collect compiler output",
-                        Some("RunCommand".into()),
-                        0.80,
-                        15_000,
-                    ),
-                ]
+                vec![DecompositionStep::new(
+                    "run build command and collect compiler output",
+                    Some("RunCommand".into()),
+                    0.80,
+                    15_000,
+                )]
             }
 
             SubGoalCategory::Lint => {
@@ -549,7 +598,9 @@ mod tests {
     }
 
     fn errors_world() -> OrchestratorWorldState {
-        OrchestratorWorldState::builder().errors_detected(true).build()
+        OrchestratorWorldState::builder()
+            .errors_detected(true)
+            .build()
     }
 
     // =======================================================================
@@ -563,8 +614,14 @@ mod tests {
 
         let result = decomposer.decompose("", &world);
 
-        assert!(result.steps().is_empty(), "empty goal must produce no steps");
-        assert!(!result.is_achievable(), "empty result must not be achievable");
+        assert!(
+            result.steps().is_empty(),
+            "empty goal must produce no steps"
+        );
+        assert!(
+            !result.is_achievable(),
+            "empty result must not be achievable"
+        );
         assert_eq!(result.estimated_total_ms(), 0);
     }
 
@@ -591,7 +648,10 @@ mod tests {
 
         let result = decomposer.decompose("fix tests", &world);
 
-        assert!(result.is_achievable(), "fix tests must produce at least one step");
+        assert!(
+            result.is_achievable(),
+            "fix tests must produce at least one step"
+        );
         // Should produce at minimum a Fix sub-goal and a Test sub-goal.
         assert!(
             result.steps().len() >= 2,
@@ -639,7 +699,10 @@ mod tests {
             .fold(0, u32::saturating_add);
 
         assert_eq!(result.estimated_total_ms(), manual_sum);
-        assert!(result.estimated_total_ms() > 0, "build goal must have non-zero cost");
+        assert!(
+            result.estimated_total_ms() > 0,
+            "build goal must have non-zero cost"
+        );
     }
 
     // =======================================================================
@@ -695,14 +758,17 @@ mod tests {
 
         assert!(result.is_achievable(), "fallback must still be achievable");
         // At least one step should mention investigate / context.
-        let has_investigate = result
-            .steps()
-            .iter()
-            .any(|s| s.description().contains("gather context") || s.description().contains("investigate"));
+        let has_investigate = result.steps().iter().any(|s| {
+            s.description().contains("gather context") || s.description().contains("investigate")
+        });
         assert!(
             has_investigate,
             "fallback goal should produce an investigate step; got: {:?}",
-            result.steps().iter().map(|s| s.description()).collect::<Vec<_>>()
+            result
+                .steps()
+                .iter()
+                .map(|s| s.description())
+                .collect::<Vec<_>>()
         );
     }
 
@@ -749,9 +815,12 @@ mod tests {
     #[test]
     fn decompose_and_replan_returns_none_when_steady() {
         let mut orch = Orchestrator::new("fix the build");
-        orch.set_plan(vec![
-            PlanStep::new("step 1", phantom_agents::AgentTask::FreeForm { prompt: "s1".into() }),
-        ]);
+        orch.set_plan(vec![PlanStep::new(
+            "step 1",
+            phantom_agents::AgentTask::FreeForm {
+                prompt: "s1".into(),
+            },
+        )]);
         let world = OrchestratorWorldState::default(); // no triggers
 
         let decomposer = GoalDecomposer::new();
@@ -767,19 +836,30 @@ mod tests {
     #[test]
     fn decompose_and_replan_installs_plan_on_trigger() {
         let mut orch = Orchestrator::new("fix the failing tests");
-        orch.set_plan(vec![
-            PlanStep::new("old step", phantom_agents::AgentTask::FreeForm { prompt: "old".into() }),
-        ]);
+        orch.set_plan(vec![PlanStep::new(
+            "old step",
+            phantom_agents::AgentTask::FreeForm {
+                prompt: "old".into(),
+            },
+        )]);
 
         // Trigger a replan via errors_detected.
-        let world = OrchestratorWorldState::builder().errors_detected(true).build();
+        let world = OrchestratorWorldState::builder()
+            .errors_detected(true)
+            .build();
         let decomposer = GoalDecomposer::new();
 
         let result = orch.decompose_and_replan(&world, &decomposer);
 
-        assert!(result.is_some(), "errors_detected trigger → should produce a result");
+        assert!(
+            result.is_some(),
+            "errors_detected trigger → should produce a result"
+        );
         let dr = result.unwrap();
-        assert!(dr.is_achievable(), "decomposition should produce at least one step");
+        assert!(
+            dr.is_achievable(),
+            "decomposition should produce at least one step"
+        );
 
         // The ledger plan should have been replaced.
         let new_plan = &orch.ledger().plan;
@@ -789,10 +869,7 @@ mod tests {
         );
         // Old step should be gone.
         let still_has_old = new_plan.iter().any(|s| s.description == "old step");
-        assert!(
-            !still_has_old,
-            "old step should be replaced after replan"
-        );
+        assert!(!still_has_old, "old step should be replaced after replan");
     }
 
     // =======================================================================
@@ -856,7 +933,10 @@ mod tests {
     fn multi_keyword_goal_produces_multi_subgoal_steps() {
         let decomposer = GoalDecomposer::new();
         // "build" + "test" + "fix" → at least 3 sub-goals → many steps.
-        let result = decomposer.decompose("build the project, fix errors, and run tests", &default_world());
+        let result = decomposer.decompose(
+            "build the project, fix errors, and run tests",
+            &default_world(),
+        );
 
         // Expect steps from at least 3 different descriptions.
         assert!(
@@ -874,7 +954,9 @@ mod tests {
     #[test]
     fn replan_steps_start_as_pending() {
         let mut orch = Orchestrator::new("deploy the service");
-        let world = OrchestratorWorldState::builder().errors_detected(true).build();
+        let world = OrchestratorWorldState::builder()
+            .errors_detected(true)
+            .build();
         let decomposer = GoalDecomposer::new();
 
         orch.decompose_and_replan(&world, &decomposer);

--- a/crates/phantom-brain/src/goals.rs
+++ b/crates/phantom-brain/src/goals.rs
@@ -161,9 +161,7 @@ impl GoalPursuit {
              Perform one task for this objective: {objective}\n"
         );
         if !context.is_empty() {
-            prompt.push_str(&format!(
-                "Previously completed tasks:\n{context}\n"
-            ));
+            prompt.push_str(&format!("Previously completed tasks:\n{context}\n"));
         }
         prompt.push_str(&format!("\nYour task: {}\n", task.name));
         prompt
@@ -206,19 +204,25 @@ pub fn build_task_creation_prompt(
     );
     if !incomplete_tasks.is_empty() {
         let list = incomplete_tasks.join(", ");
-        prompt.push_str(&format!("Incomplete tasks: {list}\n\
-             New tasks must not overlap with incomplete tasks.\n"));
+        prompt.push_str(&format!(
+            "Incomplete tasks: {list}\n\
+             New tasks must not overlap with incomplete tasks.\n"
+        ));
     }
     prompt.push_str(
         "Return new tasks as a numbered list (one per line). \
-         If no new tasks needed, write \"No new tasks.\"\n"
+         If no new tasks needed, write \"No new tasks.\"\n",
     );
     prompt
 }
 
 /// Build the prioritization prompt for the LLM.
 pub fn build_prioritization_prompt(objective: &str, task_names: &[&str]) -> String {
-    let list = task_names.iter().map(|t| format!("- {t}")).collect::<Vec<_>>().join("\n");
+    let list = task_names
+        .iter()
+        .map(|t| format!("- {t}"))
+        .collect::<Vec<_>>()
+        .join("\n");
     format!(
         "Prioritize these tasks for the objective: {objective}\n\n\
          Tasks:\n{list}\n\n\
@@ -233,9 +237,13 @@ pub fn parse_task_list(response: &str) -> Vec<String> {
     let mut tasks = Vec::new();
     for line in response.lines() {
         let trimmed = line.trim();
-        let Some((num_part, name_part)) = trimmed.split_once('.') else { continue };
+        let Some((num_part, name_part)) = trimmed.split_once('.') else {
+            continue;
+        };
         let has_digit = num_part.chars().any(|c| c.is_ascii_digit());
-        if !has_digit { continue; }
+        if !has_digit {
+            continue;
+        }
         let name: String = name_part.trim().to_string();
         if !name.is_empty() && !name.to_lowercase().starts_with("no new task") {
             tasks.push(name);
@@ -313,16 +321,13 @@ impl ReflexionMemory {
 }
 
 /// Build the self-reflection prompt (Reflexion paper, exact pattern).
-pub fn build_reflection_prompt(
-    failed_trajectory: &str,
-    prior_reflections: &[&str],
-) -> String {
+pub fn build_reflection_prompt(failed_trajectory: &str, prior_reflections: &[&str]) -> String {
     let mut prompt = String::from(
         "You will be given the history of a failed task attempt in a terminal environment. \
          Do not summarize the environment. Think about the strategy and path you took. \
          Devise a concise new plan that accounts for your mistake, referencing specific \
          actions you should have taken.\n\n\
-         Failed attempt:\n"
+         Failed attempt:\n",
     );
     prompt.push_str(failed_trajectory);
 
@@ -337,11 +342,7 @@ pub fn build_reflection_prompt(
 }
 
 /// Inject reflections into an execution prompt.
-pub fn inject_reflections(
-    base_prompt: &str,
-    task_info: &str,
-    memory: &ReflexionMemory,
-) -> String {
+pub fn inject_reflections(base_prompt: &str, task_info: &str, memory: &ReflexionMemory) -> String {
     let mut prompt = base_prompt.to_string();
     let reflections = memory.get_reflection_texts();
     if !reflections.is_empty() {
@@ -408,8 +409,18 @@ mod tests {
         q.push("b".into(), TaskOrigin::User);
 
         let new_tasks = vec![
-            BrainTask { id: 10, name: "x".into(), origin: TaskOrigin::User, result: None },
-            BrainTask { id: 11, name: "y".into(), origin: TaskOrigin::User, result: None },
+            BrainTask {
+                id: 10,
+                name: "x".into(),
+                origin: TaskOrigin::User,
+                result: None,
+            },
+            BrainTask {
+                id: 11,
+                name: "y".into(),
+                origin: TaskOrigin::User,
+                result: None,
+            },
         ];
         q.replace(new_tasks);
 
@@ -421,7 +432,10 @@ mod tests {
     fn parse_task_list_numbered() {
         let response = "1. Fix the compiler error\n2. Run tests\n3. Update docs\n";
         let tasks = parse_task_list(response);
-        assert_eq!(tasks, vec!["Fix the compiler error", "Run tests", "Update docs"]);
+        assert_eq!(
+            tasks,
+            vec!["Fix the compiler error", "Run tests", "Update docs"]
+        );
     }
 
     #[test]
@@ -450,11 +464,14 @@ mod tests {
         let task = gp.queue.pop_front().unwrap();
         assert_eq!(task.name, "run cargo test");
 
-        gp.record_completion(task, TaskResult {
-            data: "3 tests failed".into(),
-            success: false,
-            timestamp_secs: 0,
-        });
+        gp.record_completion(
+            task,
+            TaskResult {
+                data: "3 tests failed".into(),
+                success: false,
+                timestamp_secs: 0,
+            },
+        );
 
         assert_eq!(gp.current_cycle, 1);
         assert!(gp.queue.is_empty()); // No new tasks yet
@@ -489,10 +506,8 @@ mod tests {
 
     #[test]
     fn reflection_prompt_includes_trajectory() {
-        let prompt = build_reflection_prompt(
-            "> cargo test\n3 failures\n",
-            &["tried fixing imports"],
-        );
+        let prompt =
+            build_reflection_prompt("> cargo test\n3 failures\n", &["tried fixing imports"]);
         assert!(prompt.contains("cargo test"));
         assert!(prompt.contains("3 failures"));
         assert!(prompt.contains("tried fixing imports"));

--- a/crates/phantom-brain/src/ollama.rs
+++ b/crates/phantom-brain/src/ollama.rs
@@ -3,6 +3,12 @@
 //! Talks to a running Ollama instance at `localhost:11434`. The brain thread
 //! calls these functions synchronously (blocking) — this is intentional since
 //! the brain runs on its own dedicated thread.
+//!
+//! # `OllamaBackend`
+//!
+//! The [`OllamaBackend`] struct implements [`crate::goal::ChatBackend`] so it
+//! can be used wherever a `ChatBackend` is required (e.g., goal decomposition).
+//! It uses Ollama's `/api/chat` endpoint for multi-turn conversation history.
 
 use serde::{Deserialize, Serialize};
 
@@ -12,6 +18,160 @@ use serde::{Deserialize, Serialize};
 
 const DEFAULT_URL: &str = "http://localhost:11434";
 const GENERATE_TIMEOUT_SECS: u64 = 30;
+const CHAT_TIMEOUT_SECS: u64 = 60;
+
+// ---------------------------------------------------------------------------
+// OllamaBackend — implements ChatBackend (multi-turn /api/chat)
+// ---------------------------------------------------------------------------
+
+/// A [`crate::goal::ChatBackend`] that dispatches to Ollama's `/api/chat`
+/// endpoint for single-turn and multi-turn conversations.
+///
+/// # Construction
+///
+/// ```rust
+/// use phantom_brain::ollama::OllamaBackend;
+///
+/// // Default: phi3.5:latest @ http://localhost:11434
+/// let backend = OllamaBackend::default_model();
+///
+/// // Custom model:
+/// let backend = OllamaBackend::new("llama3:latest", "http://localhost:11434");
+/// ```
+pub struct OllamaBackend {
+    /// Ollama base URL (default: `http://localhost:11434`).
+    base_url: String,
+    /// Ollama model name (e.g. `"phi3.5:latest"`).
+    model: String,
+}
+
+impl OllamaBackend {
+    /// Create a backend for `model` at `base_url`.
+    pub fn new(model: impl Into<String>, base_url: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into(),
+            model: model.into(),
+        }
+    }
+
+    /// Create a backend using `phi3.5:latest` at the default local URL.
+    pub fn default_model() -> Self {
+        Self::new("phi3.5:latest", DEFAULT_URL)
+    }
+
+    /// Returns `true` when Ollama is running and reachable.
+    ///
+    /// Pings `/api/tags` which responds quickly without loading a model.
+    pub fn is_available(&self) -> bool {
+        let url = format!("{}/api/tags", self.base_url);
+        let agent = ureq::Agent::config_builder()
+            .timeout_global(Some(std::time::Duration::from_secs(2)))
+            .build()
+            .new_agent();
+        match agent.get(&url).call() {
+            Ok(resp) => resp.status() == 200,
+            Err(_) => false,
+        }
+    }
+
+    /// Return the model name in use.
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+
+    /// Return the base URL in use.
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+}
+
+// Wire types for /api/chat
+
+/// A single message in the Ollama `/api/chat` format.
+#[derive(Serialize, Deserialize, Clone)]
+struct ChatMessage {
+    role: String,
+    content: String,
+}
+
+/// Request body for Ollama's `/api/chat` endpoint.
+#[derive(Serialize)]
+struct ChatRequest<'a> {
+    model: &'a str,
+    messages: Vec<ChatMessage>,
+    stream: bool,
+    options: ChatRequestOptions,
+}
+
+#[derive(Serialize)]
+struct ChatRequestOptions {
+    num_predict: u32,
+    temperature: f32,
+}
+
+/// Response from Ollama's `/api/chat` (non-streaming).
+#[derive(Deserialize)]
+struct ChatResponse {
+    message: ChatMessage,
+    #[serde(default)]
+    done: bool,
+}
+
+impl crate::goal::ChatBackend for OllamaBackend {
+    fn chat(&self, prompt: &str) -> Result<String, String> {
+        let url = format!("{}/api/chat", self.base_url);
+
+        let request = ChatRequest {
+            model: &self.model,
+            messages: vec![ChatMessage {
+                role: "user".to_string(),
+                content: prompt.to_string(),
+            }],
+            stream: false,
+            options: ChatRequestOptions {
+                num_predict: 512,
+                temperature: 0.3,
+            },
+        };
+
+        let agent = ureq::Agent::config_builder()
+            .timeout_global(Some(std::time::Duration::from_secs(CHAT_TIMEOUT_SECS)))
+            .build()
+            .new_agent();
+
+        let start = std::time::Instant::now();
+
+        let resp = agent
+            .post(&url)
+            .send_json(&request)
+            .map_err(|e| format!("ollama /api/chat request failed: {e}"))?;
+
+        let latency_ms = start.elapsed().as_secs_f32() * 1000.0;
+
+        if resp.status() != 200 {
+            return Err(format!(
+                "ollama /api/chat returned status {}",
+                resp.status()
+            ));
+        }
+
+        let chat_resp: ChatResponse = resp
+            .into_body()
+            .read_json()
+            .map_err(|e| format!("ollama /api/chat response parse failed: {e}"))?;
+
+        let text = chat_resp.message.content.trim().to_string();
+
+        log::debug!(
+            "ollama chat: model={}, latency={latency_ms:.0}ms, done={}, len={}",
+            self.model,
+            chat_resp.done,
+            text.len()
+        );
+
+        Ok(text)
+    }
+}
 
 /// Request body for Ollama's `/api/generate` endpoint.
 #[derive(Serialize)]
@@ -68,11 +228,7 @@ pub fn is_available() -> bool {
 /// `max_tokens` caps the response length.
 ///
 /// Returns `(response_text, latency_ms)` on success.
-pub fn generate(
-    model: &str,
-    prompt: &str,
-    max_tokens: u32,
-) -> Result<(String, f32), String> {
+pub fn generate(model: &str, prompt: &str, max_tokens: u32) -> Result<(String, f32), String> {
     let url = format!("{DEFAULT_URL}/api/generate");
     let start = std::time::Instant::now();
 
@@ -91,7 +247,8 @@ pub fn generate(
         .build()
         .new_agent();
 
-    let resp = agent.post(&url)
+    let resp = agent
+        .post(&url)
         .send_json(&body)
         .map_err(|e| format!("ollama request failed: {e}"))?;
 
@@ -157,19 +314,17 @@ mod tests {
 
     #[test]
     fn build_error_triage_prompt_formats_correctly() {
-        let errors = vec![
-            phantom_semantic::DetectedError {
-                message: "mismatched types".into(),
-                error_type: phantom_semantic::ErrorType::Compiler,
-                file: Some("src/main.rs".into()),
-                line: Some(42),
-                column: Some(5),
-                code: Some("E0308".into()),
-                severity: phantom_semantic::Severity::Error,
-                raw_line: String::new(),
-                suggestion: None,
-            },
-        ];
+        let errors = vec![phantom_semantic::DetectedError {
+            message: "mismatched types".into(),
+            error_type: phantom_semantic::ErrorType::Compiler,
+            file: Some("src/main.rs".into()),
+            line: Some(42),
+            column: Some(5),
+            code: Some("E0308".into()),
+            severity: phantom_semantic::Severity::Error,
+            raw_line: String::new(),
+            suggestion: None,
+        }];
 
         let prompt = build_error_triage_prompt("cargo build", &errors, "Rust");
         assert!(prompt.contains("Rust project"));
@@ -207,5 +362,53 @@ mod tests {
         // No Ollama running in CI — should return false, not panic.
         // (If Ollama IS running locally, this will return true — both are fine.)
         let _ = is_available();
+    }
+
+    // ---------------------------------------------------------------------------
+    // OllamaBackend tests
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn ollama_backend_default_model_fields() {
+        let backend = OllamaBackend::default_model();
+        assert_eq!(backend.model(), "phi3.5:latest");
+        assert_eq!(backend.base_url(), "http://localhost:11434");
+    }
+
+    #[test]
+    fn ollama_backend_new_stores_fields() {
+        let backend = OllamaBackend::new("llama3:latest", "http://localhost:11434");
+        assert_eq!(backend.model(), "llama3:latest");
+        assert_eq!(backend.base_url(), "http://localhost:11434");
+    }
+
+    #[test]
+    fn ollama_backend_is_available_does_not_panic() {
+        // No Ollama running in CI — should return false, not panic.
+        let backend = OllamaBackend::default_model();
+        let _ = backend.is_available();
+    }
+
+    #[test]
+    fn ollama_backend_chat_fails_gracefully_without_server() {
+        use crate::goal::ChatBackend;
+
+        // Point to a port that's almost certainly not listening.
+        let backend = OllamaBackend::new("phi3.5:latest", "http://localhost:19999");
+        let result = backend.chat("Hello, are you there?");
+        assert!(
+            result.is_err(),
+            "chat must return Err when Ollama is not reachable"
+        );
+    }
+
+    #[test]
+    fn ollama_backend_implements_chat_backend_trait() {
+        use crate::goal::ChatBackend;
+
+        // Compile-time proof: OllamaBackend satisfies the ChatBackend bound.
+        fn accepts_chat_backend<B: ChatBackend>(_: &B) {}
+        let backend = OllamaBackend::default_model();
+        accepts_chat_backend(&backend);
     }
 }

--- a/crates/phantom-brain/src/ooda.rs
+++ b/crates/phantom-brain/src/ooda.rs
@@ -41,9 +41,7 @@
 
 use std::time::Instant;
 
-use crate::curves::{
-    BehaviorDecisionSystem, ScoringContext, build_default_behaviors,
-};
+use crate::curves::{BehaviorDecisionSystem, ScoringContext, build_default_behaviors};
 use crate::events::AiAction;
 
 // ---------------------------------------------------------------------------
@@ -145,7 +143,10 @@ impl OodaConfig {
     /// * `budget_ms` — frame-budget cap in milliseconds.
     /// * `action_threshold` — minimum BDS score required to emit an action.
     pub fn new(budget_ms: f32, action_threshold: f32) -> Self {
-        Self { budget_ms, action_threshold }
+        Self {
+            budget_ms,
+            action_threshold,
+        }
     }
 
     /// Frame-budget cap in milliseconds.
@@ -380,12 +381,8 @@ impl OodaLoop {
                 key: "ooda_pattern".into(),
                 value: "new pattern detected".into(),
             },
-            "notify_agent_complete" => {
-                AiAction::ShowNotification("Agent completed.".into())
-            }
-            "notify_change" => {
-                AiAction::ShowNotification("Files or git state changed.".into())
-            }
+            "notify_agent_complete" => AiAction::ShowNotification("Agent completed.".into()),
+            "notify_change" => AiAction::ShowNotification("Files or git state changed.".into()),
             // quiet / watch_build / unknown → DoNothing
             _ => AiAction::DoNothing,
         }
@@ -535,11 +532,7 @@ mod tests {
         let has_notify = actions
             .iter()
             .any(|a| matches!(a, AiAction::ShowNotification(_)));
-        assert!(
-            has_notify,
-            "expected ShowNotification, got {:?}",
-            actions
-        );
+        assert!(has_notify, "expected ShowNotification, got {:?}", actions);
     }
 
     // =======================================================================

--- a/crates/phantom-brain/src/orchestrator.rs
+++ b/crates/phantom-brain/src/orchestrator.rs
@@ -19,8 +19,8 @@
 use std::collections::{HashSet, VecDeque};
 use std::time::Instant;
 
-use phantom_agents::dispatch::Disposition;
 use phantom_agents::AgentTask;
+use phantom_agents::dispatch::Disposition;
 
 // ---------------------------------------------------------------------------
 // Fact classification (task ledger knowledge categories)

--- a/crates/phantom-brain/src/persistent_skill_registry.rs
+++ b/crates/phantom-brain/src/persistent_skill_registry.rs
@@ -401,11 +401,7 @@ impl PersistentSkillRegistry {
     pub async fn top_n(&self, n: usize) -> Vec<Skill> {
         let idx = self.index.read().await;
         let mut skills: Vec<Skill> = idx.values().cloned().collect();
-        skills.sort_by(|a, b| {
-            b.provenance
-                .success_count
-                .cmp(&a.provenance.success_count)
-        });
+        skills.sort_by(|a, b| b.provenance.success_count.cmp(&a.provenance.success_count));
         skills.truncate(n);
         skills
     }
@@ -479,13 +475,7 @@ impl PersistentSkillRegistry {
 
         tokio::fs::rename(&tmp_path, &self.path)
             .await
-            .with_context(|| {
-                format!(
-                    "rename {} -> {}",
-                    tmp_path.display(),
-                    self.path.display()
-                )
-            })?;
+            .with_context(|| format!("rename {} -> {}", tmp_path.display(), self.path.display()))?;
 
         Ok(())
     }
@@ -676,9 +666,7 @@ mod tests {
             .await
             .unwrap();
 
-        let sense_skills = registry
-            .search_by_capability(CapabilityClass::Sense)
-            .await;
+        let sense_skills = registry.search_by_capability(CapabilityClass::Sense).await;
         assert_eq!(sense_skills.len(), 2);
         for s in &sense_skills {
             assert_eq!(s.capability(), CapabilityClass::Sense);

--- a/crates/phantom-brain/src/proactive.rs
+++ b/crates/phantom-brain/src/proactive.rs
@@ -56,10 +56,7 @@ pub enum EnvSignal {
     /// Git state changed.
     GitChanged,
     /// An agent completed work.
-    AgentCompleted {
-        success: bool,
-        summary: String,
-    },
+    AgentCompleted { success: bool, summary: String },
     /// A long-running process started or is still running.
     ProcessRunning,
 }
@@ -189,7 +186,6 @@ pub struct InterventionEngine {
     window_duration_secs: f32,
 
     // -- User feedback model (approximates the paper's reward model) -------
-
     /// Acceptance rate: fraction of suggestions the user accepted.
     /// Tracks the paper's R_t = g(P_t, A_t, S_t) over time.
     pub acceptance_rate: f32,
@@ -203,7 +199,6 @@ pub struct InterventionEngine {
     pub consecutive_dismissals: u32,
 
     // -- Per-session state --------------------------------------------------
-
     /// Actions taken since last user input.
     pub actions_since_input: u32,
     /// When the last action was emitted.
@@ -294,9 +289,11 @@ impl InterventionEngine {
         let now = Instant::now();
 
         // Evict expired signals.
-        while self.signals.front().is_some_and(|s| {
-            now.duration_since(s.at).as_secs_f32() > self.window_duration_secs
-        }) {
+        while self
+            .signals
+            .front()
+            .is_some_and(|s| now.duration_since(s.at).as_secs_f32() > self.window_duration_secs)
+        {
             self.signals.pop_front();
         }
 
@@ -489,7 +486,10 @@ impl InterventionEngine {
         // Novelty boost: first-time errors get higher score.
         let is_novel = matches!(
             &latest.kind,
-            SignalKind::Env(EnvSignal::CommandFailed { is_novel_error: true, .. })
+            SignalKind::Env(EnvSignal::CommandFailed {
+                is_novel_error: true,
+                ..
+            })
         );
         let novelty_bonus = if is_novel { 0.15 } else { 0.0 };
 
@@ -554,14 +554,18 @@ impl InterventionEngine {
     fn need_from_env_changes(&self) -> Option<NeedEstimate> {
         let now = Instant::now();
 
-        let recent_changes = self.signals.iter().filter(|s| {
-            now.duration_since(s.at).as_secs() < 15
-                && matches!(
-                    s.kind,
-                    SignalKind::Env(EnvSignal::FileChanged { .. })
-                        | SignalKind::Env(EnvSignal::GitChanged)
-                )
-        }).count();
+        let recent_changes = self
+            .signals
+            .iter()
+            .filter(|s| {
+                now.duration_since(s.at).as_secs() < 15
+                    && matches!(
+                        s.kind,
+                        SignalKind::Env(EnvSignal::FileChanged { .. })
+                            | SignalKind::Env(EnvSignal::GitChanged)
+                    )
+            })
+            .count();
 
         if recent_changes > 0 {
             Some(NeedEstimate {
@@ -626,8 +630,7 @@ impl InterventionEngine {
             0.0
         };
 
-        (base + dismissal_penalty + saturation_penalty + cooldown_penalty)
-            .clamp(0.1, 0.95)
+        (base + dismissal_penalty + saturation_penalty + cooldown_penalty).clamp(0.1, 0.95)
     }
 
     // -- Action recording --------------------------------------------------
@@ -946,7 +949,9 @@ impl ProactiveSuggester {
 fn is_test_command(cmd: &str) -> bool {
     let first = cmd.split_whitespace().next().unwrap_or("");
     // Primary: first token is a well-known test runner.
-    let known_runners = ["cargo", "pytest", "jest", "mocha", "go", "rspec", "vitest", "npm", "yarn"];
+    let known_runners = [
+        "cargo", "pytest", "jest", "mocha", "go", "rspec", "vitest", "npm", "yarn",
+    ];
     if !known_runners.iter().any(|r| first.ends_with(r)) {
         return false;
     }
@@ -957,12 +962,17 @@ fn is_test_command(cmd: &str) -> bool {
 /// Return `true` if the command string looks like a build invocation.
 fn is_build_command(cmd: &str) -> bool {
     let first = cmd.split_whitespace().next().unwrap_or("");
-    let known_builders = ["cargo", "make", "cmake", "gradle", "mvn", "bazel", "buck", "npm", "yarn"];
+    let known_builders = [
+        "cargo", "make", "cmake", "gradle", "mvn", "bazel", "buck", "npm", "yarn",
+    ];
     if !known_builders.iter().any(|r| first.ends_with(r)) {
         return false;
     }
-    cmd.contains(" build") || cmd.contains(" compile") || cmd.contains(" check")
-        || cmd.contains(" install") || cmd.contains("--build")
+    cmd.contains(" build")
+        || cmd.contains(" compile")
+        || cmd.contains(" check")
+        || cmd.contains(" install")
+        || cmd.contains("--build")
 }
 
 // ---------------------------------------------------------------------------
@@ -976,8 +986,7 @@ mod tests {
     fn engine_with_expired_cooldown() -> InterventionEngine {
         let mut e = InterventionEngine::new();
         // Set last_action_at far enough in the past that cooldown is expired.
-        e.last_action_at =
-            Some(Instant::now() - std::time::Duration::from_secs(60));
+        e.last_action_at = Some(Instant::now() - std::time::Duration::from_secs(60));
         e
     }
 
@@ -1120,8 +1129,16 @@ mod tests {
         engine.actions_since_input = 100;
 
         let threshold = engine.compute_annoyance_threshold();
-        assert!(threshold <= 0.95, "threshold capped at 0.95, got {}", threshold);
-        assert!(threshold >= 0.1, "threshold floored at 0.1, got {}", threshold);
+        assert!(
+            threshold <= 0.95,
+            "threshold capped at 0.95, got {}",
+            threshold
+        );
+        assert!(
+            threshold >= 0.1,
+            "threshold floored at 0.1, got {}",
+            threshold
+        );
     }
 
     // -- Acceptance rate tracking ------------------------------------------
@@ -1343,10 +1360,18 @@ mod tests {
         let mut s = default_suggester();
         let event = AiEvent::CommandComplete(failed_output("cargo build"));
         let result = s.observe(&event);
-        if let Some(AiAction::Suggest { action, rationale, confidence }) = result {
+        if let Some(AiAction::Suggest {
+            action,
+            rationale,
+            confidence,
+        }) = result
+        {
             assert!(!action.is_empty(), "action must not be empty");
             assert!(!rationale.is_empty(), "rationale must not be empty");
-            assert!((0.0..=1.0).contains(&confidence), "confidence must be in [0,1]");
+            assert!(
+                (0.0..=1.0).contains(&confidence),
+                "confidence must be in [0,1]"
+            );
         } else {
             panic!("expected AiAction::Suggest");
         }
@@ -1386,7 +1411,10 @@ mod tests {
         // BuildError is a separate kind — its cooldown is untouched.
         let build_event = AiEvent::CommandComplete(failed_output("cargo build"));
         let r2 = s.observe(&build_event);
-        assert!(r2.is_some(), "BuildError should fire independently of TestFailed cooldown");
+        assert!(
+            r2.is_some(),
+            "BuildError should fire independently of TestFailed cooldown"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -1415,7 +1443,10 @@ mod tests {
         // Idle without a prior question.
         let idle = AiEvent::UserIdle { seconds: 30.0 };
         let result = s.observe(&idle);
-        assert!(result.is_none(), "idle without a question should not trigger");
+        assert!(
+            result.is_none(),
+            "idle without a question should not trigger"
+        );
     }
 
     #[test]
@@ -1428,7 +1459,10 @@ mod tests {
         // Idle for only 5 s — below the 10 s threshold.
         let idle = AiEvent::UserIdle { seconds: 5.0 };
         let result = s.observe(&idle);
-        assert!(result.is_none(), "idle < 10 s should not trigger IdleAfterQuestion");
+        assert!(
+            result.is_none(),
+            "idle < 10 s should not trigger IdleAfterQuestion"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -1440,7 +1474,10 @@ mod tests {
         let mut s = default_suggester();
         let event = AiEvent::GitStateChanged;
         let result = s.observe(&event);
-        assert!(result.is_some(), "ContextChange should fire on GitStateChanged");
+        assert!(
+            result.is_some(),
+            "ContextChange should fire on GitStateChanged"
+        );
     }
 
     #[test]
@@ -1452,7 +1489,10 @@ mod tests {
         let result = s.observe(&event);
         // FileChanged is not mapped to ContextChange in the issue spec.
         // This is intentional — GitStateChanged is the ContextChange signal.
-        assert!(result.is_none(), "FileChanged alone should not trigger ContextChange");
+        assert!(
+            result.is_none(),
+            "FileChanged alone should not trigger ContextChange"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -1471,7 +1511,10 @@ mod tests {
 
         // Immediate second fire: cooldown should suppress.
         let r2 = s.observe(&event);
-        assert!(r2.is_none(), "second immediate BuildError should be suppressed by cooldown");
+        assert!(
+            r2.is_none(),
+            "second immediate BuildError should be suppressed by cooldown"
+        );
     }
 
     #[test]
@@ -1507,7 +1550,12 @@ mod tests {
         let mut s = ProactiveSuggester::new(
             vec![
                 Trigger::new(TriggerKind::BuildError, "fix build", "build failed", 0.8),
-                Trigger::new(TriggerKind::ContextChange, "review changes", "context changed", 0.6),
+                Trigger::new(
+                    TriggerKind::ContextChange,
+                    "review changes",
+                    "context changed",
+                    0.6,
+                ),
             ],
             60_000, // 60 s
         );
@@ -1520,7 +1568,10 @@ mod tests {
         // ContextChange has an independent cooldown — should still fire.
         let ctx_event = AiEvent::GitStateChanged;
         let r2 = s.observe(&ctx_event);
-        assert!(r2.is_some(), "ContextChange should fire independently of BuildError cooldown");
+        assert!(
+            r2.is_some(),
+            "ContextChange should fire independently of BuildError cooldown"
+        );
 
         // BuildError again immediately — should be suppressed.
         let r3 = s.observe(&build_event);
@@ -1535,11 +1586,17 @@ mod tests {
     fn confidence_is_clamped_to_unit_range() {
         // Clamp > 1.0.
         let t = Trigger::new(TriggerKind::BuildError, "a", "b", 2.5);
-        assert!((t.confidence - 1.0).abs() < f32::EPSILON, "confidence should clamp to 1.0");
+        assert!(
+            (t.confidence - 1.0).abs() < f32::EPSILON,
+            "confidence should clamp to 1.0"
+        );
 
         // Clamp < 0.0.
         let t = Trigger::new(TriggerKind::TestFailed, "a", "b", -0.5);
-        assert!(t.confidence.abs() < f32::EPSILON, "confidence should clamp to 0.0");
+        assert!(
+            t.confidence.abs() < f32::EPSILON,
+            "confidence should clamp to 0.0"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/phantom-brain/src/provider_catalog.rs
+++ b/crates/phantom-brain/src/provider_catalog.rs
@@ -139,13 +139,14 @@ impl ProviderCatalog {
         }
     }
 
-    /// Create a catalog pre-loaded with the three built-in profiles.
+    /// Create a catalog pre-loaded with the built-in profiles.
     ///
     /// Built-in profiles:
     ///
     /// - `"claude-default"` — `claude-sonnet-4-20250514` via the `claude` CLI
     /// - `"claude-fast"`    — `claude-haiku-4-5` via the `claude` CLI
-    /// - `"ollama-phi3.5"` — `phi3.5:latest` via Ollama
+    /// - `"ollama-phi3.5"` — `phi3.5:latest` via Ollama (local)
+    /// - `"ollama-llama3"`  — `llama3:latest` via Ollama (local)
     pub fn with_builtins() -> Self {
         let mut catalog = Self::empty();
 
@@ -172,6 +173,13 @@ impl ProviderCatalog {
             "ollama run phi3.5",
             "phi3.5:latest",
             vec!["phi3.5:latest".into(), "phi3.5:3.8b".into()],
+        ));
+
+        catalog.insert(ProviderProfile::new(
+            "ollama-llama3",
+            "ollama run llama3",
+            "llama3:latest",
+            vec!["llama3:latest".into(), "llama3:8b".into()],
         ));
 
         catalog
@@ -241,6 +249,35 @@ impl ProviderCatalog {
         self.resolve(id).cloned()
     }
 
+    /// Build an [`crate::ollama::OllamaBackend`] from an `ollama-*` profile.
+    ///
+    /// Returns `None` when `id` does not resolve to a profile whose
+    /// `runtime_command` starts with `"ollama"`. The backend uses the profile's
+    /// `default_model` and the standard local Ollama URL (`http://localhost:11434`).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use phantom_brain::provider_catalog::ProviderCatalog;
+    /// use phantom_brain::goal::ChatBackend;
+    ///
+    /// let catalog = ProviderCatalog::with_builtins();
+    /// if let Some(backend) = catalog.build_ollama_backend("ollama-phi3.5") {
+    ///     // backend implements ChatBackend
+    ///     let _ = backend.chat("Hello");
+    /// }
+    /// ```
+    pub fn build_ollama_backend(&self, id: &str) -> Option<crate::ollama::OllamaBackend> {
+        let profile = self.profiles.get(id)?;
+        if !profile.runtime_command.starts_with("ollama") {
+            return None;
+        }
+        Some(crate::ollama::OllamaBackend::new(
+            profile.default_model.clone(),
+            "http://localhost:11434",
+        ))
+    }
+
     /// Returns `true` if the catalog contains a profile with `id`.
     pub fn contains(&self, id: &str) -> bool {
         self.profiles.contains_key(id)
@@ -295,12 +332,7 @@ mod tests {
     #[test]
     fn profile_auto_appends_default_model_if_missing() {
         // default_model not listed in available_models — must be appended.
-        let p = ProviderProfile::new(
-            "p",
-            "cmd",
-            "missing-model",
-            vec!["other-model".into()],
-        );
+        let p = ProviderProfile::new("p", "cmd", "missing-model", vec!["other-model".into()]);
         assert!(
             p.available_models().contains(&"missing-model".to_string()),
             "default_model must appear in available_models"
@@ -354,9 +386,9 @@ mod tests {
     // -- ProviderCatalog::with_builtins -------------------------------------
 
     #[test]
-    fn with_builtins_has_three_profiles() {
+    fn with_builtins_has_four_profiles() {
         let cat = ProviderCatalog::with_builtins();
-        assert_eq!(cat.len(), 3);
+        assert_eq!(cat.len(), 4);
     }
 
     #[test]
@@ -420,7 +452,12 @@ mod tests {
     #[test]
     fn insert_adds_new_profile() {
         let mut cat = ProviderCatalog::empty();
-        cat.insert(ProviderProfile::new("custom", "my-llm", "v1", vec!["v1".into()]));
+        cat.insert(ProviderProfile::new(
+            "custom",
+            "my-llm",
+            "v1",
+            vec!["v1".into()],
+        ));
         assert!(cat.contains("custom"));
         assert_eq!(cat.len(), 1);
     }
@@ -436,7 +473,7 @@ mod tests {
             vec!["new-model".into()],
         ));
         // Length must not grow when replacing.
-        assert_eq!(cat.len(), old_len);
+        assert_eq!(cat.len(), old_len, "length must not grow when replacing");
         let p = cat.resolve("claude-fast").expect("must exist");
         assert_eq!(p.runtime_command(), "new-command");
     }
@@ -465,6 +502,7 @@ mod tests {
         assert!(ids.contains(&"claude-default"));
         assert!(ids.contains(&"claude-fast"));
         assert!(ids.contains(&"ollama-phi3.5"));
+        assert!(ids.contains(&"ollama-llama3"));
     }
 
     // -- Default ------------------------------------------------------------
@@ -475,6 +513,7 @@ mod tests {
         assert!(cat.contains("claude-default"));
         assert!(cat.contains("claude-fast"));
         assert!(cat.contains("ollama-phi3.5"));
+        assert!(cat.contains("ollama-llama3"));
     }
 
     // -- Required named tests (Issue #61) -----------------------------------
@@ -512,7 +551,7 @@ mod tests {
         );
         assert_eq!(p.default_model(), "custom-fast-model");
         // Catalog length must not grow when replacing.
-        assert_eq!(cat.len(), 3, "length must not grow when overriding");
+        assert_eq!(cat.len(), 4, "length must not grow when overriding");
     }
 
     /// Requesting a non-existent profile via `get` returns `None`.
@@ -533,6 +572,65 @@ mod tests {
             p.default_model().contains("sonnet"),
             "default profile must use sonnet, got {}",
             p.default_model()
+        );
+    }
+
+    /// The built-in `ollama-llama3` profile must exist and use llama3.
+    #[test]
+    fn with_builtins_contains_ollama_llama3() {
+        let cat = ProviderCatalog::with_builtins();
+        assert!(
+            cat.contains("ollama-llama3"),
+            "ollama-llama3 must be present"
+        );
+        let p = cat.resolve("ollama-llama3").expect("must resolve");
+        assert_eq!(p.default_model(), "llama3:latest");
+        assert!(p.runtime_command().starts_with("ollama"));
+    }
+
+    /// `build_ollama_backend` returns an `OllamaBackend` for `ollama-*` profiles.
+    #[test]
+    fn build_ollama_backend_returns_backend_for_ollama_profile() {
+        let cat = ProviderCatalog::with_builtins();
+        let backend = cat.build_ollama_backend("ollama-phi3.5");
+        assert!(
+            backend.is_some(),
+            "build_ollama_backend must return Some for ollama-phi3.5"
+        );
+        let backend = backend.unwrap();
+        assert_eq!(backend.model(), "phi3.5:latest");
+        assert_eq!(backend.base_url(), "http://localhost:11434");
+    }
+
+    /// `build_ollama_backend` returns an `OllamaBackend` for `ollama-llama3`.
+    #[test]
+    fn build_ollama_backend_returns_backend_for_llama3_profile() {
+        let cat = ProviderCatalog::with_builtins();
+        let backend = cat
+            .build_ollama_backend("ollama-llama3")
+            .expect("ollama-llama3 must produce a backend");
+        assert_eq!(backend.model(), "llama3:latest");
+    }
+
+    /// `build_ollama_backend` returns `None` for non-Ollama profiles.
+    #[test]
+    fn build_ollama_backend_returns_none_for_claude_profile() {
+        let cat = ProviderCatalog::with_builtins();
+        let backend = cat.build_ollama_backend("claude-default");
+        assert!(
+            backend.is_none(),
+            "build_ollama_backend must return None for claude profiles"
+        );
+    }
+
+    /// `build_ollama_backend` returns `None` for missing profiles.
+    #[test]
+    fn build_ollama_backend_returns_none_for_missing_profile() {
+        let cat = ProviderCatalog::with_builtins();
+        let backend = cat.build_ollama_backend("nonexistent-profile");
+        assert!(
+            backend.is_none(),
+            "build_ollama_backend must return None for missing profiles"
         );
     }
 }

--- a/crates/phantom-brain/src/reconciler.rs
+++ b/crates/phantom-brain/src/reconciler.rs
@@ -213,17 +213,15 @@ impl ReconcilerState {
         if let Some(step) = ledger.plan.get_mut(idx) {
             if success {
                 step.record_success(summary);
-                log::info!(
-                    "Reconciler: step {} done — {}",
-                    idx,
-                    step.description
-                );
+                log::info!("Reconciler: step {} done — {}", idx, step.description);
             } else {
                 let retrying = step.record_failure(summary);
                 if retrying {
                     log::warn!(
                         "Reconciler: step {} failed, will retry (attempt={}/{})",
-                        idx, step.attempts, step.max_attempts
+                        idx,
+                        step.attempts,
+                        step.max_attempts
                     );
                 } else {
                     log::error!(
@@ -361,7 +359,12 @@ impl ReconcilerState {
             .into_iter()
             .filter(|(idx, _)| !self.active_dispatches.contains_key(idx))
             .map(|(idx, step)| {
-                (idx, step.assigned_task.clone(), step.disposition, step.description.clone())
+                (
+                    idx,
+                    step.assigned_task.clone(),
+                    step.disposition,
+                    step.description.clone(),
+                )
             })
             .collect();
 
@@ -535,7 +538,10 @@ mod tests {
 
         // Second tick — active dispatch already running, should not dispatch again.
         state.tick(&mut ledger, &tx);
-        assert!(rx.try_recv().is_err(), "should not dispatch while step active");
+        assert!(
+            rx.try_recv().is_err(),
+            "should not dispatch while step active"
+        );
     }
 
     #[test]
@@ -640,7 +646,10 @@ mod tests {
                     "flatlined id must match the spawn_tag"
                 );
                 // reason must be descriptive — not empty, not a placeholder.
-                assert!(!reason.is_empty(), "AgentFlatlined must carry a non-empty reason");
+                assert!(
+                    !reason.is_empty(),
+                    "AgentFlatlined must carry a non-empty reason"
+                );
                 assert!(
                     reason.contains("stall") || reason.contains("attempt"),
                     "reason must mention stall or attempts, got: {reason}"
@@ -694,7 +703,9 @@ mod tests {
         std::thread::sleep(Duration::from_millis(5));
         state.tick(&mut ledger, &tx);
 
-        let flatline = rx.try_recv().expect("expected AgentFlatlined after second stall");
+        let flatline = rx
+            .try_recv()
+            .expect("expected AgentFlatlined after second stall");
         assert!(
             matches!(flatline, AiAction::AgentFlatlined { .. }),
             "expected AgentFlatlined on final stall, got {flatline:?}"
@@ -814,7 +825,11 @@ mod tests {
             StepStatus::Active,
             "step must remain Active when spawn_tag is None"
         );
-        assert_eq!(state.active_dispatches.len(), 1, "dispatch must remain registered");
+        assert_eq!(
+            state.active_dispatches.len(),
+            1,
+            "dispatch must remain registered"
+        );
     }
 
     /// `on_agent_complete` with a spawn_tag that doesn't match any active
@@ -994,7 +1009,9 @@ mod tests {
 
         // Stall timeout should have fired, exhausted retries, and emitted
         // AgentFlatlined -- no panic.
-        let action = rx.try_recv().expect("expected AgentFlatlined from stall timeout");
+        let action = rx
+            .try_recv()
+            .expect("expected AgentFlatlined from stall timeout");
         assert!(
             matches!(action, AiAction::AgentFlatlined { .. }),
             "expected AgentFlatlined, got {action:?}"
@@ -1035,10 +1052,17 @@ mod tests {
         let mut state = ReconcilerState::new();
         let mut ledger = TaskLedger::new("test goal");
         ledger.set_plan(vec![
-            PlanStep::new("root", AgentTask::FreeForm { prompt: "root".into() }),
+            PlanStep::new(
+                "root",
+                AgentTask::FreeForm {
+                    prompt: "root".into(),
+                },
+            ),
             PlanStep::with_deps(
                 "blocked",
-                AgentTask::FreeForm { prompt: "blocked".into() },
+                AgentTask::FreeForm {
+                    prompt: "blocked".into(),
+                },
                 vec![0],
             ),
         ]);
@@ -1046,13 +1070,24 @@ mod tests {
         state.tick(&mut ledger, &tx);
 
         // Only root dispatched; blocked still Pending.
-        assert_eq!(ledger.plan[0].status, StepStatus::Active, "root must be Active");
-        assert_eq!(ledger.plan[1].status, StepStatus::Pending, "blocked must still be Pending");
+        assert_eq!(
+            ledger.plan[0].status,
+            StepStatus::Active,
+            "root must be Active"
+        );
+        assert_eq!(
+            ledger.plan[1].status,
+            StepStatus::Pending,
+            "blocked must still be Pending"
+        );
         assert_eq!(state.active_dispatches.len(), 1);
 
         let a = rx.try_recv().expect("one SpawnAgent");
         assert!(matches!(a, AiAction::SpawnAgent { .. }));
-        assert!(rx.try_recv().is_err(), "must not emit second SpawnAgent for blocked step");
+        assert!(
+            rx.try_recv().is_err(),
+            "must not emit second SpawnAgent for blocked step"
+        );
     }
 
     /// After a dependency completes, the blocked step becomes eligible on the next tick.
@@ -1062,10 +1097,17 @@ mod tests {
         let mut state = ReconcilerState::new();
         let mut ledger = TaskLedger::new("test goal");
         ledger.set_plan(vec![
-            PlanStep::new("root", AgentTask::FreeForm { prompt: "root".into() }),
+            PlanStep::new(
+                "root",
+                AgentTask::FreeForm {
+                    prompt: "root".into(),
+                },
+            ),
             PlanStep::with_deps(
                 "blocked",
-                AgentTask::FreeForm { prompt: "blocked".into() },
+                AgentTask::FreeForm {
+                    prompt: "blocked".into(),
+                },
                 vec![0],
             ),
         ]);
@@ -1073,7 +1115,9 @@ mod tests {
         // Tick 1: dispatch root, capture spawn_tag.
         state.tick(&mut ledger, &tx);
         let a = rx.try_recv().expect("SpawnAgent for root");
-        let AiAction::SpawnAgent { spawn_tag, .. } = a else { panic!("expected SpawnAgent") };
+        let AiAction::SpawnAgent { spawn_tag, .. } = a else {
+            panic!("expected SpawnAgent")
+        };
         let tag = spawn_tag.expect("spawn_tag must be Some");
 
         // Complete root.
@@ -1082,8 +1126,15 @@ mod tests {
 
         // Tick 2: blocked step is now eligible.
         state.tick(&mut ledger, &tx);
-        assert_eq!(ledger.plan[1].status, StepStatus::Active, "blocked must now be Active");
-        assert!(rx.try_recv().is_ok(), "must emit SpawnAgent for previously blocked step");
+        assert_eq!(
+            ledger.plan[1].status,
+            StepStatus::Active,
+            "blocked must now be Active"
+        );
+        assert!(
+            rx.try_recv().is_ok(),
+            "must emit SpawnAgent for previously blocked step"
+        );
     }
 
     /// Calling tick twice does not double-dispatch the same active step.
@@ -1100,8 +1151,15 @@ mod tests {
 
         // Tick 2: step-a still active, must not be re-dispatched.
         state.tick(&mut ledger, &tx);
-        assert!(rx.try_recv().is_err(), "must not re-dispatch an Active step");
-        assert_eq!(state.active_dispatches.len(), 1, "dispatch count must not grow");
+        assert!(
+            rx.try_recv().is_err(),
+            "must not re-dispatch an Active step"
+        );
+        assert_eq!(
+            state.active_dispatches.len(),
+            1,
+            "dispatch count must not grow"
+        );
     }
 
     // -- Issue #49: auto-approve fast path for safe dispositions ------------------
@@ -1123,7 +1181,9 @@ mod tests {
         // Build a step with Chat disposition (read-only — should auto-approve).
         let step = PlanStep::new(
             "chat step",
-            AgentTask::FreeForm { prompt: "summarise the diff".into() },
+            AgentTask::FreeForm {
+                prompt: "summarise the diff".into(),
+            },
         )
         .with_disposition(Disposition::Chat);
         ledger.set_plan(vec![step]);
@@ -1345,8 +1405,7 @@ mod tests {
             .next()
             .expect("active_dispatches must have one entry");
         assert_eq!(
-            stored_id,
-            above_u32_max,
+            stored_id, above_u32_max,
             "active_dispatches must store the raw u64 agent ID, not a saturated u32 (fixes #273)"
         );
 
@@ -1357,5 +1416,4 @@ mod tests {
             "PlanStep::agent_id must store the full u64 agent ID (fixes #273)"
         );
     }
-
 }

--- a/crates/phantom-brain/src/router.rs
+++ b/crates/phantom-brain/src/router.rs
@@ -451,7 +451,10 @@ mod tests {
         }
         let router = BrainRouter::new(config);
         let backends = router.route(TaskComplexity::Complex);
-        assert!(!backends.is_empty(), "should have a complex-capable backend");
+        assert!(
+            !backends.is_empty(),
+            "should have a complex-capable backend"
+        );
         // Claude is the only backend with Complex capability.
         assert_eq!(backends.last().unwrap().name, "claude-sonnet");
     }
@@ -499,10 +502,7 @@ mod tests {
         let router = BrainRouter::new(config);
         // Heuristic only handles Trivial, not Complex.
         let backends = router.route(TaskComplexity::Complex);
-        assert!(
-            backends.is_empty(),
-            "heuristic cannot handle Complex tasks"
-        );
+        assert!(backends.is_empty(), "heuristic cannot handle Complex tasks");
     }
 
     #[test]
@@ -523,7 +523,12 @@ mod tests {
         let mut router = BrainRouter::new(RouterConfig::default());
         // First call sets latency directly.
         router.record_result("heuristic", 100.0, true);
-        let backend = router.config.backends.iter().find(|b| b.name == "heuristic").unwrap();
+        let backend = router
+            .config
+            .backends
+            .iter()
+            .find(|b| b.name == "heuristic")
+            .unwrap();
         assert!(
             (backend.avg_latency_ms - 100.0).abs() < f32::EPSILON,
             "first call should set latency directly"
@@ -531,7 +536,12 @@ mod tests {
 
         // Second call applies EMA: 100 * 0.8 + 200 * 0.2 = 120.
         router.record_result("heuristic", 200.0, true);
-        let backend = router.config.backends.iter().find(|b| b.name == "heuristic").unwrap();
+        let backend = router
+            .config
+            .backends
+            .iter()
+            .find(|b| b.name == "heuristic")
+            .unwrap();
         assert!(
             (backend.avg_latency_ms - 120.0).abs() < 0.01,
             "EMA should be 120, got {}",
@@ -547,7 +557,12 @@ mod tests {
 
         router.record_result("heuristic", 50.0, false);
 
-        let backend = router.config.backends.iter().find(|b| b.name == "heuristic").unwrap();
+        let backend = router
+            .config
+            .backends
+            .iter()
+            .find(|b| b.name == "heuristic")
+            .unwrap();
         assert!(
             !backend.available,
             "failed backend should be marked unavailable"
@@ -562,7 +577,12 @@ mod tests {
 
         router.health_check();
 
-        let backend = router.config.backends.iter().find(|b| b.name == "heuristic").unwrap();
+        let backend = router
+            .config
+            .backends
+            .iter()
+            .find(|b| b.name == "heuristic")
+            .unwrap();
         assert!(
             backend.available,
             "health_check should restore heuristic availability"
@@ -634,7 +654,12 @@ mod tests {
         // Should not panic or change any state.
         router.record_result("nonexistent-backend", 100.0, true);
         // Verify existing backends are unchanged.
-        let heuristic = router.config.backends.iter().find(|b| b.name == "heuristic").unwrap();
+        let heuristic = router
+            .config
+            .backends
+            .iter()
+            .find(|b| b.name == "heuristic")
+            .unwrap();
         assert_eq!(heuristic.avg_latency_ms, 0.0);
     }
 }

--- a/crates/phantom-brain/src/scoring.rs
+++ b/crates/phantom-brain/src/scoring.rs
@@ -7,8 +7,8 @@
 //!
 //! Inspired by game AI utility systems — see `docs/research/ai-control-loop.md`.
 
-use std::collections::hash_map::DefaultHasher;
 use std::collections::VecDeque;
+use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::time::Instant;
 
@@ -92,18 +92,20 @@ impl UtilityScorer {
     /// Check if a suggestion text was recently shown (within dedup window).
     fn is_duplicate(&self, text: &str) -> bool {
         let now = Instant::now();
-        self.recent_suggestions.iter().any(|(t, when)| {
-            t == text && now.duration_since(*when).as_secs() < DEDUP_WINDOW_SECS
-        })
+        self.recent_suggestions
+            .iter()
+            .any(|(t, when)| t == text && now.duration_since(*when).as_secs() < DEDUP_WINDOW_SECS)
     }
 
     /// Record a suggestion that was emitted (for dedup tracking).
     fn record_suggestion(&mut self, text: &str) {
         let now = Instant::now();
         // Evict expired entries.
-        while self.recent_suggestions.front().is_some_and(|(_, when)| {
-            now.duration_since(*when).as_secs() >= DEDUP_WINDOW_SECS
-        }) {
+        while self
+            .recent_suggestions
+            .front()
+            .is_some_and(|(_, when)| now.duration_since(*when).as_secs() >= DEDUP_WINDOW_SECS)
+        {
             self.recent_suggestions.pop_front();
         }
         self.recent_suggestions.push_back((text.to_string(), now));
@@ -115,9 +117,8 @@ impl UtilityScorer {
 
     /// Returns true if the action cooldown has not yet elapsed.
     fn on_cooldown(&self) -> bool {
-        self.last_action_time.is_some_and(|t| {
-            t.elapsed().as_secs_f32() < ACTION_COOLDOWN_SECS
-        })
+        self.last_action_time
+            .is_some_and(|t| t.elapsed().as_secs_f32() < ACTION_COOLDOWN_SECS)
     }
 
     // -----------------------------------------------------------------------
@@ -194,8 +195,8 @@ impl UtilityScorer {
     pub fn explain_score(&self, parsed: &ParsedOutput, idle_time: f32) -> ScoredAction {
         // Suppress "user stuck" heuristic when inside a REPL session.
         const REPL_COMMANDS: &[&str] = &[
-            "python", "python3", "node", "irb", "ghci", "psql", "mysql",
-            "sqlite3", "lua", "julia", "erl", "iex",
+            "python", "python3", "node", "irb", "ghci", "psql", "mysql", "sqlite3", "lua", "julia",
+            "erl", "iex",
         ];
         if let Some(ref cmd) = self.last_command {
             let first_word = cmd.split_whitespace().next().unwrap_or("");
@@ -223,8 +224,18 @@ impl UtilityScorer {
                 action: AiAction::ShowSuggestion {
                     text: "Want me to explain this error?".into(),
                     options: vec![
-                        SuggestionOption { key: 'y', label: "Yes, explain".into(), action: Some(Box::new(AiAction::ConsoleReply("Let me explain...".into()))) },
-                        SuggestionOption { key: 'n', label: "No thanks".into(), action: None },
+                        SuggestionOption {
+                            key: 'y',
+                            label: "Yes, explain".into(),
+                            action: Some(Box::new(AiAction::ConsoleReply(
+                                "Let me explain...".into(),
+                            ))),
+                        },
+                        SuggestionOption {
+                            key: 'n',
+                            label: "No thanks".into(),
+                            action: None,
+                        },
                     ],
                 },
                 score: 0.7,
@@ -237,8 +248,18 @@ impl UtilityScorer {
                 action: AiAction::ShowSuggestion {
                     text: "Need help with anything?".into(),
                     options: vec![
-                        SuggestionOption { key: 'y', label: "Yes".into(), action: Some(Box::new(AiAction::ConsoleReply("Let me explain...".into()))) },
-                        SuggestionOption { key: 'n', label: "No".into(), action: None },
+                        SuggestionOption {
+                            key: 'y',
+                            label: "Yes".into(),
+                            action: Some(Box::new(AiAction::ConsoleReply(
+                                "Let me explain...".into(),
+                            ))),
+                        },
+                        SuggestionOption {
+                            key: 'n',
+                            label: "No".into(),
+                            action: None,
+                        },
                     ],
                 },
                 score: 0.3,
@@ -261,7 +282,14 @@ impl UtilityScorer {
         match event {
             AiEvent::CommandComplete(parsed) => {
                 // Detect a potential new pattern: the command type as a memory key.
-                let key = format!("cmd:{}", parsed.command.split_whitespace().next().unwrap_or("unknown"));
+                let key = format!(
+                    "cmd:{}",
+                    parsed
+                        .command
+                        .split_whitespace()
+                        .next()
+                        .unwrap_or("unknown")
+                );
 
                 if memory.get(&key).is_none() {
                     ScoredAction {
@@ -417,7 +445,11 @@ impl UtilityScorer {
         // Pick the highest-scoring action.
         let mut best = candidates
             .into_iter()
-            .max_by(|a, b| a.score.partial_cmp(&b.score).unwrap_or(std::cmp::Ordering::Equal))
+            .max_by(|a, b| {
+                a.score
+                    .partial_cmp(&b.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
             .unwrap_or_else(|| self.quiet_score());
 
         // --- Spam prevention gates ---
@@ -426,10 +458,14 @@ impl UtilityScorer {
         // heavily dampen all non-urgent scores.
         if self.suggestions_since_input >= MAX_SUGGESTIONS_WITHOUT_INPUT
             && !matches!(best.action, AiAction::DoNothing)
-            && best.score < 0.8 // Allow truly urgent actions (agent complete, etc.)
+            && best.score < 0.8
+        // Allow truly urgent actions (agent complete, etc.)
         {
             best.score *= 0.2;
-            best.reason = format!("{} (dampened: {} suggestions without input)", best.reason, self.suggestions_since_input);
+            best.reason = format!(
+                "{} (dampened: {} suggestions without input)",
+                best.reason, self.suggestions_since_input
+            );
         }
 
         // Gate 2: Dedup — suppress if we recently showed the same suggestion text.
@@ -503,9 +539,27 @@ impl UtilityScorer {
         AiAction::ShowSuggestion {
             text: format!("Fix: {error_summary}"),
             options: vec![
-                SuggestionOption { key: 'f', label: "Fix it".into(), action: Some(Box::new(AiAction::SpawnAgent { task: phantom_agents::AgentTask::FreeForm { prompt: error_summary }, spawn_tag: None, disposition: phantom_agents::dispatch::Disposition::BugFix })) },
-                SuggestionOption { key: 'e', label: "Explain".into(), action: Some(Box::new(AiAction::ConsoleReply("Let me explain...".into()))) },
-                SuggestionOption { key: 'd', label: "Dismiss".into(), action: None },
+                SuggestionOption {
+                    key: 'f',
+                    label: "Fix it".into(),
+                    action: Some(Box::new(AiAction::SpawnAgent {
+                        task: phantom_agents::AgentTask::FreeForm {
+                            prompt: error_summary,
+                        },
+                        spawn_tag: None,
+                        disposition: phantom_agents::dispatch::Disposition::BugFix,
+                    })),
+                },
+                SuggestionOption {
+                    key: 'e',
+                    label: "Explain".into(),
+                    action: Some(Box::new(AiAction::ConsoleReply("Let me explain...".into()))),
+                },
+                SuggestionOption {
+                    key: 'd',
+                    label: "Dismiss".into(),
+                    action: None,
+                },
             ],
         }
     }

--- a/crates/phantom-brain/src/skill_store.rs
+++ b/crates/phantom-brain/src/skill_store.rs
@@ -133,18 +133,19 @@ impl SkillStore {
         );
 
         let key = format!("{SKILL_PREFIX}{name}");
-        memory.set(&key, &value, MemoryCategory::Convention, MemorySource::Agent)?;
+        memory.set(
+            &key,
+            &value,
+            MemoryCategory::Convention,
+            MemorySource::Agent,
+        )?;
         self.skills.insert(name.to_owned(), entry);
 
         Ok(())
     }
 
     /// Record a successful use of an existing skill.
-    pub fn record_use(
-        &mut self,
-        name: &str,
-        memory: &mut MemoryStore,
-    ) -> anyhow::Result<()> {
+    pub fn record_use(&mut self, name: &str, memory: &mut MemoryStore) -> anyhow::Result<()> {
         let Some(skill) = self.skills.get_mut(name) else {
             return Ok(());
         };
@@ -158,7 +159,12 @@ impl SkillStore {
         );
 
         let key = format!("{SKILL_PREFIX}{name}");
-        memory.set(&key, &value, MemoryCategory::Convention, MemorySource::Agent)?;
+        memory.set(
+            &key,
+            &value,
+            MemoryCategory::Convention,
+            MemorySource::Agent,
+        )?;
 
         Ok(())
     }
@@ -423,8 +429,12 @@ mod tests {
         let mut store = SkillStore::new();
         let (mut memory, _dir) = tmp_memory();
 
-        store.add_skill("a", "code", "desc", "task", &mut memory).unwrap();
-        store.add_skill("b", "code", "desc", "task", &mut memory).unwrap();
+        store
+            .add_skill("a", "code", "desc", "task", &mut memory)
+            .unwrap();
+        store
+            .add_skill("b", "code", "desc", "task", &mut memory)
+            .unwrap();
 
         let names = store.list_skill_names();
         assert_eq!(names.len(), 2);

--- a/crates/phantom-nlp/src/lib.rs
+++ b/crates/phantom-nlp/src/lib.rs
@@ -2,7 +2,9 @@ pub mod interpreter;
 pub mod translate;
 
 pub use interpreter::*;
-pub use translate::{ClaudeLlmBackend, Intent, LlmBackend, TranslateError, translate};
+pub use translate::{
+    ClaudeLlmBackend, Intent, LlmBackend, OllamaLlmBackend, TranslateError, translate,
+};
 
 #[cfg(any(test, feature = "testing"))]
 pub use translate::MockLlmBackend;

--- a/crates/phantom-nlp/src/translate.rs
+++ b/crates/phantom-nlp/src/translate.rs
@@ -301,6 +301,123 @@ impl LlmBackend for ClaudeLlmBackend {
 }
 
 // ---------------------------------------------------------------------------
+// OllamaLlmBackend — local model via Ollama's /api/chat endpoint
+// ---------------------------------------------------------------------------
+
+const OLLAMA_DEFAULT_URL: &str = "http://localhost:11434";
+const OLLAMA_CHAT_TIMEOUT_SECS: u64 = 30;
+
+/// Ollama backend for [`translate`].
+///
+/// Calls Ollama's `/api/chat` endpoint on localhost. No API key required.
+/// Use [`OllamaLlmBackend::from_env`] to read the base URL from
+/// `OLLAMA_HOST` (falling back to `http://localhost:11434`) and the model
+/// from `OLLAMA_MODEL` (falling back to `phi3.5:latest`).
+#[derive(Debug)]
+pub struct OllamaLlmBackend {
+    base_url: String,
+    model: String,
+}
+
+impl OllamaLlmBackend {
+    /// Construct from explicit parameters.
+    pub fn new(model: impl Into<String>, base_url: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into(),
+            model: model.into(),
+        }
+    }
+
+    /// Construct using environment variables or fall back to defaults.
+    ///
+    /// | Variable      | Default                        |
+    /// |---------------|--------------------------------|
+    /// | `OLLAMA_HOST` | `http://localhost:11434`       |
+    /// | `OLLAMA_MODEL`| `phi3.5:latest`                |
+    pub fn from_env() -> Self {
+        let base_url =
+            std::env::var("OLLAMA_HOST").unwrap_or_else(|_| OLLAMA_DEFAULT_URL.to_owned());
+        let model = std::env::var("OLLAMA_MODEL").unwrap_or_else(|_| "phi3.5:latest".to_owned());
+        Self { base_url, model }
+    }
+
+    /// Returns `true` when Ollama is running and reachable at the configured URL.
+    pub fn is_available(&self) -> bool {
+        let url = format!("{}/api/tags", self.base_url);
+        let agent = ureq::Agent::config_builder()
+            .timeout_global(Some(std::time::Duration::from_secs(2)))
+            .build()
+            .new_agent();
+        match agent.get(&url).call() {
+            Ok(resp) => resp.status() == 200,
+            Err(_) => false,
+        }
+    }
+
+    /// Return the model name in use.
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+}
+
+impl LlmBackend for OllamaLlmBackend {
+    fn name(&self) -> &'static str {
+        "ollama"
+    }
+
+    fn complete(&self, system_prompt: &str, user_message: &str) -> Result<String, TranslateError> {
+        let url = format!("{}/api/chat", self.base_url);
+
+        let body = serde_json::json!({
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_message}
+            ],
+            "stream": false,
+            "options": {
+                "num_predict": 256,
+                "temperature": 0.1
+            }
+        });
+
+        let body_str = serde_json::to_string(&body)
+            .map_err(|e| TranslateError::Other(format!("serialise error: {e}")))?;
+
+        let agent = ureq::Agent::config_builder()
+            .timeout_global(Some(std::time::Duration::from_secs(
+                OLLAMA_CHAT_TIMEOUT_SECS,
+            )))
+            .build()
+            .new_agent();
+
+        let mut response = agent
+            .post(&url)
+            .header("content-type", "application/json")
+            .send(body_str.as_bytes())
+            .map_err(|e| TranslateError::Transport(e.to_string()))?;
+
+        let text = response
+            .body_mut()
+            .read_to_string()
+            .map_err(|e| TranslateError::Transport(format!("read body: {e}")))?;
+
+        let json: serde_json::Value = serde_json::from_str(&text)
+            .map_err(|e| TranslateError::Other(format!("parse response: {e}")))?;
+
+        // Ollama /api/chat response: { "message": { "role": "assistant", "content": "..." } }
+        let content = json
+            .get("message")
+            .and_then(|m| m.get("content"))
+            .and_then(|c| c.as_str())
+            .unwrap_or("")
+            .to_owned();
+
+        Ok(content)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // MockLlmBackend — for tests only
 // ---------------------------------------------------------------------------
 
@@ -921,6 +1038,52 @@ mod tests {
         assert!(prompt.contains("SearchHistory"));
         assert!(prompt.contains("SpawnAgent"));
         assert!(prompt.contains("Clarify"));
+    }
+
+    // -------------------------------------------------------------------------
+    // OllamaLlmBackend — configuration and graceful failure
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn ollama_backend_name_is_ollama() {
+        let b = OllamaLlmBackend::new("phi3.5:latest", "http://localhost:11434");
+        assert_eq!(b.name(), "ollama");
+    }
+
+    #[test]
+    fn ollama_backend_stores_model() {
+        let b = OllamaLlmBackend::new("llama3:latest", "http://localhost:11434");
+        assert_eq!(b.model(), "llama3:latest");
+    }
+
+    #[test]
+    fn ollama_backend_from_env_is_constructible() {
+        // Without OLLAMA_HOST / OLLAMA_MODEL set, uses defaults.
+        let b = OllamaLlmBackend::from_env();
+        assert_eq!(b.name(), "ollama");
+        assert!(!b.model().is_empty());
+    }
+
+    #[test]
+    fn ollama_backend_is_available_does_not_panic() {
+        let b = OllamaLlmBackend::from_env();
+        let _ = b.is_available();
+    }
+
+    #[test]
+    fn ollama_backend_complete_fails_gracefully_without_server() {
+        // Point at a port that is almost certainly not running Ollama.
+        let b = OllamaLlmBackend::new("phi3.5:latest", "http://localhost:19998");
+        let result = b.complete("system", "user");
+        assert!(
+            result.is_err(),
+            "complete must return Err when Ollama is not reachable"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, TranslateError::Transport(_)),
+            "unreachable server must produce TranslateError::Transport, got {err:?}"
+        );
     }
 
     /// Live integration test — only runs when ANTHROPIC_API_KEY is present.


### PR DESCRIPTION
## Summary

- Adds `OllamaBackend` struct to `crates/phantom-brain/src/ollama.rs` implementing the `ChatBackend` trait via Ollama's `/api/chat` endpoint (multi-turn conversation support)
- Adds `OllamaLlmBackend` struct to `crates/phantom-nlp/src/translate.rs` implementing the `LlmBackend` trait for NLP intent routing via Ollama
- Registers `ollama-llama3` (`llama3:latest`) as a built-in provider profile alongside the existing `ollama-phi3.5`
- Adds `ProviderCatalog::build_ollama_backend(id)` factory method that instantiates an `OllamaBackend` from any `ollama-*` catalog entry
- Exposes `OllamaLlmBackend` from `phantom-nlp`'s public API
- Applies `cargo fmt` to phantom-brain files (pre-existing formatting drift)

## Architecture

`OllamaBackend` (phantom-brain) → `ChatBackend` trait → used for goal decomposition and brain-level multi-turn agent tasks

`OllamaLlmBackend` (phantom-nlp) → `LlmBackend` trait → used in NLP intent routing when Claude is unavailable

Both use blocking HTTP via `ureq`, appropriate for dedicated brain/NLP threads. `is_available()` pings `/api/tags` with a 2s timeout for fast health checks.

## Test plan

- [x] `cargo build -p phantom-brain -p phantom-nlp` — clean
- [x] `cargo test -p phantom-brain -p phantom-nlp` — 474 tests, 0 failures
- [x] `cargo fmt -p phantom-brain -p phantom-nlp -- --check` — passes
- [x] New tests: `OllamaBackend` construction, `is_available` no-panic, graceful failure when Ollama unreachable, `ChatBackend` trait satisfaction, `build_ollama_backend` for valid/invalid profiles, `OllamaLlmBackend` construction and graceful transport failure
- [ ] Live integration test (requires local Ollama): `OllamaBackend::default_model().chat("Hello")` — manual only

🤖 Generated with [Claude Code](https://claude.com/claude-code)