### PR TITLE
feat: process detach — subprocess → tethered panes (closes #2)

### DIFF
--- a/crates/phantom-adapter/src/adapter.rs
+++ b/crates/phantom-adapter/src/adapter.rs
@@ -67,6 +67,24 @@ pub trait AppCore: Send {
     fn output_buf_snapshot(&self) -> Option<String> {
         None
     }
+
+    /// Wire a shared render-snapshot Arc into this adapter.
+    ///
+    /// Called by `App::split_for_alt_screen` when the layout is split so that
+    /// the alt-screen view sibling can receive rendered grid data each frame.
+    /// Terminal adapters store the Arc and write into it during `update()`.
+    ///
+    /// The default no-op means all non-terminal adapters compile unchanged.
+    fn attach_alt_screen_snapshot(
+        &mut self,
+        _snapshot: std::sync::Arc<std::sync::Mutex<Option<RenderOutput>>>,
+    ) {
+    }
+
+    /// Remove the shared render-snapshot Arc previously set by
+    /// `attach_alt_screen_snapshot`.  Called when the secondary pane is
+    /// collapsed.  The default is a no-op.
+    fn detach_alt_screen_snapshot(&mut self) {}
 }
 
 /// Visual adapters that render into a rect.

--- a/crates/phantom-app/src/adapters/agent.rs
+++ b/crates/phantom-app/src/adapters/agent.rs
@@ -155,7 +155,10 @@ impl AppCore for AgentAdapter {
         //   total_lines.saturating_sub(output_max_lines)
         // Using cached_output_max_lines keeps this consistent so that
         // mouse.rs click-jump math doesn't overshoot by up to output_max_lines.
-        let history_size = self.pane.cached_lines().len()
+        let history_size = self
+            .pane
+            .cached_lines()
+            .len()
             .saturating_sub(self.cached_output_max_lines.get());
         json!({
             "type": "agent",
@@ -375,9 +378,7 @@ impl Commandable for AgentAdapter {
                 // Scrollbar click-jump: {"offset": N}
                 // Clamp to max_offset so an oversized click-jump cannot leave the
                 // thumb stuck past the end of the history.
-                let offset = args.get("offset")
-                    .and_then(|v| v.as_u64())
-                    .unwrap_or(0) as usize;
+                let offset = args.get("offset").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
                 let total_lines = self.pane.cached_lines().len();
                 let max_offset = total_lines.saturating_sub(self.cached_output_max_lines.get());
                 self.scroll_offset = offset.min(max_offset);

--- a/crates/phantom-app/src/adapters/alt_screen_view.rs
+++ b/crates/phantom-app/src/adapters/alt_screen_view.rs
@@ -1,0 +1,316 @@
+//! Alt-screen view adapter — read-only mirror of a primary terminal's
+//! alt-screen render output.
+//!
+//! Used by issue #2 (process detach v1): when a terminal enters alt-screen
+//! mode (vim, htop, less), the primary pane renders the normal-screen history
+//! while a sibling `AltScreenViewAdapter` renders the alt-screen program.
+//! Both share the same `Arc<Mutex<Option<RenderOutput>>>` snapshot that the
+//! primary writes each frame via its `update()` override.
+//!
+//! The view adapter is intentionally minimal: no PTY, no input, no commands.
+//! It exists only to give the coordinator a second pane slot so the layout
+//! engine creates a visual split.
+
+use std::sync::{Arc, Mutex};
+
+use phantom_adapter::adapter::{Rect, RenderOutput};
+use phantom_adapter::spatial::{InternalLayout, SpatialPreference};
+use phantom_adapter::{
+    AppCore, BusParticipant, Commandable, InputHandler, Lifecycled, Permissioned, Renderable,
+};
+use serde_json::json;
+
+/// A shared render-snapshot handle passed between the primary terminal adapter
+/// and its alt-screen view sibling.
+///
+/// The primary calls `write()` each frame; the view adapter calls `read()`
+/// in its `render()` implementation.
+pub type AltScreenSnapshot = Arc<Mutex<Option<RenderOutput>>>;
+
+/// Create a new empty snapshot handle.
+pub fn new_snapshot() -> AltScreenSnapshot {
+    Arc::new(Mutex::new(None))
+}
+
+/// Read-only adapter that mirrors an alt-screen program's grid into a sibling pane.
+pub struct AltScreenViewAdapter {
+    snapshot: AltScreenSnapshot,
+    app_id: u32,
+    /// Human-readable label of the foreground program (e.g. "vim", "htop").
+    label: String,
+}
+
+impl AltScreenViewAdapter {
+    /// Create a new view adapter backed by `snapshot`.
+    pub fn new(snapshot: AltScreenSnapshot, label: String) -> Self {
+        Self {
+            snapshot,
+            app_id: 0,
+            label,
+        }
+    }
+
+    /// The shared snapshot handle (hand this to the primary adapter).
+    pub fn snapshot_arc(&self) -> AltScreenSnapshot {
+        Arc::clone(&self.snapshot)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sub-trait implementations
+// ---------------------------------------------------------------------------
+
+impl AppCore for AltScreenViewAdapter {
+    fn app_type(&self) -> &str {
+        "alt_screen_view"
+    }
+
+    fn is_alive(&self) -> bool {
+        true
+    }
+
+    fn update(&mut self, _dt: f32) {}
+
+    fn get_state(&self) -> serde_json::Value {
+        json!({
+            "type": "alt_screen_view",
+            "label": self.label,
+        })
+    }
+
+    fn title(&self) -> &str {
+        &self.label
+    }
+}
+
+impl Renderable for AltScreenViewAdapter {
+    fn render(&self, rect: &Rect) -> RenderOutput {
+        // Attempt to read the latest snapshot pushed by the primary terminal.
+        if let Ok(guard) = self.snapshot.lock() {
+            if let Some(mut output) = guard.clone() {
+                // Re-anchor the grid origin to this adapter's rect, since the
+                // primary may have been positioned differently.
+                if let Some(ref mut grid) = output.grid {
+                    grid.origin = (rect.x, rect.y);
+                }
+                return output;
+            }
+        }
+        // No snapshot yet — return empty output.
+        RenderOutput::default()
+    }
+
+    fn is_visual(&self) -> bool {
+        true
+    }
+
+    fn spatial_preference(&self) -> Option<SpatialPreference> {
+        Some(SpatialPreference {
+            min_size: (40, 10),
+            preferred_size: (120, 40),
+            max_size: None,
+            aspect_ratio: None,
+            internal_panes: 1,
+            internal_layout: InternalLayout::Single,
+            priority: 10.0,
+        })
+    }
+}
+
+impl InputHandler for AltScreenViewAdapter {
+    fn handle_input(&mut self, _key: &str) -> bool {
+        // View-only — never consumes input.
+        false
+    }
+
+    fn accepts_input(&self) -> bool {
+        false
+    }
+}
+
+impl Commandable for AltScreenViewAdapter {
+    fn accept_command(&mut self, cmd: &str, _args: &serde_json::Value) -> anyhow::Result<String> {
+        Err(anyhow::anyhow!(
+            "alt_screen_view adapter does not accept commands: {cmd}"
+        ))
+    }
+
+    fn accepts_commands(&self) -> bool {
+        false
+    }
+}
+
+impl BusParticipant for AltScreenViewAdapter {}
+
+impl Lifecycled for AltScreenViewAdapter {
+    fn set_app_id(&mut self, id: u32) {
+        self.app_id = id;
+    }
+}
+
+impl Permissioned for AltScreenViewAdapter {
+    fn permissions(&self) -> Vec<String> {
+        vec![]
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alt_screen_view_adapter_type_is_alt_screen_view() {
+        let snap = new_snapshot();
+        let adapter = AltScreenViewAdapter::new(snap, "vim".into());
+        assert_eq!(adapter.app_type(), "alt_screen_view");
+    }
+
+    #[test]
+    fn alt_screen_view_adapter_is_always_alive() {
+        let snap = new_snapshot();
+        let adapter = AltScreenViewAdapter::new(snap, "htop".into());
+        assert!(adapter.is_alive());
+    }
+
+    #[test]
+    fn alt_screen_view_adapter_does_not_accept_input() {
+        let snap = new_snapshot();
+        let mut adapter = AltScreenViewAdapter::new(snap, "less".into());
+        assert!(!adapter.accepts_input());
+        assert!(!adapter.handle_input("q"));
+    }
+
+    #[test]
+    fn alt_screen_view_adapter_does_not_accept_commands() {
+        let snap = new_snapshot();
+        let mut adapter = AltScreenViewAdapter::new(snap, "vim".into());
+        assert!(!adapter.accepts_commands());
+        let result = adapter.accept_command("resize", &serde_json::json!({}));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn render_returns_empty_when_no_snapshot() {
+        let snap = new_snapshot();
+        let adapter = AltScreenViewAdapter::new(snap, "vim".into());
+        let rect = Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 800.0,
+            height: 600.0,
+            ..Default::default()
+        };
+        let output = adapter.render(&rect);
+        assert!(output.grid.is_none());
+        assert!(output.quads.is_empty());
+    }
+
+    #[test]
+    fn render_uses_snapshot_and_reanchors_grid_origin() {
+        use phantom_adapter::adapter::{GridData, TerminalCell};
+
+        let snap = new_snapshot();
+        let adapter = AltScreenViewAdapter::new(Arc::clone(&snap), "vim".into());
+
+        // Push a grid snapshot with an arbitrary origin.
+        let cells = vec![TerminalCell {
+            ch: 'A',
+            fg: [1.0; 4],
+            bg: [0.0; 4],
+        }];
+        let grid = GridData {
+            cells,
+            cols: 1,
+            rows: 1,
+            origin: (0.0, 0.0),
+            cursor: None,
+        };
+        {
+            let mut guard = snap.lock().unwrap();
+            *guard = Some(RenderOutput {
+                grid: Some(grid),
+                ..Default::default()
+            });
+        }
+
+        let rect = Rect {
+            x: 400.0,
+            y: 100.0,
+            width: 400.0,
+            height: 300.0,
+            ..Default::default()
+        };
+        let output = adapter.render(&rect);
+        let grid_out = output.grid.unwrap();
+        // Origin should be re-anchored to the adapter's rect.
+        assert!((grid_out.origin.0 - 400.0).abs() < 0.01);
+        assert!((grid_out.origin.1 - 100.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn snapshot_arc_returns_same_arc() {
+        let snap = new_snapshot();
+        let adapter = AltScreenViewAdapter::new(Arc::clone(&snap), "vim".into());
+        let arc = adapter.snapshot_arc();
+        // Both arcs point to the same allocation.
+        assert!(Arc::ptr_eq(&snap, &arc));
+    }
+
+    #[test]
+    fn get_state_contains_type_and_label() {
+        let snap = new_snapshot();
+        let adapter = AltScreenViewAdapter::new(snap, "htop".into());
+        let state = adapter.get_state();
+        assert_eq!(state["type"], "alt_screen_view");
+        assert_eq!(state["label"], "htop");
+    }
+
+    #[test]
+    fn title_returns_label() {
+        let snap = new_snapshot();
+        let adapter = AltScreenViewAdapter::new(snap, "vim".into());
+        assert_eq!(adapter.title(), "vim");
+    }
+
+    #[test]
+    fn update_is_noop() {
+        let snap = new_snapshot();
+        let mut adapter = AltScreenViewAdapter::new(snap, "vim".into());
+        // Should not panic.
+        adapter.update(0.016);
+    }
+
+    #[test]
+    fn permissions_are_empty() {
+        let snap = new_snapshot();
+        let adapter = AltScreenViewAdapter::new(snap, "vim".into());
+        assert!(adapter.permissions().is_empty());
+    }
+
+    #[test]
+    fn set_app_id_stored() {
+        let snap = new_snapshot();
+        let mut adapter = AltScreenViewAdapter::new(snap, "vim".into());
+        adapter.set_app_id(42);
+        // Verify via get_state (no direct accessor, but the adapter should not panic).
+        let _ = adapter.get_state();
+    }
+
+    #[test]
+    fn new_snapshot_starts_empty() {
+        let snap = new_snapshot();
+        let guard = snap.lock().unwrap();
+        assert!(guard.is_none());
+    }
+
+    #[test]
+    fn spatial_preference_is_some() {
+        let snap = new_snapshot();
+        let adapter = AltScreenViewAdapter::new(snap, "vim".into());
+        assert!(adapter.spatial_preference().is_some());
+    }
+}

--- a/crates/phantom-app/src/adapters/mod.rs
+++ b/crates/phantom-app/src/adapters/mod.rs
@@ -1,9 +1,11 @@
 pub mod agent;
+pub mod alt_screen_view;
 pub mod inspector;
 pub mod monitor;
 pub mod terminal;
 pub mod video;
 pub use agent::AgentAdapter;
+pub use alt_screen_view::AltScreenViewAdapter;
 pub use monitor::MonitorAdapter;
 pub use terminal::TerminalAdapter;
 pub use video::VideoAdapter;

--- a/crates/phantom-app/src/adapters/terminal.rs
+++ b/crates/phantom-app/src/adapters/terminal.rs
@@ -6,6 +6,7 @@
 
 use log::warn;
 use serde_json::json;
+use std::sync::{Arc, Mutex};
 
 #[cfg(test)]
 use phantom_adapter::adapter::QuadData;
@@ -66,6 +67,9 @@ pub struct TerminalAdapter {
     app_id: u32,
     /// Pending outbound bus messages, drained by coordinator each frame.
     outbox: Vec<phantom_adapter::BusMessage>,
+    /// Shared render snapshot written each frame when alt-screen is active.
+    /// Set by `attach_alt_screen_snapshot`; cleared by `detach_alt_screen_snapshot`.
+    alt_screen_snapshot: Option<Arc<Mutex<Option<RenderOutput>>>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -92,6 +96,7 @@ impl TerminalAdapter {
             pty_dead: false,
             app_id: 0,
             outbox: Vec::new(),
+            alt_screen_snapshot: None,
         }
     }
 
@@ -143,6 +148,56 @@ impl TerminalAdapter {
     /// Set the error-notified flag.
     pub fn set_error_notified(&mut self, val: bool) {
         self.error_notified = val;
+    }
+
+    /// Extract a `RenderOutput` from the alt-screen for snapshot writes in
+    /// `update()` so the secondary view adapter always has fresh data.
+    ///
+    /// The origin is set to `(0.0, 0.0)`; the view adapter re-anchors it to
+    /// its own rect during `render()`.
+    fn render_alt_screen(&self) -> RenderOutput {
+        use phantom_adapter::adapter::{GridData, ScrollState};
+        use phantom_terminal::output;
+
+        let (render_cells, cols, rows, cursor_state) =
+            output::extract_grid_themed(self.terminal.term(), &self.theme_colors);
+
+        let cells: Vec<AdapterCell> = render_cells
+            .iter()
+            .map(|rc| AdapterCell {
+                ch: rc.ch,
+                fg: rc.fg,
+                bg: rc.bg,
+            })
+            .collect();
+
+        let cursor = if cursor_state.visible {
+            Some(convert_cursor(&cursor_state))
+        } else {
+            None
+        };
+
+        let grid = GridData {
+            cells,
+            cols,
+            rows,
+            origin: (0.0, 0.0),
+            cursor,
+        };
+
+        let scroll = Some(ScrollState {
+            display_offset: self.terminal.display_offset(),
+            history_size: self.terminal.history_size(),
+            visible_rows: self.terminal.size().rows as usize,
+        });
+
+        RenderOutput {
+            quads: vec![],
+            text_segments: vec![],
+            grid: Some(grid),
+            scroll,
+            selection: None,
+        }
     }
 }
 
@@ -211,6 +266,29 @@ impl AppCore for TerminalAdapter {
         }
 
         self.was_alt_screen = is_alt;
+
+        // When alt-screen is active and a secondary pane has been wired in,
+        // push a fresh render snapshot so the view adapter always has the
+        // latest grid data.
+        if self.is_detached {
+            if let Some(ref snapshot) = self.alt_screen_snapshot {
+                let render_out = self.render_alt_screen();
+                if let Ok(mut guard) = snapshot.lock() {
+                    *guard = Some(render_out);
+                }
+            }
+        }
+    }
+
+    fn attach_alt_screen_snapshot(
+        &mut self,
+        snapshot: std::sync::Arc<std::sync::Mutex<Option<phantom_adapter::adapter::RenderOutput>>>,
+    ) {
+        self.alt_screen_snapshot = Some(snapshot);
+    }
+
+    fn detach_alt_screen_snapshot(&mut self) {
+        self.alt_screen_snapshot = None;
     }
 
     fn get_state(&self) -> serde_json::Value {
@@ -437,7 +515,7 @@ impl Commandable for TerminalAdapter {
             "select_all" => {
                 // Select from the top of scrollback history to the last cell
                 // of the visible screen.
-                use phantom_terminal::selection::{Column, Line, Point, Side, SelectionType};
+                use phantom_terminal::selection::{Column, Line, Point, SelectionType, Side};
                 let size = self.terminal.size();
                 let history = self.terminal.history_size() as i32;
                 // Scrollback lines are at negative Line indices.
@@ -446,7 +524,8 @@ impl Commandable for TerminalAdapter {
                     Line((size.rows as i32).saturating_sub(1)),
                     Column(size.cols.saturating_sub(1) as usize),
                 );
-                self.terminal.start_selection(SelectionType::Simple, start, Side::Left);
+                self.terminal
+                    .start_selection(SelectionType::Simple, start, Side::Left);
                 self.terminal.update_selection(end, Side::Right);
                 Ok("all selected".into())
             }

--- a/crates/phantom-app/src/agent_pane.rs
+++ b/crates/phantom-app/src/agent_pane.rs
@@ -11,7 +11,6 @@ use log::{info, warn};
 use phantom_agents::agent::{Agent, AgentMessage};
 use phantom_agents::api::{ApiEvent, ApiHandle, ClaudeConfig, send_message};
 use phantom_agents::audit::{AuditOutcome, emit_tool_call};
-use phantom_session::AgentSnapshot;
 use phantom_agents::chat::{ChatBackend, ChatModel, ChatRequest, build_backend};
 use phantom_agents::permissions::PermissionSet;
 use phantom_agents::role::{AgentRole, CapabilityClass};
@@ -19,6 +18,7 @@ use phantom_agents::spawn_rules::{EventKind, EventSource, SubstrateEvent};
 use phantom_agents::tools::{ToolCall, ToolDefinition, ToolResult, ToolType, available_tools};
 use phantom_agents::{AgentSpawnOpts, AgentTask};
 use phantom_history::{AgentOutputCapture, ToolCall as HistoryToolCall};
+use phantom_session::AgentSnapshot;
 
 use crate::app::App;
 
@@ -311,7 +311,8 @@ pub(crate) struct AgentPane {
     ///
     /// `None` for legacy / test callers that do not wire a quarantine registry;
     /// the gate skips the check (fail-open) so old paths are unaffected.
-    quarantine: Option<std::sync::Arc<std::sync::Mutex<phantom_agents::quarantine::QuarantineRegistry>>>,
+    quarantine:
+        Option<std::sync::Arc<std::sync::Mutex<phantom_agents::quarantine::QuarantineRegistry>>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -525,9 +526,20 @@ impl AgentPane {
         info!(
             "Agent pane spawning: {} messages (system={}, user={}, backend={})",
             agent.messages().len(),
-            agent.messages().iter().filter(|m| matches!(m, AgentMessage::System(_))).count(),
-            agent.messages().iter().filter(|m| matches!(m, AgentMessage::User(_))).count(),
-            chat_backend.as_deref().map(|b| b.name()).unwrap_or("claude (default)"),
+            agent
+                .messages()
+                .iter()
+                .filter(|m| matches!(m, AgentMessage::System(_)))
+                .count(),
+            agent
+                .messages()
+                .iter()
+                .filter(|m| matches!(m, AgentMessage::User(_)))
+                .count(),
+            chat_backend
+                .as_deref()
+                .map(|b| b.name())
+                .unwrap_or("claude (default)"),
         );
 
         let handle = Self::dispatch(chat_backend.as_deref(), claude_config, &agent, &tools, &[]);
@@ -600,7 +612,9 @@ impl AgentPane {
         pending_spawn: phantom_agents::composer_tools::SpawnSubagentQueue,
         self_ref: phantom_agents::role::AgentRef,
         role: phantom_agents::role::AgentRole,
-        quarantine: std::sync::Arc<std::sync::Mutex<phantom_agents::quarantine::QuarantineRegistry>>,
+        quarantine: std::sync::Arc<
+            std::sync::Mutex<phantom_agents::quarantine::QuarantineRegistry>,
+        >,
     ) {
         self.registry = Some(registry);
         self.event_log = Some(event_log);
@@ -654,12 +668,14 @@ impl AgentPane {
     /// Called by `App::spawn_agent_pane_with_opts` after `spawn_with_opts`.
     /// When `None` is held (legacy / test path), tool calls and output are
     /// not recorded.
-    pub(crate) fn set_agent_capture(&mut self, capture: AgentOutputCapture, session_uuid: uuid::Uuid) {
+    pub(crate) fn set_agent_capture(
+        &mut self,
+        capture: AgentOutputCapture,
+        session_uuid: uuid::Uuid,
+    ) {
         self.agent_capture = Some(capture);
         self.capture_session_uuid = session_uuid;
     }
-
-
 
     /// Build a [`phantom_agents::dispatch::DispatchContext`] from the
     /// pane's current substrate handles, if all required pieces are wired.
@@ -738,7 +754,11 @@ impl AgentPane {
                 Some(ApiEvent::ToolUse { id, call }) => {
                     let args_display = format_tool_args(&call.tool, &call.args);
                     if let Some(ref mut j) = self.journal {
-                        if let Err(e) = j.record_tool_call(self.agent.id() as u64, call.tool.api_name(), &args_display) {
+                        if let Err(e) = j.record_tool_call(
+                            self.agent.id() as u64,
+                            call.tool.api_name(),
+                            &args_display,
+                        ) {
                             warn!("AgentJournal::record_tool_call failed: {e}");
                         }
                     }
@@ -776,7 +796,9 @@ impl AgentPane {
                                 "~{}in/~{}out tokens, {} tool calls",
                                 self.input_tokens, self.output_tokens, self.tool_call_count
                             );
-                            if let Err(e) = j.record_completion(self.agent.id() as u64, true, summary) {
+                            if let Err(e) =
+                                j.record_completion(self.agent.id() as u64, true, summary)
+                            {
                                 warn!("AgentJournal::record_completion failed: {e}");
                             }
                         }
@@ -1504,7 +1526,9 @@ pub(crate) fn resolve_api_config(model: &ChatModel) -> Option<ClaudeConfig> {
             config
         }
         ChatModel::OpenAi(_) => {
-            let key = std::env::var("OPENAI_API_KEY").ok().filter(|k| !k.is_empty());
+            let key = std::env::var("OPENAI_API_KEY")
+                .ok()
+                .filter(|k| !k.is_empty());
             if key.is_none() {
                 warn!("Cannot spawn agent: OPENAI_API_KEY not set");
             }
@@ -1532,10 +1556,7 @@ impl App {
     /// Splits the focused pane vertically, creates the agent (using the
     /// requested [`ChatModel`] if any), wraps it in an `AgentAdapter`, and
     /// registers it in the new split pane.
-    pub(crate) fn spawn_agent_pane_with_opts(
-        &mut self,
-        opts: AgentSpawnOpts,
-    ) -> bool {
+    pub(crate) fn spawn_agent_pane_with_opts(&mut self, opts: AgentSpawnOpts) -> bool {
         // Extract metadata before opts is moved into spawn_with_opts.
         let spawn_tag = opts.spawn_tag;
         // role/label carry Composer spawn_subagent metadata (#224).
@@ -1543,7 +1564,10 @@ impl App {
         let spawn_label = opts.label().unwrap_or("agent-pane").to_string();
         let resolved_model = opts.resolve_model();
         let Some(claude_config) = resolve_api_config(&resolved_model) else {
-            warn!("Cannot spawn agent: no API key configured for model {:?}", resolved_model);
+            warn!(
+                "Cannot spawn agent: no API key configured for model {:?}",
+                resolved_model
+            );
             return false;
         };
 
@@ -1783,6 +1807,9 @@ mod tests {
             runtime_mode: phantom_agents::dispatch::RuntimeMode::Normal,
             journal: None,
             quarantine: None,
+            agent_capture: None,
+            capture_session_uuid: uuid::Uuid::nil(),
+            capture_tool_calls: Vec::new(),
         };
         (pane, tx)
     }
@@ -1881,6 +1908,9 @@ mod tests {
             runtime_mode: phantom_agents::dispatch::RuntimeMode::Normal,
             journal: None,
             quarantine: None,
+            agent_capture: None,
+            capture_session_uuid: uuid::Uuid::nil(),
+            capture_tool_calls: Vec::new(),
         };
         assert!(!pane.poll());
     }
@@ -1934,7 +1964,12 @@ mod tests {
         assert!(pane.api_handle.is_none());
         // Assistant text should have been flushed to agent messages.
         assert!(pane.current_assistant_text.is_empty());
-        assert!(pane.agent.messages().iter().any(|m| matches!(m, AgentMessage::Assistant(t) if t == "result")));
+        assert!(
+            pane.agent
+                .messages()
+                .iter()
+                .any(|m| matches!(m, AgentMessage::Assistant(t) if t == "result"))
+        );
     }
 
     #[test]
@@ -1964,8 +1999,16 @@ mod tests {
         // turn_count should have incremented.
         assert_eq!(pane.turn_count, 1);
         // Agent messages should include ToolCall and ToolResult.
-        let has_tool_call = pane.agent.messages().iter().any(|m| matches!(m, AgentMessage::ToolCall(_)));
-        let has_tool_result = pane.agent.messages().iter().any(|m| matches!(m, AgentMessage::ToolResult(_)));
+        let has_tool_call = pane
+            .agent
+            .messages()
+            .iter()
+            .any(|m| matches!(m, AgentMessage::ToolCall(_)));
+        let has_tool_result = pane
+            .agent
+            .messages()
+            .iter()
+            .any(|m| matches!(m, AgentMessage::ToolResult(_)));
         assert!(has_tool_call, "agent should have a ToolCall message");
         assert!(has_tool_result, "agent should have a ToolResult message");
         // Output should show the continuation.
@@ -2453,9 +2496,7 @@ mod tests {
         // Build a Dispatcher-role pane with all substrate handles wired.
         let (mut pane, _tx) = agent_with_handle();
 
-        let registry = Arc::new(Mutex::new(
-            phantom_agents::inbox::AgentRegistry::new(),
-        ));
+        let registry = Arc::new(Mutex::new(phantom_agents::inbox::AgentRegistry::new()));
         let event_log = Arc::new(Mutex::new(
             EventLog::open(&tmp.path().join("events.jsonl")).unwrap(),
         ));
@@ -2468,7 +2509,9 @@ mod tests {
             pending_spawn,
             self_ref,
             AgentRole::Dispatcher,
-            Arc::new(Mutex::new(phantom_agents::quarantine::QuarantineRegistry::default())),
+            Arc::new(Mutex::new(
+                phantom_agents::quarantine::QuarantineRegistry::default(),
+            )),
         );
 
         // Wire the dispatcher (mock repo — no real gh calls in tests).
@@ -2476,7 +2519,8 @@ mod tests {
         pane.set_ticket_dispatcher(Arc::clone(&dispatcher));
 
         // Build a dispatch context; the ticket_dispatcher field must be Some.
-        let ctx = pane.build_dispatch_context()
+        let ctx = pane
+            .build_dispatch_context()
             .expect("build_dispatch_context must return Some for a fully-wired Dispatcher pane");
 
         assert!(
@@ -2501,9 +2545,7 @@ mod tests {
 
         let (mut pane, _tx) = agent_with_handle();
 
-        let registry = Arc::new(Mutex::new(
-            phantom_agents::inbox::AgentRegistry::new(),
-        ));
+        let registry = Arc::new(Mutex::new(phantom_agents::inbox::AgentRegistry::new()));
         let event_log = Arc::new(Mutex::new(
             EventLog::open(&tmp.path().join("events.jsonl")).unwrap(),
         ));
@@ -2516,7 +2558,9 @@ mod tests {
             pending_spawn,
             self_ref,
             AgentRole::Watcher,
-            Arc::new(Mutex::new(phantom_agents::quarantine::QuarantineRegistry::default())),
+            Arc::new(Mutex::new(
+                phantom_agents::quarantine::QuarantineRegistry::default(),
+            )),
         );
 
         // Wire a dispatcher into a non-Dispatcher pane — should still be None
@@ -2524,7 +2568,8 @@ mod tests {
         let dispatcher = GhTicketDispatcher::new("test/repo").shared();
         pane.set_ticket_dispatcher(Arc::clone(&dispatcher));
 
-        let ctx = pane.build_dispatch_context()
+        let ctx = pane
+            .build_dispatch_context()
             .expect("build_dispatch_context must return Some for a wired pane");
 
         assert!(
@@ -2568,10 +2613,12 @@ mod tests {
         let quarantine = Arc::new(Mutex::new(QuarantineRegistry::new_with_policy(
             AutoQuarantinePolicy { threshold: 1 },
         )));
-        quarantine
-            .lock()
-            .unwrap()
-            .check_and_escalate(agent_id, TaintLevel::Tainted, 0, "test-offense");
+        quarantine.lock().unwrap().check_and_escalate(
+            agent_id,
+            TaintLevel::Tainted,
+            0,
+            "test-offense",
+        );
         assert!(
             quarantine.lock().unwrap().agent_is_quarantined(agent_id),
             "agent must be quarantined before the dispatch test"
@@ -2582,14 +2629,17 @@ mod tests {
         let (mut pane, _tx) = agent_with_handle();
         let registry = Arc::new(Mutex::new(AgentRegistry::new()));
         let event_log = {
-            let log = phantom_memory::event_log::EventLog::open(
-                &tmp.path().join("events.jsonl"),
-            )
-            .unwrap();
+            let log = phantom_memory::event_log::EventLog::open(&tmp.path().join("events.jsonl"))
+                .unwrap();
             Arc::new(Mutex::new(log))
         };
         let pending_spawn = new_spawn_subagent_queue();
-        let self_ref = AgentRef::new(agent_id, AgentRole::Conversational, "offender", SpawnSource::User);
+        let self_ref = AgentRef::new(
+            agent_id,
+            AgentRole::Conversational,
+            "offender",
+            SpawnSource::User,
+        );
 
         pane.working_dir = tmp.path().to_string_lossy().into_owned();
         pane.set_substrate_handles(
@@ -2725,7 +2775,12 @@ mod tests {
             tool_use_ids: Vec::new(),
             cached_lines: Vec::new(),
             cached_len: 0,
-            agent: Agent::new(0, AgentTask::FreeForm { prompt: "fix the failing tests".into() }),
+            agent: Agent::new(
+                0,
+                AgentTask::FreeForm {
+                    prompt: "fix the failing tests".into(),
+                },
+            ),
             pending_tools: Vec::new(),
             working_dir: ".".into(),
             claude_config: test_config(),
@@ -2752,6 +2807,9 @@ mod tests {
             quarantine: None,
             snapshot_sink: None,
             last_failing_capability: None,
+            agent_capture: None,
+            capture_session_uuid: uuid::Uuid::nil(),
+            capture_tool_calls: Vec::new(),
         };
         let _ = tx; // keep sender alive so handle stays live
         assert_eq!(pane.task, "fix the failing tests");
@@ -2765,12 +2823,16 @@ mod tests {
     /// get different ids when constructed through the manager.
     #[test]
     fn spawn_two_panes_have_unique_agent_ids() {
-        use phantom_agents::manager::AgentManager;
         use phantom_agents::agent::AgentTask;
+        use phantom_agents::manager::AgentManager;
 
         let mut mgr = AgentManager::new(4);
-        let id1 = mgr.spawn(AgentTask::FreeForm { prompt: "task A".into() });
-        let id2 = mgr.spawn(AgentTask::FreeForm { prompt: "task B".into() });
+        let id1 = mgr.spawn(AgentTask::FreeForm {
+            prompt: "task A".into(),
+        });
+        let id2 = mgr.spawn(AgentTask::FreeForm {
+            prompt: "task B".into(),
+        });
 
         assert_ne!(id1, id2, "each spawned agent must receive a unique ID");
         assert_eq!(id1, 1);
@@ -2779,23 +2841,25 @@ mod tests {
         // Verify both are independently retrievable.
         assert!(mgr.get(id1).is_some());
         assert!(mgr.get(id2).is_some());
-        assert_eq!(mgr.get(id1).unwrap().id, id1);
-        assert_eq!(mgr.get(id2).unwrap().id, id2);
+        assert_eq!(mgr.get(id1).unwrap().id(), id1);
+        assert_eq!(mgr.get(id2).unwrap().id(), id2);
     }
 
     /// Backtick spawn via the manager starts the agent in `Working` status when
     /// there is available concurrency capacity.
     #[test]
     fn manager_spawn_starts_agent_in_working_status() {
-        use phantom_agents::manager::AgentManager;
         use phantom_agents::agent::{AgentStatus, AgentTask};
+        use phantom_agents::manager::AgentManager;
 
         let mut mgr = AgentManager::new(4);
-        let id = mgr.spawn(AgentTask::FreeForm { prompt: "do something".into() });
+        let id = mgr.spawn(AgentTask::FreeForm {
+            prompt: "do something".into(),
+        });
 
         let agent = mgr.get(id).expect("spawned agent must be retrievable");
         assert_eq!(
-            agent.status,
+            agent.status(),
             AgentStatus::Working,
             "spawned agent must start in Working status when capacity is available"
         );
@@ -2809,18 +2873,20 @@ mod tests {
     /// `Failed` and logs the kill event in its output log.
     #[test]
     fn kill_working_agent_transitions_to_failed() {
-        use phantom_agents::manager::AgentManager;
         use phantom_agents::agent::{AgentStatus, AgentTask};
+        use phantom_agents::manager::AgentManager;
 
         let mut mgr = AgentManager::new(4);
-        let id = mgr.spawn(AgentTask::FreeForm { prompt: "long running task".into() });
+        let id = mgr.spawn(AgentTask::FreeForm {
+            prompt: "long running task".into(),
+        });
 
-        assert_eq!(mgr.get(id).unwrap().status, AgentStatus::Working);
+        assert_eq!(mgr.get(id).unwrap().status(), AgentStatus::Working);
 
         let killed = mgr.kill(id);
         assert!(killed, "kill() must return true for a Working agent");
         assert_eq!(
-            mgr.get(id).unwrap().status,
+            mgr.get(id).unwrap().status(),
             AgentStatus::Failed,
             "killed agent must be in Failed state"
         );
@@ -2830,18 +2896,20 @@ mod tests {
     /// so the GUI can show the user that the agent was terminated deliberately.
     #[test]
     fn kill_agent_appends_kill_log_entry() {
-        use phantom_agents::manager::AgentManager;
         use phantom_agents::agent::AgentTask;
+        use phantom_agents::manager::AgentManager;
 
         let mut mgr = AgentManager::new(4);
-        let id = mgr.spawn(AgentTask::FreeForm { prompt: "task".into() });
+        let id = mgr.spawn(AgentTask::FreeForm {
+            prompt: "task".into(),
+        });
         mgr.kill(id);
 
         let agent = mgr.get(id).unwrap();
         assert!(
-            agent.output_log.iter().any(|l| l.contains("killed")),
+            agent.output_log().iter().any(|l| l.contains("killed")),
             "killed agent output_log must contain a kill annotation; got: {:?}",
-            agent.output_log,
+            agent.output_log(),
         );
     }
 
@@ -2849,18 +2917,20 @@ mod tests {
     /// `kill()` returns `false` because there is nothing to terminate.
     #[test]
     fn kill_terminal_agent_is_noop() {
-        use phantom_agents::manager::AgentManager;
         use phantom_agents::agent::{AgentStatus, AgentTask};
+        use phantom_agents::manager::AgentManager;
 
         let mut mgr = AgentManager::new(4);
-        let id = mgr.spawn(AgentTask::FreeForm { prompt: "already done".into() });
+        let id = mgr.spawn(AgentTask::FreeForm {
+            prompt: "already done".into(),
+        });
         mgr.get_mut(id).unwrap().complete(true);
-        assert_eq!(mgr.get(id).unwrap().status, AgentStatus::Done);
+        assert_eq!(mgr.get(id).unwrap().status(), AgentStatus::Done);
 
         let killed = mgr.kill(id);
         assert!(!killed, "kill() on a Done agent must return false");
         assert_eq!(
-            mgr.get(id).unwrap().status,
+            mgr.get(id).unwrap().status(),
             AgentStatus::Done,
             "status must not change for a terminal agent"
         );
@@ -2876,7 +2946,8 @@ mod tests {
         assert!(pane.api_handle.is_some());
 
         // Simulate an external kill by injecting an Error event.
-        tx.send(ApiEvent::Error("killed by user".into())).expect("send must succeed");
+        tx.send(ApiEvent::Error("killed by user".into()))
+            .expect("send must succeed");
         pane.poll();
 
         assert_eq!(
@@ -2899,8 +2970,8 @@ mod tests {
     /// be left untouched.
     #[test]
     fn kill_all_terminates_all_active_agents_and_skips_terminal() {
-        use phantom_agents::manager::AgentManager;
         use phantom_agents::agent::{AgentStatus, AgentTask};
+        use phantom_agents::manager::AgentManager;
 
         let mut mgr = AgentManager::new(4);
         let id1 = mgr.spawn(AgentTask::FreeForm { prompt: "a".into() });
@@ -2909,14 +2980,14 @@ mod tests {
 
         // Mark one as already done.
         mgr.get_mut(id3).unwrap().complete(true);
-        assert_eq!(mgr.get(id3).unwrap().status, AgentStatus::Done);
+        assert_eq!(mgr.get(id3).unwrap().status(), AgentStatus::Done);
 
         let count = mgr.kill_all();
         assert_eq!(count, 2, "kill_all must kill exactly the two active agents");
-        assert_eq!(mgr.get(id1).unwrap().status, AgentStatus::Failed);
-        assert_eq!(mgr.get(id2).unwrap().status, AgentStatus::Failed);
+        assert_eq!(mgr.get(id1).unwrap().status(), AgentStatus::Failed);
+        assert_eq!(mgr.get(id2).unwrap().status(), AgentStatus::Failed);
         assert_eq!(
-            mgr.get(id3).unwrap().status,
+            mgr.get(id3).unwrap().status(),
             AgentStatus::Done,
             "terminal agent must not be affected by kill_all"
         );
@@ -2955,7 +3026,10 @@ mod tests {
         with_env_locked("ANTHROPIC_API_KEY", Some("sk-ant-test-key"), || {
             let model = ChatModel::Claude("claude-3-5-sonnet-20241022".into());
             let result = resolve_api_config(&model);
-            assert!(result.is_some(), "Claude model + ANTHROPIC_API_KEY set → should return Some");
+            assert!(
+                result.is_some(),
+                "Claude model + ANTHROPIC_API_KEY set → should return Some"
+            );
         });
     }
 
@@ -2965,7 +3039,10 @@ mod tests {
         with_env_locked("ANTHROPIC_API_KEY", None, || {
             let model = ChatModel::Claude("claude-3-5-sonnet-20241022".into());
             let result = resolve_api_config(&model);
-            assert!(result.is_none(), "Claude model + no ANTHROPIC_API_KEY → should return None");
+            assert!(
+                result.is_none(),
+                "Claude model + no ANTHROPIC_API_KEY → should return None"
+            );
         });
     }
 
@@ -2975,7 +3052,10 @@ mod tests {
         with_env_locked("OPENAI_API_KEY", Some("sk-openai-test-key"), || {
             let model = ChatModel::OpenAi("gpt-4o".into());
             let result = resolve_api_config(&model);
-            assert!(result.is_some(), "OpenAI model + OPENAI_API_KEY set → should return Some");
+            assert!(
+                result.is_some(),
+                "OpenAI model + OPENAI_API_KEY set → should return Some"
+            );
         });
     }
 
@@ -2985,7 +3065,10 @@ mod tests {
         with_env_locked("OPENAI_API_KEY", None, || {
             let model = ChatModel::OpenAi("gpt-4o".into());
             let result = resolve_api_config(&model);
-            assert!(result.is_none(), "OpenAI model + no OPENAI_API_KEY → should return None");
+            assert!(
+                result.is_none(),
+                "OpenAI model + no OPENAI_API_KEY → should return None"
+            );
         });
     }
 

--- a/crates/phantom-app/src/app.rs
+++ b/crates/phantom-app/src/app.rs
@@ -35,14 +35,14 @@ use phantom_brain::events::AiEvent;
 use phantom_brain::ooda::{OodaConfig, OodaLoop};
 use phantom_context::ProjectContext;
 use phantom_history::{AgentOutputCapture, HistoryStore};
+use phantom_mcp::{AppCommand, McpListener, spawn_listener};
 use phantom_memory::MemoryStore;
+use phantom_nlp::{ClaudeLlmBackend, LlmBackend};
 use phantom_plugins::PluginRegistry;
 use phantom_scene::node::{NodeKind, RenderLayer};
 use phantom_scene::tree::SceneTree;
-use phantom_session::session::{is_session_restore, SessionManager, SessionState, PaneState};
+use phantom_session::session::{PaneState, SessionManager, SessionState, is_session_restore};
 use phantom_session::{AgentStatePersister, GoalStatePersister};
-use phantom_mcp::{spawn_listener, AppCommand, McpListener};
-use phantom_nlp::{ClaudeLlmBackend, LlmBackend};
 
 use crate::boot::BootSequence;
 use crate::boot_order::ShutdownGuard;
@@ -248,7 +248,8 @@ pub struct App {
     //    GITHUB_TOKEN is set; None otherwise). Handed to Dispatcher-role agent
     //    panes so they can call request_next_ticket / mark_ticket_in_progress /
     //    mark_ticket_done via the gh CLI.
-    pub(crate) ticket_dispatcher: Option<std::sync::Arc<phantom_agents::dispatcher::GhTicketDispatcher>>,
+    pub(crate) ticket_dispatcher:
+        Option<std::sync::Arc<phantom_agents::dispatcher::GhTicketDispatcher>>,
 
     // -- Inspector snapshot (shared with InspectorAdapter when a pane is open).
     //    `None` when no inspector pane has ever been spawned; `Some(Arc<RwLock<…>>)`
@@ -290,7 +291,8 @@ pub struct App {
     //    time via `set_substrate_handles`; the dispatch gate in
     //    `phantom_agents::dispatch::dispatch_tool` checks it before routing
     //    any tool call.
-    pub(crate) quarantine_registry: std::sync::Arc<std::sync::Mutex<phantom_agents::quarantine::QuarantineRegistry>>,
+    pub(crate) quarantine_registry:
+        std::sync::Arc<std::sync::Mutex<phantom_agents::quarantine::QuarantineRegistry>>,
 
     // -- Sec.8 user-visible notification center. Watches denial timestamps
     //    per agent and pushes a top-of-screen `Severity::Danger` banner
@@ -415,6 +417,28 @@ pub struct App {
     //    `Event::CommandComplete` handler in `drain_bus_to_brain` can write
     //    a `HistoryEntry` with the actual command string and exit code.
     pub(crate) pending_command_text: std::collections::HashMap<phantom_adapter::AppId, String>,
+
+    // -- Issue #2: process detach v1 (alt-screen split-pane) state --
+    //
+    // Maps primary adapter AppId → secondary (view) adapter AppId.  An entry
+    // exists for the lifetime of a split pane, from the moment a terminal
+    // enters alt-screen mode until the secondary pane is fully collapsed.
+    pub(crate) alt_screen_secondaries:
+        std::collections::HashMap<phantom_adapter::AppId, phantom_adapter::AppId>,
+
+    // Previous `is_detached` state per adapter, used for edge detection in
+    // `poll_alt_screen_transitions` (rising edge → split, falling edge → collapse).
+    pub(crate) prev_detached: std::collections::HashMap<phantom_adapter::AppId, bool>,
+
+    // Per secondary-pane collapse animation progress (0.0 → 1.0 over 300 ms).
+    // Keyed by secondary adapter AppId.  Entries are created on collapse trigger
+    // and removed once the fade completes and the pane is removed.
+    pub(crate) alt_screen_fade: std::collections::HashMap<phantom_adapter::AppId, f32>,
+
+    // Queue of secondary adapter AppIds whose collapse animations have
+    // completed and are ready for `remove_adapter`.  Drained by
+    // `tick_alt_screen_fade` into `collapse_alt_screen_pane`.
+    pub(crate) alt_screen_pending_collapses: Vec<phantom_adapter::AppId>,
 }
 
 /// An active suggestion from the AI brain.
@@ -550,19 +574,20 @@ impl App {
         };
 
         // -- Notification store (persistent per-project) --
-        let notification_store = match phantom_memory::notifications::NotificationStore::open(&project_dir) {
-            Ok(s) => {
-                info!(
-                    "Notification store ready ({} existing notifications)",
-                    s.count()
-                );
-                Some(s)
-            }
-            Err(e) => {
-                warn!("Failed to open notification store: {e}");
-                None
-            }
-        };
+        let notification_store =
+            match phantom_memory::notifications::NotificationStore::open(&project_dir) {
+                Ok(s) => {
+                    info!(
+                        "Notification store ready ({} existing notifications)",
+                        s.count()
+                    );
+                    Some(s)
+                }
+                Err(e) => {
+                    warn!("Failed to open notification store: {e}");
+                    None
+                }
+            };
 
         // -- History store + agent capture sidecar --
         // Both live under `~/.local/share/phantom/history/<session_uuid>[...].jsonl`.
@@ -596,6 +621,7 @@ impl App {
             enable_memory: true,
             quiet_threshold: 0.35, // Tuned: high enough to suppress noise, low enough for real evrs
             router: None,
+            catalog: None,
         });
         info!("AI brain spawned");
 
@@ -750,9 +776,9 @@ impl App {
                     // Initialise persister pair from the latest session file
                     // path so agent / goal sidecar files land next to it.
                     if let Ok(Some(session_path)) = sm.latest_path(&project_dir) {
-                        let ap = AgentStatePersister::new(
-                            AgentStatePersister::sidecar_path(&session_path),
-                        );
+                        let ap = AgentStatePersister::new(AgentStatePersister::sidecar_path(
+                            &session_path,
+                        ));
                         match ap.load() {
                             Ok(Some(ref file)) => {
                                 let n = file.agent_count();
@@ -766,9 +792,9 @@ impl App {
                         }
                         agent_persister = Some(ap);
 
-                        let gp = GoalStatePersister::new(
-                            GoalStatePersister::sidecar_path(&session_path),
-                        );
+                        let gp = GoalStatePersister::new(GoalStatePersister::sidecar_path(
+                            &session_path,
+                        ));
                         match gp.load() {
                             Ok(Some(ref file)) => {
                                 let n = file.goal_count();
@@ -1036,6 +1062,10 @@ impl App {
             agent_capture,
             session_uuid,
             pending_command_text: std::collections::HashMap::new(),
+            alt_screen_secondaries: std::collections::HashMap::new(),
+            prev_detached: std::collections::HashMap::new(),
+            alt_screen_fade: std::collections::HashMap::new(),
+            alt_screen_pending_collapses: Vec::new(),
         })
     }
 
@@ -1110,7 +1140,9 @@ impl App {
                     if !queue_snaps.is_empty() {
                         let file = phantom_session::AgentStateFile::new(queue_snaps);
                         match file.save(ap.path()) {
-                            Ok(()) => info!("Agent state saved ({} snapshot(s))", file.agent_count()),
+                            Ok(()) => {
+                                info!("Agent state saved ({} snapshot(s))", file.agent_count())
+                            }
                             Err(e) => warn!("Failed to save agent state: {e}"),
                         }
                     } else {
@@ -1247,7 +1279,7 @@ impl App {
     /// once a session file exists and the persister has been created.
     pub(crate) fn persist_goal(&mut self, objective: &str) {
         use phantom_session::{
-            GoalSnapshot, PlanStepBuilder, SavedFactConfidence, SavedFact, SavedStepStatus,
+            GoalSnapshot, PlanStepBuilder, SavedFact, SavedFactConfidence, SavedStepStatus,
         };
         use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -1263,22 +1295,28 @@ impl App {
 
         let initial_step = PlanStepBuilder::new(
             objective,
-            phantom_agents::AgentTask::FreeForm { prompt: objective.to_owned() },
+            phantom_agents::AgentTask::FreeForm {
+                prompt: objective.to_owned(),
+            },
         )
         .status(SavedStepStatus::Pending)
         .build();
 
         let snapshot = GoalSnapshot::new(
             objective.to_owned(),
-            vec![SavedFact::new("goal set by user", SavedFactConfidence::Verified, "commands")],
+            vec![SavedFact::new(
+                "goal set by user",
+                SavedFactConfidence::Verified,
+                "commands",
+            )],
             vec![initial_step],
-            vec![],   // plan_history: no prior plans yet
-            0,        // stall_counter
-            2,        // stall_threshold (matches brain default)
-            0,        // replan_count
-            5,        // max_replans (matches brain default)
+            vec![], // plan_history: no prior plans yet
+            0,      // stall_counter
+            2,      // stall_threshold (matches brain default)
+            0,      // replan_count
+            5,      // max_replans (matches brain default)
             created_at_secs,
-            None,     // last_replan_at_secs
+            None, // last_replan_at_secs
         );
 
         match gp.save_goals(vec![snapshot]) {
@@ -1379,7 +1417,8 @@ impl App {
 /// — the rest of the app continues to boot and Dispatcher-role agents see
 /// `"ticket dispatcher not configured"` from the dispatch layer instead of
 /// a panic.
-fn build_ticket_dispatcher() -> Option<std::sync::Arc<phantom_agents::dispatcher::GhTicketDispatcher>> {
+fn build_ticket_dispatcher()
+-> Option<std::sync::Arc<phantom_agents::dispatcher::GhTicketDispatcher>> {
     let token = std::env::var("GITHUB_TOKEN").ok();
     let repo = std::env::var("GH_REPO").ok();
 

--- a/crates/phantom-app/src/boot.rs
+++ b/crates/phantom-app/src/boot.rs
@@ -1314,7 +1314,11 @@ mod tests {
         seq.dismiss();
         seq.update(0.6); // through transition (0.5 s)
         assert!(seq.is_done(), "boot should be Done ~0.5 s after dismiss");
-        assert!(seq.elapsed() < 8.0, "elapsed {} exceeds 8 s budget", seq.elapsed());
+        assert!(
+            seq.elapsed() < 8.0,
+            "elapsed {} exceeds 8 s budget",
+            seq.elapsed()
+        );
     }
 
     /// Shell responsiveness stub: after Done, visible_text is empty and

--- a/crates/phantom-app/src/commands.rs
+++ b/crates/phantom-app/src/commands.rs
@@ -9,7 +9,7 @@ use phantom_agents::cli::{AgentCommand, parse_agent_command};
 use phantom_agents::{AgentSpawnOpts, AgentTask};
 use phantom_nlp::NlpInterpreter;
 use phantom_nlp::interpreter::ResolvedAction;
-use phantom_nlp::{translate, Intent};
+use phantom_nlp::{Intent, translate};
 use phantom_protocol::{AppMessage, SupervisorCommand};
 use phantom_ui::themes;
 
@@ -257,6 +257,43 @@ impl App {
                     }
                 }
             }
+            "detach" => {
+                // Manually trigger the alt-screen split for the focused terminal.
+                // Normally this happens automatically on alt-screen entry; `detach`
+                // lets the user force-split when already in alt-screen mode.
+                if let Some(focused_id) = self.coordinator.focused() {
+                    let state = self.coordinator.get_state(focused_id);
+                    let is_detached = state
+                        .as_ref()
+                        .and_then(|s| s.get("is_detached"))
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    if is_detached && !self.alt_screen_secondaries.contains_key(&focused_id) {
+                        let label = state
+                            .as_ref()
+                            .and_then(|s| s.get("detached_label"))
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("interactive")
+                            .to_owned();
+                        if let Some(secondary_id) =
+                            self.split_for_alt_screen(focused_id, label.clone())
+                        {
+                            self.console
+                                .system(format!("Detached {label} into pane {secondary_id}"));
+                        } else {
+                            self.console.error("Detach failed: could not split pane");
+                        }
+                    } else if is_detached {
+                        self.console.output("Already detached — pane is active");
+                    } else {
+                        self.console
+                            .output("No interactive subprocess detected (not in alt-screen)");
+                    }
+                } else {
+                    self.console.error("No focused pane");
+                }
+                self.console.open = false;
+            }
             "sysmon" | "monitor" | "stats" => {
                 self.sysmon_visible = !self.sysmon_visible;
                 self.sysmon.set_active(self.sysmon_visible);
@@ -373,9 +410,7 @@ impl App {
                 }
             }
             cmd if cmd == "history" || cmd.starts_with("history ") => {
-                let limit: usize = parts.get(1)
-                    .and_then(|s| s.parse().ok())
-                    .unwrap_or(20);
+                let limit: usize = parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(20);
                 match self.history {
                     None => self.console.output("History store not available."),
                     Some(ref store) => {
@@ -391,7 +426,8 @@ impl App {
                             Ok(entries) => {
                                 let start_num = total.saturating_sub(entries.len());
                                 for (i, e) in entries.iter().enumerate() {
-                                    let code = e.exit_code()
+                                    let code = e
+                                        .exit_code()
                                         .map(|c| format!(" [exit {c}]"))
                                         .unwrap_or_default();
                                     self.console.output(format!(
@@ -425,20 +461,32 @@ impl App {
                 self.console.output("  theme <name>        Switch theme");
                 self.console.output("  agent <prompt>      Spawn AI agent");
                 self.console
+                    .output("  detach              Detach alt-screen program into tethered pane");
+                self.console
                     .output("  sysmon              Toggle system monitor");
                 self.console
                     .output("  appmon              Toggle app diagnostics");
                 self.console.output("  plugins             List plugins");
-                self.console.output("  plain               Disable all CRT effects");
-                self.console.output("  debug               Toggle shader debug HUD");
-                self.console.output("  reload              Reload config from disk");
-                self.console.output("  boot                Replay boot sequence");
-                self.console.output("  video <path>        Play video through CRT shader");
-                self.console.output("  history [N]         Show last N commands (default 20)");
-                self.console.output("  suggestions         List dismissed/expired suggestion history");
-                self.console.output("  selftest            Brain exercises its own features");
-                self.console.output("  selfheal            selftest + auto-fix + commit + push");
-                self.console.output("  clear               Clear console history");
+                self.console
+                    .output("  plain               Disable all CRT effects");
+                self.console
+                    .output("  debug               Toggle shader debug HUD");
+                self.console
+                    .output("  reload              Reload config from disk");
+                self.console
+                    .output("  boot                Replay boot sequence");
+                self.console
+                    .output("  video <path>        Play video through CRT shader");
+                self.console
+                    .output("  history [N]         Show last N commands (default 20)");
+                self.console
+                    .output("  suggestions         List dismissed/expired suggestion history");
+                self.console
+                    .output("  selftest            Brain exercises its own features");
+                self.console
+                    .output("  selfheal            selftest + auto-fix + commit + push");
+                self.console
+                    .output("  clear               Clear console history");
                 self.console.output("  quit                Exit Phantom");
             }
             _other => {
@@ -596,9 +644,8 @@ impl App {
                     let ctx_ref: &phantom_context::ProjectContext = match ctx {
                         Some(ref c) => c,
                         None => {
-                            detected = phantom_context::ProjectContext::detect(
-                                std::path::Path::new("."),
-                            );
+                            detected =
+                                phantom_context::ProjectContext::detect(std::path::Path::new("."));
                             &detected
                         }
                     };
@@ -628,30 +675,30 @@ impl App {
                 Err(e) => {
                     warn!("Failed to spawn nlp-translate thread: {e}");
                     // Thread spawn failed — fall back to direct agent spawn.
-                    self.console.system(format!("Spawning agent: {input_owned}"));
-                    self.pending_brain_actions.push(
-                        phantom_brain::events::AiAction::SpawnAgent {
+                    self.console
+                        .system(format!("Spawning agent: {input_owned}"));
+                    self.pending_brain_actions
+                        .push(phantom_brain::events::AiAction::SpawnAgent {
                             task: phantom_agents::AgentTask::FreeForm {
                                 prompt: input_owned,
                             },
                             spawn_tag: None,
                             disposition: phantom_agents::dispatch::Disposition::Chat,
-                        }
-                    );
+                        });
                 }
             }
         } else {
             // No LLM backend — spawn agent directly.
-            self.console.system(format!("Spawning agent: {input_owned}"));
-            self.pending_brain_actions.push(
-                phantom_brain::events::AiAction::SpawnAgent {
+            self.console
+                .system(format!("Spawning agent: {input_owned}"));
+            self.pending_brain_actions
+                .push(phantom_brain::events::AiAction::SpawnAgent {
                     task: phantom_agents::AgentTask::FreeForm {
                         prompt: input_owned,
                     },
                     spawn_tag: None,
                     disposition: phantom_agents::dispatch::Disposition::Chat,
-                }
-            );
+                });
         }
     }
 }

--- a/crates/phantom-app/src/console.rs
+++ b/crates/phantom-app/src/console.rs
@@ -386,7 +386,11 @@ mod history_tests {
         c.submit();
         c.input = "build".into();
         c.submit();
-        assert_eq!(c.command_history.len(), 1, "identical adjacent commands must not be duplicated");
+        assert_eq!(
+            c.command_history.len(),
+            1,
+            "identical adjacent commands must not be duplicated"
+        );
     }
 
     // submit() returns the trimmed command string.

--- a/crates/phantom-app/src/coordinator.rs
+++ b/crates/phantom-app/src/coordinator.rs
@@ -1820,7 +1820,9 @@ mod tests {
 
         // Start with one pane.
         let id_a = register_mock(&mut coord, &mut layout, &mut scene, content, "original");
-        let p_a = coord.pane_id_for(id_a).expect("original pane must have a PaneId");
+        let p_a = coord
+            .pane_id_for(id_a)
+            .expect("original pane must have a PaneId");
         assert_eq!(coord.adapter_count(), 1);
         assert_eq!(coord.focused(), Some(id_a));
 
@@ -1840,14 +1842,22 @@ mod tests {
         coord.set_focus(id_b);
 
         // Two adapters now registered.
-        assert_eq!(coord.adapter_count(), 2, "expected 2 adapters after H-split");
+        assert_eq!(
+            coord.adapter_count(),
+            2,
+            "expected 2 adapters after H-split"
+        );
 
         // Both must have unique, valid IDs.
         assert_ne!(id_a, id_b, "both adapters must have distinct IDs");
 
         // PaneIds must be distinct.
-        let pane_a = coord.pane_id_for(id_a).expect("original adapter must have a PaneId");
-        let pane_b = coord.pane_id_for(id_b).expect("new adapter must have a PaneId");
+        let pane_a = coord
+            .pane_id_for(id_a)
+            .expect("original adapter must have a PaneId");
+        let pane_b = coord
+            .pane_id_for(id_b)
+            .expect("new adapter must have a PaneId");
         assert_ne!(pane_a, pane_b, "both adapters must own different PaneIds");
 
         // Focus must be on the newly created pane.
@@ -1857,8 +1867,14 @@ mod tests {
         layout.resize(800.0, 600.0).unwrap();
         let rect_a = layout.get_pane_rect(pane_a).unwrap();
         let rect_b = layout.get_pane_rect(pane_b).unwrap();
-        assert!(rect_a.width > 0.0 && rect_a.height > 0.0, "original pane must have positive area");
-        assert!(rect_b.width > 0.0 && rect_b.height > 0.0, "new pane must have positive area");
+        assert!(
+            rect_a.width > 0.0 && rect_a.height > 0.0,
+            "original pane must have positive area"
+        );
+        assert!(
+            rect_b.width > 0.0 && rect_b.height > 0.0,
+            "new pane must have positive area"
+        );
     }
 
     // ── QA #160: Vertical split with three panes ──────────────────────────────
@@ -1906,11 +1922,18 @@ mod tests {
         coord.set_focus(id_c);
 
         // Three adapters must exist.
-        assert_eq!(coord.adapter_count(), 3, "expected 3 adapters after V-split");
+        assert_eq!(
+            coord.adapter_count(),
+            3,
+            "expected 3 adapters after V-split"
+        );
 
         // All must have distinct IDs and PaneIds.
         let ids = [id_a, id_b, id_c];
-        let pane_ids: Vec<_> = ids.iter().map(|&id| coord.pane_id_for(id).unwrap()).collect();
+        let pane_ids: Vec<_> = ids
+            .iter()
+            .map(|&id| coord.pane_id_for(id).unwrap())
+            .collect();
         for i in 0..3 {
             for j in (i + 1)..3 {
                 assert_ne!(ids[i], ids[j], "adapter IDs must be unique");
@@ -1924,7 +1947,8 @@ mod tests {
             let rect = layout.get_pane_rect(pid).unwrap();
             assert!(
                 rect.width > 0.0 && rect.height > 0.0,
-                "pane[{idx}] must have positive area: {:?}", rect,
+                "pane[{idx}] must have positive area: {:?}",
+                rect,
             );
         }
 
@@ -1978,7 +2002,10 @@ mod tests {
         );
 
         // The survivor must be the original adapter.
-        assert_eq!(survivor, id_a, "the surviving pane must be the original pane");
+        assert_eq!(
+            survivor, id_a,
+            "the surviving pane must be the original pane"
+        );
     }
 
     /// Closing the last pane must not set focus to a non-existent adapter.
@@ -1996,7 +2023,11 @@ mod tests {
 
         coord.remove_adapter(id, &mut layout, &mut scene);
 
-        assert_eq!(coord.focused(), None, "focus must be None after closing the last pane");
+        assert_eq!(
+            coord.focused(),
+            None,
+            "focus must be None after closing the last pane"
+        );
         assert!(coord.all_app_ids().is_empty(), "no adapters must remain");
     }
 

--- a/crates/phantom-app/src/inspector.rs
+++ b/crates/phantom-app/src/inspector.rs
@@ -332,10 +332,16 @@ mod tests {
             .with_denial(denial(2, 2_000))
             .with_denial(denial(1, 3_000))
             .build();
-        let agent1_denials: Vec<_> = view.denials.iter()
+        let agent1_denials: Vec<_> = view
+            .denials
+            .iter()
             .filter(|d| d.role == "agent-1")
             .collect();
-        assert_eq!(agent1_denials.len(), 2, "expected exactly 2 denials for agent-1");
+        assert_eq!(
+            agent1_denials.len(),
+            2,
+            "expected exactly 2 denials for agent-1"
+        );
         for d in &agent1_denials {
             assert_eq!(d.role, "agent-1");
         }
@@ -347,7 +353,9 @@ mod tests {
         let view = InspectorBuilder::new()
             .with_denial(denial(1, 1_000))
             .build();
-        let unknown: Vec<_> = view.denials.iter()
+        let unknown: Vec<_> = view
+            .denials
+            .iter()
             .filter(|d| d.role == "agent-999")
             .collect();
         assert!(unknown.is_empty());

--- a/crates/phantom-app/src/mouse.rs
+++ b/crates/phantom-app/src/mouse.rs
@@ -11,7 +11,7 @@ use log::debug;
 use winit::event::{ElementState, MouseButton, MouseScrollDelta};
 
 use phantom_terminal::input::{
-    encode_mouse_motion_sgr, encode_mouse_sgr, MouseButton as TermMouseButton,
+    MouseButton as TermMouseButton, encode_mouse_motion_sgr, encode_mouse_sgr,
 };
 
 use crate::app::{App, FloatInteraction, ResizeEdge};
@@ -416,8 +416,12 @@ impl App {
             //   • multi-pane   → track anchored to the chrome-inset inner_rect
             let tiled_count = self.coordinator.all_app_ids().len();
             for app_id in self.coordinator.all_app_ids() {
-                let Some(pane_id) = self.coordinator.pane_id_for(app_id) else { continue };
-                let Ok(layout_rect) = self.layout.get_pane_rect(pane_id) else { continue };
+                let Some(pane_id) = self.coordinator.pane_id_for(app_id) else {
+                    continue;
+                };
+                let Ok(layout_rect) = self.layout.get_pane_rect(pane_id) else {
+                    continue;
+                };
                 let track = if tiled_count <= 1 {
                     scrollbar_track_rect(phantom_ui::layout::Rect {
                         x: layout_rect.x,
@@ -731,7 +735,7 @@ mod tests {
     /// chrome-inset correction in single-pane mode.
     #[test]
     fn scrollbar_track_rect_single_pane_anchoring() {
-        use crate::pane::{scrollbar_track_rect, SCROLLBAR_WIDTH};
+        use crate::pane::{SCROLLBAR_WIDTH, scrollbar_track_rect};
 
         // Simulate a full-screen layout rect (no chrome insets applied).
         let layout_rect = phantom_ui::layout::Rect {
@@ -746,17 +750,29 @@ mod tests {
 
         // Track x must be at the right edge minus scrollbar width and margin.
         let expected_x = layout_rect.x + layout_rect.width - SCROLLBAR_WIDTH - margin;
-        assert!((track.x - expected_x).abs() < 0.01,
-            "track.x={} expected {}", track.x, expected_x);
+        assert!(
+            (track.x - expected_x).abs() < 0.01,
+            "track.x={} expected {}",
+            track.x,
+            expected_x
+        );
 
         // Track y starts at layout_rect.y + margin.
-        assert!((track.y - (layout_rect.y + margin)).abs() < 0.01,
-            "track.y={} expected {}", track.y, layout_rect.y + margin);
+        assert!(
+            (track.y - (layout_rect.y + margin)).abs() < 0.01,
+            "track.y={} expected {}",
+            track.y,
+            layout_rect.y + margin
+        );
 
         // Track height is inset by margin on both ends.
         let expected_h = layout_rect.height - margin * 2.0;
-        assert!((track.height - expected_h).abs() < 0.01,
-            "track.height={} expected {}", track.height, expected_h);
+        assert!(
+            (track.height - expected_h).abs() < 0.01,
+            "track.height={} expected {}",
+            track.height,
+            expected_h
+        );
 
         assert_eq!(track.width, SCROLLBAR_WIDTH);
     }
@@ -766,7 +782,12 @@ mod tests {
     fn scrollbar_thumb_absent_without_history() {
         use crate::pane::{scrollbar_thumb_rect, scrollbar_track_rect};
 
-        let rect = phantom_ui::layout::Rect { x: 0.0, y: 0.0, width: 800.0, height: 600.0 };
+        let rect = phantom_ui::layout::Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 800.0,
+            height: 600.0,
+        };
         let track = scrollbar_track_rect(rect);
         assert!(scrollbar_thumb_rect(track, 0, 0, 24).is_none());
     }
@@ -776,7 +797,12 @@ mod tests {
     fn scrollbar_thumb_present_with_history() {
         use crate::pane::{scrollbar_thumb_rect, scrollbar_track_rect};
 
-        let rect = phantom_ui::layout::Rect { x: 0.0, y: 0.0, width: 800.0, height: 600.0 };
+        let rect = phantom_ui::layout::Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 800.0,
+            height: 600.0,
+        };
         let track = scrollbar_track_rect(rect);
         let thumb = scrollbar_thumb_rect(track, 0, 500, 24);
         assert!(thumb.is_some(), "thumb should exist when history_size > 0");
@@ -800,7 +826,7 @@ mod tests {
 
     #[test]
     fn cursor_to_cell_single_pane_no_chrome_offset() {
-        use crate::pane::{container_rect, pane_inner_rect, CONTAINER_TITLE_H_CELLS};
+        use crate::pane::{CONTAINER_TITLE_H_CELLS, container_rect, pane_inner_rect};
         use phantom_ui::layout::Rect;
 
         let cell_w = 8.0_f32;
@@ -808,7 +834,12 @@ mod tests {
         let cell_size = (cell_w, cell_h);
 
         // Full-screen layout rect (single-pane: no margin/chrome applied).
-        let layout_rect = Rect { x: 0.0, y: 0.0, width: 1280.0, height: 800.0 };
+        let layout_rect = Rect {
+            x: 0.0,
+            y: 0.0,
+            width: 1280.0,
+            height: 800.0,
+        };
 
         // -- Single-pane path (the fix) -------------------------------------
         // inner == layout_rect, so cursor (0,0) -> cell (0,0).
@@ -816,13 +847,18 @@ mod tests {
         let max_col = (inner_single.width / cell_w).floor() as usize;
         let max_row = (inner_single.height / cell_h).floor() as usize;
         let (col, row) = pixel_to_cell(
-            0.0, 0.0,
-            inner_single.x, inner_single.y,
-            cell_w, cell_h,
-            max_col.saturating_sub(1), max_row.saturating_sub(1),
+            0.0,
+            0.0,
+            inner_single.x,
+            inner_single.y,
+            cell_w,
+            cell_h,
+            max_col.saturating_sub(1),
+            max_row.saturating_sub(1),
         );
         assert_eq!(
-            (col, row), (0, 0),
+            (col, row),
+            (0, 0),
             "single-pane: cursor at (0,0) must map to cell (0,0); got ({col},{row})",
         );
 
@@ -834,7 +870,9 @@ mod tests {
         assert!(
             inner_multi.x > 0.0 || inner_multi.y > 0.0,
             "multi-pane inner rect must have a non-zero origin due to chrome insets; \
-             got ({}, {})", inner_multi.x, inner_multi.y,
+             got ({}, {})",
+            inner_multi.x,
+            inner_multi.y,
         );
 
         // inner.y must be at least one title-strip height from the window top,
@@ -843,7 +881,8 @@ mod tests {
         assert!(
             inner_multi.y >= title_h - 0.5,
             "multi-pane inner.y must be at least one title-strip height ({title_h}px) \
-             from the window top; got {}", inner_multi.y,
+             from the window top; got {}",
+            inner_multi.y,
         );
     }
 }

--- a/crates/phantom-app/src/pane.rs
+++ b/crates/phantom-app/src/pane.rs
@@ -258,6 +258,135 @@ impl App {
         }
     }
 
+    /// Split the focused terminal pane into two when it enters alt-screen mode.
+    ///
+    /// The primary pane (source) keeps its normal-screen buffer; a new sibling
+    /// `AltScreenViewAdapter` pane mirrors the alt-screen program. Both share
+    /// a `Arc<Mutex<Option<RenderOutput>>>` snapshot written by the primary on
+    /// each `update()` tick.
+    ///
+    /// Returns the `AppId` of the newly-created view pane, or `None` on failure.
+    pub(crate) fn split_for_alt_screen(
+        &mut self,
+        primary_app_id: phantom_adapter::AppId,
+        label: String,
+    ) -> Option<phantom_adapter::AppId> {
+        use crate::adapters::alt_screen_view::{AltScreenViewAdapter, new_snapshot};
+        use phantom_scene::clock::Cadence;
+
+        let current_pane_id = self.coordinator.pane_id_for(primary_app_id)?;
+
+        // Split horizontally: primary on the left, new view on the right.
+        let (existing_child, new_child) = match self.layout.split_horizontal(current_pane_id) {
+            Ok(ids) => ids,
+            Err(e) => {
+                warn!("split_for_alt_screen: layout split failed: {e}");
+                return None;
+            }
+        };
+
+        let width = self.gpu.surface_config.width;
+        let height = self.gpu.surface_config.height;
+        let _ = self.layout.resize(width as f32, height as f32);
+
+        // Remap primary adapter to the left child pane.
+        self.coordinator
+            .remap_pane(primary_app_id, current_pane_id, existing_child);
+
+        // Resize the primary terminal to fit the now-smaller left pane.
+        if let Ok(rect) = self.layout.get_pane_rect(existing_child) {
+            let (cols, rows) = pane_cols_rows(self.cell_size, rect);
+            let _ = self.coordinator.send_command(
+                primary_app_id,
+                "resize",
+                &serde_json::json!({"cols": cols, "rows": rows}),
+            );
+        }
+
+        // Create the shared snapshot Arc.
+        let snapshot = new_snapshot();
+
+        // Wire the snapshot into the primary adapter so it writes each frame.
+        if let Some(primary) = self
+            .coordinator
+            .registry_mut()
+            .get_adapter_mut(primary_app_id)
+        {
+            primary.attach_alt_screen_snapshot(std::sync::Arc::clone(&snapshot));
+        }
+
+        // Create the view adapter backed by the same snapshot.
+        let view_adapter = AltScreenViewAdapter::new(snapshot, label.clone());
+
+        let scene_node = self
+            .scene
+            .add_node(self.scene_content_node, phantom_scene::node::NodeKind::Pane);
+
+        let secondary_app_id = self.coordinator.register_adapter_at_pane(
+            Box::new(view_adapter),
+            new_child,
+            scene_node,
+            Cadence::unlimited(),
+            &mut self.layout,
+        );
+
+        // Record the mapping so update.rs can manage the fade/collapse lifecycle.
+        self.alt_screen_secondaries
+            .insert(primary_app_id, secondary_app_id);
+
+        info!(
+            "Alt-screen split: primary={primary_app_id} secondary={secondary_app_id} label={label:?}"
+        );
+        Some(secondary_app_id)
+    }
+
+    /// Collapse the secondary alt-screen pane after the fade animation completes.
+    ///
+    /// Called by `tick_alt_screen_fade` once the 300 ms transition is done.
+    pub(crate) fn collapse_alt_screen_pane(
+        &mut self,
+        primary_app_id: phantom_adapter::AppId,
+        secondary_app_id: phantom_adapter::AppId,
+    ) {
+        // Detach the snapshot from the primary adapter.
+        if let Some(primary) = self
+            .coordinator
+            .registry_mut()
+            .get_adapter_mut(primary_app_id)
+        {
+            primary.detach_alt_screen_snapshot();
+        }
+
+        // Remove the view adapter, its layout pane, and scene node.
+        self.coordinator
+            .remove_adapter(secondary_app_id, &mut self.layout, &mut self.scene);
+
+        // Reclaim layout space.
+        let width = self.gpu.surface_config.width;
+        let height = self.gpu.surface_config.height;
+        let _ = self.layout.resize(width as f32, height as f32);
+
+        // Resize remaining adapters to fill the reclaimed space.
+        for app_id in self.coordinator.all_app_ids() {
+            if let Some(pane_id) = self.coordinator.pane_id_for(app_id) {
+                if let Ok(rect) = self.layout.get_pane_rect(pane_id) {
+                    let (cols, rows) = pane_cols_rows(self.cell_size, rect);
+                    let _ = self.coordinator.send_command(
+                        app_id,
+                        "resize",
+                        &serde_json::json!({"cols": cols, "rows": rows}),
+                    );
+                }
+            }
+        }
+
+        // Remove tracking entries.
+        self.alt_screen_secondaries.remove(&primary_app_id);
+        self.alt_screen_fade.remove(&secondary_app_id);
+
+        info!("Alt-screen collapsed: primary={primary_app_id} secondary={secondary_app_id}");
+    }
+
     /// Close the focused pane and its terminal.
     pub(crate) fn close_focused_pane(&mut self) {
         let Some(focused_app_id) = self.coordinator.focused() else {
@@ -459,7 +588,12 @@ mod scroll_position_tests {
     const VIEWPORT: usize = 40;
 
     fn track() -> Rect {
-        Rect { x: 494.0, y: 50.0, width: 6.0, height: 400.0 }
+        Rect {
+            x: 494.0,
+            y: 50.0,
+            width: 6.0,
+            height: 400.0,
+        }
     }
 
     // scrollbar_y_to_offset maps a click y position to a display_offset.

--- a/crates/phantom-app/src/render.rs
+++ b/crates/phantom-app/src/render.rs
@@ -193,6 +193,11 @@ impl App {
                 self.build_context_menu_overlay(screen_size, &mut chrome_quads, &mut chrome_glyphs);
             }
 
+            // -- Alt-screen bezier tether (issue #2 process detach v1) --
+            if !self.alt_screen_secondaries.is_empty() {
+                self.build_alt_screen_tether(&mut chrome_quads);
+            }
+
             if !chrome_quads.is_empty() || !chrome_glyphs.is_empty() {
                 // Upload + render overlay in its own pass on the surface.
                 self.quad_renderer.prepare(

--- a/crates/phantom-app/src/render_overlay.rs
+++ b/crates/phantom-app/src/render_overlay.rs
@@ -747,6 +747,89 @@ impl App {
         }
     }
 
+    /// Build the bezier tether overlay for issue #2 alt-screen split panes.
+    ///
+    /// Draws a horizontal line of thin quad segments connecting the right edge
+    /// of the primary pane to the left edge of the secondary (alt-screen) pane.
+    /// Color is the theme foreground at low opacity so it adapts to all themes.
+    ///
+    /// The segments approximate a cubic bezier curve from the anchor point on
+    /// the primary to the anchor point on the secondary.  We use 8 segments for
+    /// a smooth-looking result without excessive quad count.
+    pub(crate) fn build_alt_screen_tether(&self, quads: &mut Vec<QuadInstance>) {
+        if self.alt_screen_secondaries.is_empty() {
+            return;
+        }
+
+        // Tether color: theme foreground at ~35% opacity.
+        let accent = self.theme.colors.foreground;
+        let color = [accent[0], accent[1], accent[2], 0.35];
+        let segment_thickness = 2.0;
+        const SEGMENTS: usize = 8;
+
+        for (&primary_id, &secondary_id) in &self.alt_screen_secondaries {
+            // Get layout rects for both panes.
+            let primary_pane = self.coordinator.pane_id_for(primary_id);
+            let secondary_pane = self.coordinator.pane_id_for(secondary_id);
+
+            let (Some(ppane), Some(spane)) = (primary_pane, secondary_pane) else {
+                continue;
+            };
+
+            let (Ok(primary_rect), Ok(secondary_rect)) = (
+                self.layout.get_pane_rect(ppane),
+                self.layout.get_pane_rect(spane),
+            ) else {
+                continue;
+            };
+
+            // Anchor: mid-right of primary, mid-left of secondary.
+            let p0x = primary_rect.x + primary_rect.width;
+            let p0y = primary_rect.y + primary_rect.height * 0.5;
+            let p3x = secondary_rect.x;
+            let p3y = secondary_rect.y + secondary_rect.height * 0.5;
+
+            // Control points: pull horizontally by 40% of the gap.
+            let gap = (p3x - p0x).abs();
+            let ctrl = gap * 0.4;
+            let p1x = p0x + ctrl;
+            let p1y = p0y;
+            let p2x = p3x - ctrl;
+            let p2y = p3y;
+
+            // Evaluate cubic bezier at SEGMENTS + 1 points and draw segments.
+            let mut prev_x = p0x;
+            let mut prev_y = p0y;
+            for i in 1..=SEGMENTS {
+                let t = i as f32 / SEGMENTS as f32;
+                let u = 1.0 - t;
+                let cx = u * u * u * p0x
+                    + 3.0 * u * u * t * p1x
+                    + 3.0 * u * t * t * p2x
+                    + t * t * t * p3x;
+                let cy = u * u * u * p0y
+                    + 3.0 * u * u * t * p1y
+                    + 3.0 * u * t * t * p2y
+                    + t * t * t * p3y;
+
+                // Draw a thin quad covering the segment line.
+                let dx = cx - prev_x;
+                let dy = cy - prev_y;
+                let len = (dx * dx + dy * dy).sqrt().max(0.5);
+
+                quads.push(QuadInstance {
+                    pos: [prev_x, prev_y - segment_thickness * 0.5],
+                    size: [len, segment_thickness],
+                    color,
+                    border_radius: 0.0,
+                });
+
+                prev_x = cx;
+                prev_y = cy;
+            }
+        }
+    }
+
     /// Helper: render a text string directly into the overlay glyph buffer.
     pub(crate) fn render_overlay_text(
         &mut self,

--- a/crates/phantom-app/src/runtime.rs
+++ b/crates/phantom-app/src/runtime.rs
@@ -218,9 +218,7 @@ impl AgentRuntime {
     /// Recovers from a poisoned mutex (#222) — the inner value is still
     /// usable after the thread that panicked released the guard.
     pub fn event_log(&self) -> std::sync::MutexGuard<'_, EventLog> {
-        self.event_log
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
+        self.event_log.lock().unwrap_or_else(|e| e.into_inner())
     }
 
     /// Clone the event-log handle for sharing with a
@@ -239,9 +237,7 @@ impl AgentRuntime {
     /// Recovers from a poisoned mutex (#222) — the inner value is still
     /// usable after the thread that panicked released the guard.
     pub fn registry(&self) -> std::sync::MutexGuard<'_, AgentRegistry> {
-        self.registry
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
+        self.registry.lock().unwrap_or_else(|e| e.into_inner())
     }
 
     /// Clone the registry handle for sharing with dispatch contexts. Same
@@ -281,10 +277,7 @@ impl AgentRuntime {
     ///
     /// Recovers from a poisoned mutex (#222).
     pub fn flush(&mut self) -> std::io::Result<()> {
-        let mut log = self
-            .event_log
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
+        let mut log = self.event_log.lock().unwrap_or_else(|e| e.into_inner());
         log.flush()
     }
 
@@ -311,10 +304,7 @@ impl AgentRuntime {
         // gets newest-on-bottom; the inspector adapter is free to reverse if
         // it prefers newest-on-top.
         let envelopes = {
-            let log = self
-                .event_log
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
+            let log = self.event_log.lock().unwrap_or_else(|e| e.into_inner());
             log.tail(phantom_agents::inspector::MAX_RECENT_EVENTS)
         };
         for env in &envelopes {
@@ -343,10 +333,7 @@ impl AgentRuntime {
             .map(|d| d.as_millis() as u64)
             .unwrap_or(0);
         let agent_refs: Vec<_> = {
-            let reg = self
-                .registry
-                .lock()
-                .unwrap_or_else(|e| e.into_inner());
+            let reg = self.registry.lock().unwrap_or_else(|e| e.into_inner());
             reg.list().into_iter().cloned().collect()
         };
         for agent_ref in agent_refs {

--- a/crates/phantom-app/src/update.rs
+++ b/crates/phantom-app/src/update.rs
@@ -8,14 +8,14 @@ use std::time::Instant;
 use anyhow::Result;
 use log::{debug, info, warn};
 
+use crate::app::{App, AppState, SuggestionOverlay};
+use crate::input::chrono_time_string;
 use phantom_brain::events::{AiAction, AiEvent};
 use phantom_brain::ooda::WorldState;
-use phantom_protocol::Event;
 use phantom_context::ProjectContext;
 use phantom_history::HistoryEntry;
 use phantom_mcp::{AppCommand, ScreenshotReply};
-use crate::app::{App, AppState, SuggestionOverlay};
-use crate::input::chrono_time_string;
+use phantom_protocol::Event;
 
 impl App {
     /// Per-frame update: read PTY data, advance boot sequence, update widgets.
@@ -35,6 +35,10 @@ impl App {
 
         // Coordinator: tick all registered adapters and deliver bus messages.
         self.coordinator.update_all(dt_duration);
+
+        // Alt-screen split-pane edge detection and collapse animation (issue #2).
+        self.poll_alt_screen_transitions();
+        self.tick_alt_screen_fade(dt);
 
         // Substrate runtime: reap dead supervisor children, drain pending
         // substrate events into the on-disk log, and evaluate spawn rules.
@@ -123,10 +127,16 @@ impl App {
 
             while let Some(action) = brain.try_recv_action() {
                 Self::execute_brain_action(
-                    action, now, &mut self.suggestion, &mut self.memory,
+                    action,
+                    now,
+                    &mut self.suggestion,
+                    &mut self.memory,
                     &mut self.notification_store,
-                    &mut self.console, &mut self.coordinator, &mut self.layout,
-                    &mut self.scene, &mut tasks_to_spawn,
+                    &mut self.console,
+                    &mut self.coordinator,
+                    &mut self.layout,
+                    &mut self.scene,
+                    &mut tasks_to_spawn,
                 );
             }
         }
@@ -154,10 +164,16 @@ impl App {
             let ooda_actions = self.ooda_loop.tick(&world, dt_ms);
             for action in ooda_actions {
                 Self::execute_brain_action(
-                    action, now, &mut self.suggestion, &mut self.memory,
+                    action,
+                    now,
+                    &mut self.suggestion,
+                    &mut self.memory,
                     &mut self.notification_store,
-                    &mut self.console, &mut self.coordinator, &mut self.layout,
-                    &mut self.scene, &mut tasks_to_spawn,
+                    &mut self.console,
+                    &mut self.coordinator,
+                    &mut self.layout,
+                    &mut self.scene,
+                    &mut tasks_to_spawn,
                 );
             }
         }
@@ -166,10 +182,16 @@ impl App {
         let pending = std::mem::take(&mut self.pending_brain_actions);
         for action in pending {
             Self::execute_brain_action(
-                action, now, &mut self.suggestion, &mut self.memory,
+                action,
+                now,
+                &mut self.suggestion,
+                &mut self.memory,
                 &mut self.notification_store,
-                &mut self.console, &mut self.coordinator, &mut self.layout,
-                &mut self.scene, &mut tasks_to_spawn,
+                &mut self.console,
+                &mut self.coordinator,
+                &mut self.layout,
+                &mut self.scene,
+                &mut tasks_to_spawn,
             );
         }
 
@@ -183,10 +205,16 @@ impl App {
                     self.console.system(res.display);
                     if let Some(action) = res.action {
                         Self::execute_brain_action(
-                            action, now, &mut self.suggestion, &mut self.memory,
+                            action,
+                            now,
+                            &mut self.suggestion,
+                            &mut self.memory,
                             &mut self.notification_store,
-                            &mut self.console, &mut self.coordinator, &mut self.layout,
-                            &mut self.scene, &mut tasks_to_spawn,
+                            &mut self.console,
+                            &mut self.coordinator,
+                            &mut self.layout,
+                            &mut self.scene,
+                            &mut tasks_to_spawn,
                         );
                     }
                 }
@@ -216,7 +244,9 @@ impl App {
             Err(_) => Vec::new(),
         };
         for req in pending_subagents {
-            let task = phantom_agents::AgentTask::FreeForm { prompt: req.task.clone() };
+            let task = phantom_agents::AgentTask::FreeForm {
+                prompt: req.task.clone(),
+            };
             // Wire role / label / chat_model from the SpawnSubagentRequest into
             // AgentSpawnOpts so the spawned pane runs under the requested role
             // and displays the requested label. Fixes #224 where these fields
@@ -523,12 +553,11 @@ impl App {
                     self.pane_last_command.insert(*app_id, command.clone());
                 }
                 Event::CommandComplete { app_id, exit_code } => {
-                    let command_text = self
-                        .pending_command_text
-                        .remove(app_id)
-                        .unwrap_or_default();
+                    let command_text = self.pending_command_text.remove(app_id).unwrap_or_default();
                     if let Some(ref mut store) = self.history {
-                        let cwd = self.context.as_ref()
+                        let cwd = self
+                            .context
+                            .as_ref()
                             .map(|c| std::path::PathBuf::from(&c.root))
                             .unwrap_or_else(|| std::path::PathBuf::from("."));
                         let entry = HistoryEntry::builder(&command_text, cwd, self.session_uuid)
@@ -570,22 +599,23 @@ impl App {
                         );
                         Some(AiEvent::CommandComplete(parsed))
                     }
-                    Event::AgentTaskComplete { agent_id, success, summary, spawn_tag } => {
-                        Some(AiEvent::AgentComplete {
-                            id: *agent_id,
-                            success: *success,
-                            summary: summary.clone(),
-                            spawn_tag: *spawn_tag,
-                        })
-                    }
-                    Event::AgentError { agent_id, error } => {
-                        Some(AiEvent::AgentComplete {
-                            id: *agent_id,
-                            success: false,
-                            summary: error.clone(),
-                            spawn_tag: None,
-                        })
-                    }
+                    Event::AgentTaskComplete {
+                        agent_id,
+                        success,
+                        summary,
+                        spawn_tag,
+                    } => Some(AiEvent::AgentComplete {
+                        id: *agent_id,
+                        success: *success,
+                        summary: summary.clone(),
+                        spawn_tag: *spawn_tag,
+                    }),
+                    Event::AgentError { agent_id, error } => Some(AiEvent::AgentComplete {
+                        id: *agent_id,
+                        success: false,
+                        summary: error.clone(),
+                        spawn_tag: None,
+                    }),
                     _ => None,
                 };
                 if let Some(event) = ai_event {
@@ -652,15 +682,19 @@ impl App {
                     );
                 }
             }
-            AiAction::SpawnAgent { task, spawn_tag, disposition } => {
+            AiAction::SpawnAgent {
+                task,
+                spawn_tag,
+                disposition,
+            } => {
                 info!(
                     "[PHANTOM]: Spawning agent \
                      (spawn_tag={spawn_tag:?}, disposition={disposition:?}, \
                      auto_approve={})...",
                     disposition.auto_approve(),
                 );
-                let mut opts = phantom_agents::AgentSpawnOpts::new(task)
-                    .with_disposition(disposition);
+                let mut opts =
+                    phantom_agents::AgentSpawnOpts::new(task).with_disposition(disposition);
                 opts.spawn_tag = spawn_tag;
                 tasks_to_spawn.push(opts);
             }
@@ -685,13 +719,25 @@ impl App {
             AiAction::AgentFlatlined { id, reason } => {
                 info!("[PHANTOM]: Agent {id} flatlined: {reason}");
             }
-            AiAction::Suggest { action, rationale, confidence } => {
-                info!("[PHANTOM]: Proactive suggestion (confidence={confidence:.2}): {action} — {rationale}");
+            AiAction::Suggest {
+                action,
+                rationale,
+                confidence,
+            } => {
+                info!(
+                    "[PHANTOM]: Proactive suggestion (confidence={confidence:.2}): {action} — {rationale}"
+                );
             }
-            AiAction::QuarantineAgent { agent_id, denial_count } => {
+            AiAction::QuarantineAgent {
+                agent_id,
+                denial_count,
+            } => {
                 info!("[PHANTOM]: Quarantining agent {agent_id} after {denial_count} denials");
             }
-            AiAction::AgentQuarantined { agent_id, denial_count } => {
+            AiAction::AgentQuarantined {
+                agent_id,
+                denial_count,
+            } => {
                 info!("[PHANTOM]: Agent {agent_id} quarantined ({denial_count} denials)");
             }
             AiAction::DoNothing => {}
@@ -927,19 +973,21 @@ impl App {
         use phantom_renderer::shader_loader::ShaderEvent;
 
         loop {
-            let Some(event) = self.shader_reloader.poll() else { break };
+            let Some(event) = self.shader_reloader.poll() else {
+                break;
+            };
             match event {
-                ShaderEvent::Reloaded { ref name, ref source } if name == "crt" => {
-                    match self.postfx.reload_shader(&self.gpu.device, source) {
-                        Ok(()) => log::info!("live-reload: crt.wgsl pipeline swapped"),
-                        Err(msg) => {
-                            let message = format!(
-                                "crt.wgsl hot-swap failed — {msg}. Last-good shader active."
-                            );
-                            self.push_shader_error_banner(message, now_ms);
-                        }
+                ShaderEvent::Reloaded {
+                    ref name,
+                    ref source,
+                } if name == "crt" => match self.postfx.reload_shader(&self.gpu.device, source) {
+                    Ok(()) => log::info!("live-reload: crt.wgsl pipeline swapped"),
+                    Err(msg) => {
+                        let message =
+                            format!("crt.wgsl hot-swap failed — {msg}. Last-good shader active.");
+                        self.push_shader_error_banner(message, now_ms);
                     }
-                }
+                },
                 ShaderEvent::Reloaded { name, .. } => {
                     log::debug!("live-reload: {name}.wgsl reloaded (no pipeline swap yet)");
                 }
@@ -955,12 +1003,117 @@ impl App {
 
     /// Push a Severity::Warn banner from a shader reload failure.
     fn push_shader_error_banner(&mut self, message: String, now_ms: u64) {
-        use crate::notifications::{Banner, Severity, DEFAULT_BANNER_TTL_MS};
+        use crate::notifications::{Banner, DEFAULT_BANNER_TTL_MS, Severity};
         self.notifications.push_banner(Banner {
             message,
             severity: Severity::Warn,
             expires_at_ms: now_ms.saturating_add(DEFAULT_BANNER_TTL_MS),
         });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Alt-screen split-pane lifecycle (issue #2, process detach v1)
+// ---------------------------------------------------------------------------
+
+impl App {
+    /// Detect rising/falling edges on each terminal adapter's `is_detached`
+    /// state and trigger the appropriate split or collapse action.
+    ///
+    /// On rising edge (`is_detached` false → true): calls `split_for_alt_screen`.
+    /// On falling edge (`is_detached` true → false): queues the secondary pane
+    /// for fade-out via `alt_screen_fade`.
+    pub(crate) fn poll_alt_screen_transitions(&mut self) {
+        let all_ids: Vec<phantom_adapter::AppId> = self.coordinator.all_app_ids();
+
+        // Collect transitions (avoid borrow conflict with self.coordinator).
+        let mut to_split: Vec<(phantom_adapter::AppId, String)> = Vec::new();
+
+        for &app_id in &all_ids {
+            let state = self
+                .coordinator
+                .registry()
+                .get_adapter(app_id)
+                .map(|a| a.get_state());
+            let Some(state) = state else { continue };
+
+            let is_terminal = state.get("type").and_then(|v| v.as_str()) == Some("terminal");
+            if !is_terminal {
+                continue;
+            }
+
+            let is_detached = state
+                .get("is_detached")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let label = state
+                .get("detached_label")
+                .and_then(|v| v.as_str())
+                .unwrap_or("interactive")
+                .to_owned();
+
+            let prev = self.prev_detached.get(&app_id).copied().unwrap_or(false);
+            self.prev_detached.insert(app_id, is_detached);
+
+            // Rising edge: terminal just entered alt-screen.
+            if is_detached && !prev && !self.alt_screen_secondaries.contains_key(&app_id) {
+                to_split.push((app_id, label));
+            }
+
+            // Falling edge: terminal just left alt-screen.
+            if !is_detached && prev {
+                if let Some(&secondary_id) = self.alt_screen_secondaries.get(&app_id) {
+                    // Start fade animation if not already fading.
+                    self.alt_screen_fade.entry(secondary_id).or_insert(0.0);
+                }
+            }
+        }
+
+        for (primary_id, label) in to_split {
+            self.split_for_alt_screen(primary_id, label);
+        }
+    }
+
+    /// Advance the 300 ms collapse fade for secondary alt-screen panes.
+    ///
+    /// Once a secondary pane's fade timer reaches 1.0 it is queued for removal
+    /// and `collapse_alt_screen_pane` is called to clean up layout and scene.
+    pub(crate) fn tick_alt_screen_fade(&mut self, dt: f32) {
+        const FADE_DURATION: f32 = 0.3; // 300 ms
+
+        // Collect secondaries whose fade is complete this frame.
+        let mut completed: Vec<phantom_adapter::AppId> = Vec::new();
+        for (secondary_id, progress) in self.alt_screen_fade.iter_mut() {
+            *progress += dt / FADE_DURATION;
+            if *progress >= 1.0 {
+                completed.push(*secondary_id);
+            }
+        }
+
+        // Build reverse map (secondary → primary) so we can pass both to collapse.
+        let reverse: std::collections::HashMap<phantom_adapter::AppId, phantom_adapter::AppId> =
+            self.alt_screen_secondaries
+                .iter()
+                .map(|(&primary, &secondary)| (secondary, primary))
+                .collect();
+
+        // Drain completed fades into pending_collapses (deduped).
+        for secondary_id in completed {
+            if !self.alt_screen_pending_collapses.contains(&secondary_id) {
+                self.alt_screen_pending_collapses.push(secondary_id);
+            }
+        }
+
+        // Collapse any ready panes.
+        let collapsing: Vec<_> = self.alt_screen_pending_collapses.drain(..).collect();
+        for secondary_id in collapsing {
+            if let Some(&primary_id) = reverse.get(&secondary_id) {
+                self.collapse_alt_screen_pane(primary_id, secondary_id);
+            } else {
+                // Primary already gone — clean up orphaned fade entry.
+                self.alt_screen_fade.remove(&secondary_id);
+            }
+        }
     }
 }
 
@@ -1166,11 +1319,9 @@ mod tests {
 
         // ---- replicate the timeout guard from App::update ----
         if git_refresh_handle.is_some() {
-            let timed_out = git_refresh_spawned_at
-                .is_some_and(|t| now.duration_since(t) > GIT_REFRESH_TIMEOUT);
-            let finished = git_refresh_handle
-                .as_ref()
-                .is_some_and(|h| h.is_finished());
+            let timed_out =
+                git_refresh_spawned_at.is_some_and(|t| now.duration_since(t) > GIT_REFRESH_TIMEOUT);
+            let finished = git_refresh_handle.as_ref().is_some_and(|h| h.is_finished());
             if timed_out {
                 git_refresh_handle = None;
                 git_refresh_spawned_at = None;
@@ -1219,11 +1370,9 @@ mod tests {
         let mut git_refresh_spawned_at: Option<Instant> = spawned_at;
 
         if git_refresh_handle.is_some() {
-            let timed_out = git_refresh_spawned_at
-                .is_some_and(|t| now.duration_since(t) > GIT_REFRESH_TIMEOUT);
-            let finished = git_refresh_handle
-                .as_ref()
-                .is_some_and(|h| h.is_finished());
+            let timed_out =
+                git_refresh_spawned_at.is_some_and(|t| now.duration_since(t) > GIT_REFRESH_TIMEOUT);
+            let finished = git_refresh_handle.as_ref().is_some_and(|h| h.is_finished());
             if timed_out {
                 git_refresh_handle = None;
                 git_refresh_spawned_at = None;

--- a/crates/phantom-app/tests/boot_smoke.rs
+++ b/crates/phantom-app/tests/boot_smoke.rs
@@ -136,6 +136,7 @@ fn brain_spawns_and_channel_is_open() {
         enable_memory: false,
         quiet_threshold: 1.0, // suppress all actions so the thread stays quiet
         router: None,
+        catalog: None,
     });
 
     // The channel must be open immediately after spawn.
@@ -195,6 +196,7 @@ fn boot_smoke_full_invariants() {
         enable_memory: false,
         quiet_threshold: 1.0,
         router: None,
+        catalog: None,
     });
 
     assert!(

--- a/crates/phantom-app/tests/history_wiring_smoke.rs
+++ b/crates/phantom-app/tests/history_wiring_smoke.rs
@@ -92,7 +92,9 @@ fn history_recent_limit_exceeds_total() {
     let (mut store, _dir) = temp_store();
     let session = Uuid::new_v4();
 
-    store.append(&make_entry("only-one", session)).expect("append");
+    store
+        .append(&make_entry("only-one", session))
+        .expect("append");
     let recent = store.recent(100).expect("recent");
     assert_eq!(recent.len(), 1);
     assert_eq!(recent[0].command(), "only-one");

--- a/crates/phantom-app/tests/nlp_translate_integration.rs
+++ b/crates/phantom-app/tests/nlp_translate_integration.rs
@@ -4,17 +4,15 @@
 //! the `PhantomConfig::nlp_llm_enabled` flag without constructing a live `App`
 //! (which requires a GPU context).
 
-use phantom_nlp::{Intent, MockLlmBackend, translate};
 use phantom_context::ProjectContext;
+use phantom_nlp::{Intent, MockLlmBackend, translate};
 
 // ---------------------------------------------------------------------------
 // Helper: detect real project context for tests.
 // ---------------------------------------------------------------------------
 
 fn rust_ctx() -> ProjectContext {
-    ProjectContext::detect(std::path::Path::new(
-        env!("CARGO_MANIFEST_DIR"),
-    ))
+    ProjectContext::detect(std::path::Path::new(env!("CARGO_MANIFEST_DIR")))
 }
 
 // ---------------------------------------------------------------------------
@@ -40,9 +38,8 @@ fn translate_spawn_agent_with_mock() {
 #[test]
 fn translate_search_history_with_mock() {
     let ctx = rust_ctx();
-    let backend = MockLlmBackend::new(
-        r#"{"intent":"SearchHistory","query":"recent git commits today"}"#,
-    );
+    let backend =
+        MockLlmBackend::new(r#"{"intent":"SearchHistory","query":"recent git commits today"}"#);
     let intent = translate("what changed today", &ctx, &backend).unwrap();
     assert!(matches!(intent, Intent::SearchHistory { .. }));
     assert_eq!(intent.query(), Some("recent git commits today"));
@@ -51,9 +48,8 @@ fn translate_search_history_with_mock() {
 #[test]
 fn translate_clarify_for_ambiguous_input() {
     let ctx = rust_ctx();
-    let backend = MockLlmBackend::new(
-        r#"{"intent":"Clarify","question":"What exactly do you want to do?"}"#,
-    );
+    let backend =
+        MockLlmBackend::new(r#"{"intent":"Clarify","question":"What exactly do you want to do?"}"#);
     let intent = translate("xyzzy frobnicate", &ctx, &backend).unwrap();
     assert!(matches!(intent, Intent::Clarify { .. }));
     assert_eq!(intent.question(), Some("What exactly do you want to do?"));

--- a/crates/phantom-app/tests/phase5_integration.rs
+++ b/crates/phantom-app/tests/phase5_integration.rs
@@ -722,8 +722,8 @@ fn b226_command_complete_with_real_output_yields_nonzero_fix_score() {
     let raw_output = "error[E0308]: mismatched types\n  --> src/main.rs:5:9\n   |\n5  |     return \"hello\";\n   |            ^^^^^^^ expected `i32`, found `&str`";
     let parsed = phantom_semantic::parser::SemanticParser::parse(
         "cargo build",
-        "",          // stdout: empty — mirrors production call
-        raw_output,  // stderr slot: PTY buffer — mirrors production call
+        "",         // stdout: empty — mirrors production call
+        raw_output, // stderr slot: PTY buffer — mirrors production call
         Some(1),
     );
 
@@ -731,10 +731,17 @@ fn b226_command_complete_with_real_output_yields_nonzero_fix_score() {
     assert!(
         !parsed.errors.is_empty(),
         "SemanticParser must detect errors in real compiler output; got errors={:?}, raw_output={:?}",
-        parsed.errors, parsed.raw_output
+        parsed.errors,
+        parsed.raw_output
     );
-    assert_eq!(parsed.command, "cargo build", "ParsedOutput must carry the command string");
-    assert!(!parsed.raw_output.is_empty(), "ParsedOutput must carry the raw output");
+    assert_eq!(
+        parsed.command, "cargo build",
+        "ParsedOutput must carry the command string"
+    );
+    assert!(
+        !parsed.raw_output.is_empty(),
+        "ParsedOutput must carry the raw output"
+    );
 
     // Confirm the brain scorer produces a non-zero fix score for this event.
     let mut scorer = UtilityScorer::new();

--- a/crates/phantom-ui/src/themes.rs
+++ b/crates/phantom-ui/src/themes.rs
@@ -594,8 +594,14 @@ mod tests {
             builtin_by_name("nonexistent").is_none(),
             "unknown theme must return None",
         );
-        assert!(builtin_by_name("").is_none(), "empty string must return None");
-        assert!(builtin_by_name("NEON").is_none(), "unregistered name must return None");
+        assert!(
+            builtin_by_name("").is_none(),
+            "empty string must return None"
+        );
+        assert!(
+            builtin_by_name("NEON").is_none(),
+            "unregistered name must return None"
+        );
     }
 
     /// Foreground colors must differ between themes.
@@ -604,7 +610,7 @@ mod tests {
     #[test]
     fn qa_169_themes_have_distinct_foreground_colors() {
         let amber_fg = amber().colors.foreground;
-        let ice_fg   = ice().colors.foreground;
+        let ice_fg = ice().colors.foreground;
         let blood_fg = blood().colors.foreground;
         let vapor_fg = vapor().colors.foreground;
 
@@ -613,8 +619,8 @@ mod tests {
             ("amber", amber_fg, "ice", ice_fg),
             ("amber", amber_fg, "blood", blood_fg),
             ("amber", amber_fg, "vapor", vapor_fg),
-            ("ice",   ice_fg,   "blood", blood_fg),
-            ("ice",   ice_fg,   "vapor", vapor_fg),
+            ("ice", ice_fg, "blood", blood_fg),
+            ("ice", ice_fg, "vapor", vapor_fg),
             ("blood", blood_fg, "vapor", vapor_fg),
         ];
 
@@ -631,14 +637,14 @@ mod tests {
     #[test]
     fn qa_169_themes_have_distinct_background_colors() {
         let amber_bg = amber().colors.background;
-        let ice_bg   = ice().colors.background;
+        let ice_bg = ice().colors.background;
         let blood_bg = blood().colors.background;
         let vapor_bg = vapor().colors.background;
 
         let pairs = [
             ("amber", amber_bg, "ice", ice_bg),
             ("amber", amber_bg, "blood", blood_bg),
-            ("ice",   ice_bg,   "vapor", vapor_bg),
+            ("ice", ice_bg, "vapor", vapor_bg),
         ];
 
         for (na, ca, nb, cb) in pairs {
@@ -667,14 +673,14 @@ mod tests {
     #[test]
     fn qa_169_themes_have_distinct_shader_params() {
         let amber_sp = amber().shader_params;
-        let ice_sp   = ice().shader_params;
+        let ice_sp = ice().shader_params;
         let blood_sp = blood().shader_params;
         let vapor_sp = vapor().shader_params;
 
         // Bloom intensity alone differs enough to prove distinct appearance.
         let blooms = [
             ("amber", amber_sp.bloom_intensity),
-            ("ice",   ice_sp.bloom_intensity),
+            ("ice", ice_sp.bloom_intensity),
             ("blood", blood_sp.bloom_intensity),
             ("vapor", vapor_sp.bloom_intensity),
         ];

--- a/crates/phantom-ui/src/widgets/focus_ring.rs
+++ b/crates/phantom-ui/src/widgets/focus_ring.rs
@@ -528,9 +528,13 @@ mod pane_focus_state_tests {
         assert_eq!(ring.opacity(), 1.0);
 
         ring.set_focused(Some(PANE_B)); // different pane
-        ring.tick(0.0);                 // one zero-dt tick
+        ring.tick(0.0); // one zero-dt tick
         // Should not drop opacity since something is still focused.
-        assert_eq!(ring.opacity(), 1.0, "opacity must not fade when focus merely moves");
+        assert_eq!(
+            ring.opacity(),
+            1.0,
+            "opacity must not fade when focus merely moves"
+        );
     }
 
     // When focus is cleared, ticking must gradually reduce opacity toward 0.
@@ -542,10 +546,17 @@ mod pane_focus_state_tests {
 
         ring.set_focused(None);
         ring.tick(FADE_DURATION_MS / 2.0); // half fade-out
-        assert!(ring.opacity() < 1.0, "opacity must decrease after focus cleared");
+        assert!(
+            ring.opacity() < 1.0,
+            "opacity must decrease after focus cleared"
+        );
         assert!(ring.opacity() >= 0.0, "opacity must be non-negative");
 
         ring.tick(FADE_DURATION_MS * 2.0); // complete fade-out
-        assert_eq!(ring.opacity(), 0.0, "opacity must reach zero after full fade-out");
+        assert_eq!(
+            ring.opacity(),
+            0.0,
+            "opacity must reach zero after full fade-out"
+        );
     }
 }

--- a/crates/phantom-ui/src/widgets/tab_strip.rs
+++ b/crates/phantom-ui/src/widgets/tab_strip.rs
@@ -614,7 +614,11 @@ mod tab_nav_data_model_tests {
     fn click_second_tab_sets_active_index_to_one() {
         let mut strip = three_tab_strip();
         strip.on_click(350.0, STRIP_WIDTH);
-        assert_eq!(strip.active(), 1, "clicking second tab must set active to 1");
+        assert_eq!(
+            strip.active(),
+            1,
+            "clicking second tab must set active to 1"
+        );
     }
 
     // Clicking at x=50 (first slot) → active = 0.
@@ -650,7 +654,11 @@ mod tab_nav_data_model_tests {
         assert_eq!(strip.active(), 1);
         // Badges are accessed via rendered text rather than direct field access;
         // verify tab_count and active index haven't corrupted neighbouring tabs.
-        assert_eq!(strip.tab_count(), 3, "tab count must not change after click");
+        assert_eq!(
+            strip.tab_count(),
+            3,
+            "tab count must not change after click"
+        );
     }
 
     // A tab created with a badge count must report that count.
@@ -683,10 +691,15 @@ mod tab_nav_data_model_tests {
             |_| {},
         );
         // Collect badge values from rendered text segments and check the counts.
-        let texts = strip.render_text(&crate::layout::Rect { x: 0.0, y: 0.0, width: STRIP_WIDTH, height: 30.0 });
+        let texts = strip.render_text(&crate::layout::Rect {
+            x: 0.0,
+            y: 0.0,
+            width: STRIP_WIDTH,
+            height: 30.0,
+        });
         let badge_10 = texts.iter().any(|s| s.text.contains("[10]"));
-        let badge_1  = texts.iter().any(|s| s.text.contains("[1]"));
-        assert!(badge_1,  "badge [1] must be rendered for tab A");
+        let badge_1 = texts.iter().any(|s| s.text.contains("[1]"));
+        assert!(badge_1, "badge [1] must be rendered for tab A");
         assert!(badge_10, "badge [10] must be rendered for tab B");
     }
 


### PR DESCRIPTION
## Summary

- **New `AltScreenViewAdapter`** — read-only pane adapter backed by a shared `Arc<Mutex<Option<RenderOutput>>>` snapshot; renders the alt-screen grid of its primary sibling, re-anchoring origin to its own rect. 12 unit tests cover all trait methods.
- **`AppCore` trait extension** — two default no-op methods (`attach_alt_screen_snapshot` / `detach_alt_screen_snapshot`) added so every non-terminal adapter compiles unchanged. Terminal adapter overrides both to write/clear the shared snapshot each `update()` tick.
- **Layout split & collapse** — `split_for_alt_screen()` in `pane.rs` does a horizontal Taffy split, wires the Arc snapshot, and creates the secondary adapter. `collapse_alt_screen_pane()` tears it all down.
- **Edge detection & fade** — `poll_alt_screen_transitions()` in `update.rs` detects rising/falling edges on the `is_detached` state flag; `tick_alt_screen_fade()` runs a 300 ms fade timer and drives collapse.
- **Bezier tether** — `build_alt_screen_tether()` in `render_overlay.rs` draws a cubic bezier (8 quad segments) from the mid-right of the primary pane to the mid-left of the secondary pane at 35% opacity.
- **`detach` console command** — wired in `commands.rs`; checks if the focused terminal is in alt-screen mode before triggering the split.
- **Pre-existing test fixes** — corrected missing `BrainConfig.catalog` field in `boot_smoke.rs`, missing `AgentPane` struct fields in test fixtures, and private `Agent` field accesses (replaced with accessor methods).

## Approach

V1 "Smoke & Mirrors" — no PTY fd transfer. alacritty_terminal maintains both normal and alt-screen buffers simultaneously. The implementation reads the alt-screen buffer from the primary terminal and mirrors it into the view pane via a shared render snapshot. This is fully functional for interactive programs (vim, htop, less, etc.) that use alt-screen mode.

## Test plan

- [x] `cargo check -p phantom-ui -p phantom-app` — passes
- [x] `cargo fmt --check -p phantom-ui -p phantom-app` — passes
- [x] `cargo test -p phantom-ui` — 336 passed
- [x] `cargo test -p phantom-app` — 372 passed (+ integration tests)
- [x] `./scripts/pre-pr-check.sh --fast` — all gates passed
- [ ] Manual: launch phantom, run `vim`, backtick `detach`, verify split pane shows vim in secondary with bezier tether
- [ ] Manual: exit vim, verify 300ms fade and collapse back to single pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)