### PR TITLE
hotfix: unblock main — phantom-session tests + phantom-protocol clippy

### DIFF
--- a/crates/phantom-agents/src/agent.rs
+++ b/crates/phantom-agents/src/agent.rs
@@ -370,6 +370,19 @@ impl Agent {
         self.status = status;
     }
 
+    /// Test-only escape hatch that forces an agent into a specific lifecycle
+    /// status, bypassing all FSM guards.
+    ///
+    /// Hidden from rustdoc and intended **only** for downstream-crate tests
+    /// (e.g. `phantom-session`) that need to construct fixtures in arbitrary
+    /// lifecycle states to exercise snapshot/normalisation behaviour. Calling
+    /// this from production code is a bug — use the FSM transition helpers
+    /// (`approve_plan`, `complete`, `flatline`, ...) instead.
+    #[doc(hidden)]
+    pub fn force_status_for_test(&mut self, status: AgentStatus) {
+        self.status = status;
+    }
+
     /// Return the full conversation history.
     #[must_use]
     pub fn messages(&self) -> &[AgentMessage] {

--- a/crates/phantom-protocol/src/events.rs
+++ b/crates/phantom-protocol/src/events.rs
@@ -81,6 +81,7 @@ pub enum EventTopic {
 
 impl Event {
     /// Returns the topic this event belongs to.
+    #[must_use]
     pub fn topic(&self) -> EventTopic {
         match self {
             Self::TerminalOutput { .. }

--- a/crates/phantom-protocol/src/lib.rs
+++ b/crates/phantom-protocol/src/lib.rs
@@ -38,11 +38,13 @@ pub const RESTART_WINDOW_SECS: u64 = 60;
 // ---------------------------------------------------------------------------
 
 /// Returns the canonical socket path for a supervisor with the given PID.
+#[must_use]
 pub fn socket_path(supervisor_pid: u32) -> PathBuf {
     PathBuf::from(format!("/tmp/phantom-{supervisor_pid}.sock"))
 }
 
 /// Scans `/tmp` for an existing `phantom-*.sock` file and returns the first match.
+#[must_use]
 pub fn find_socket() -> Option<PathBuf> {
     let Ok(entries) = std::fs::read_dir("/tmp") else {
         return None;
@@ -78,6 +80,7 @@ pub enum SupervisorCommand {
 
 impl SupervisorCommand {
     /// Serialize to the wire format (without trailing newline).
+    #[must_use]
     pub fn to_line(&self) -> String {
         match self {
             Self::Set { key, value } => format!("CMD:SET:{key}:{value}"),
@@ -89,6 +92,7 @@ impl SupervisorCommand {
     }
 
     /// Parse from a wire-format line (without trailing newline).
+    #[must_use]
     pub fn from_line(s: &str) -> Option<Self> {
         let s = s.strip_prefix("CMD:")?;
         if let Some(rest) = s.strip_prefix("SET:") {
@@ -130,6 +134,7 @@ pub enum AppMessage {
 }
 
 impl AppMessage {
+    #[must_use]
     pub fn to_line(&self) -> String {
         match self {
             Self::Heartbeat => "HEARTBEAT".into(),
@@ -140,6 +145,7 @@ impl AppMessage {
         }
     }
 
+    #[must_use]
     pub fn from_line(s: &str) -> Option<Self> {
         if let Some(msg) = s.strip_prefix("LOG:") {
             Some(Self::Log(msg.to_owned()))
@@ -174,6 +180,7 @@ pub enum UserCommand {
 }
 
 impl UserCommand {
+    #[must_use]
     pub fn to_line(&self) -> String {
         match self {
             Self::Restart => "USER:RESTART".into(),
@@ -187,6 +194,7 @@ impl UserCommand {
         }
     }
 
+    #[must_use]
     pub fn from_line(s: &str) -> Option<Self> {
         let s = s.strip_prefix("USER:")?;
         if let Some(rest) = s.strip_prefix("SET:") {
@@ -223,6 +231,7 @@ pub enum Response {
 }
 
 impl Response {
+    #[must_use]
     pub fn to_line(&self) -> String {
         match self {
             Self::Ok(None) => "OK".into(),
@@ -231,6 +240,7 @@ impl Response {
         }
     }
 
+    #[must_use]
     pub fn from_line(s: &str) -> Option<Self> {
         if let Some(msg) = s.strip_prefix("ERR:") {
             Some(Self::Err(msg.to_owned()))

--- a/crates/phantom-session/src/agent_state.rs
+++ b/crates/phantom-session/src/agent_state.rs
@@ -614,7 +614,7 @@ mod tests {
     #[test]
     fn working_status_normalised_to_queued() {
         let mut agent = free_agent(2, "working agent");
-        agent.status = AgentStatus::Working;
+        agent.force_status_for_test(AgentStatus::Working);
         let snap = AgentSnapshot::from_agent(&agent);
         assert_eq!(snap.status(), AgentStatus::Queued,
             "Working must normalise to Queued for clean restart");
@@ -623,7 +623,7 @@ mod tests {
     #[test]
     fn waiting_for_tool_normalised_to_queued() {
         let mut agent = free_agent(3, "waiting agent");
-        agent.status = AgentStatus::WaitingForTool;
+        agent.force_status_for_test(AgentStatus::WaitingForTool);
         let snap = AgentSnapshot::from_agent(&agent);
         assert_eq!(snap.status(), AgentStatus::Queued);
     }
@@ -631,7 +631,7 @@ mod tests {
     #[test]
     fn planning_status_normalised_to_queued() {
         let mut agent = free_agent(4, "planning agent");
-        agent.status = AgentStatus::Planning;
+        agent.force_status_for_test(AgentStatus::Planning);
         let snap = AgentSnapshot::from_agent(&agent);
         assert_eq!(snap.status(), AgentStatus::Queued,
             "Planning must normalise to Queued for clean restart");
@@ -640,7 +640,7 @@ mod tests {
     #[test]
     fn awaiting_approval_normalised_to_queued() {
         let mut agent = free_agent(5, "awaiting agent");
-        agent.status = AgentStatus::AwaitingApproval;
+        agent.force_status_for_test(AgentStatus::AwaitingApproval);
         let snap = AgentSnapshot::from_agent(&agent);
         assert_eq!(snap.status(), AgentStatus::Queued,
             "AwaitingApproval must normalise to Queued for clean restart");
@@ -649,7 +649,7 @@ mod tests {
     #[test]
     fn done_status_preserved() {
         let mut agent = free_agent(4, "done agent");
-        agent.status = AgentStatus::Done;
+        agent.force_status_for_test(AgentStatus::Done);
         let snap = AgentSnapshot::from_agent(&agent);
         assert_eq!(snap.status(), AgentStatus::Done);
     }
@@ -769,7 +769,7 @@ mod tests {
 
         let agent1 = free_agent(1, "ongoing");
         let mut agent2 = free_agent(2, "done agent");
-        agent2.status = AgentStatus::Done;
+        agent2.force_status_for_test(AgentStatus::Done);
 
         persister.save_agents(&[&agent1, &agent2], false).unwrap();
 
@@ -786,7 +786,7 @@ mod tests {
 
         let agent1 = free_agent(1, "ongoing");
         let mut agent2 = free_agent(2, "done agent");
-        agent2.status = AgentStatus::Done;
+        agent2.force_status_for_test(AgentStatus::Done);
 
         persister.save_agents(&[&agent1, &agent2], true).unwrap();
 


### PR DESCRIPTION
## Summary
- Fixes `phantom-session` test-build failure (closes #357) — adds a narrow, `#[doc(hidden)]` test-only escape hatch (`Agent::force_status_for_test`) so downstream-crate tests can construct lifecycle fixtures without reopening `Agent.status` encapsulation.
- Fixes `phantom-protocol` clippy failures on main — 11 `#[must_use]` annotations on pure return-value methods/free fns.
- Unblocks the active PR round; every steward / reviewer is currently hitting at least one of these on verification.

## Scope notes
- Surface area is intentionally tiny: 4 files, +31 / -7 lines.
- `Agent.status` stays private. The new `force_status_for_test` is `#[doc(hidden)]` and clearly documented as test-only.
- `#[must_use]` is purely additive — no behaviour change, no API break.
- This PR does **not** attempt to fix the broader workspace-wide clippy situation (phantom-memory, phantom-context, phantom-semantic still have pre-existing clippy lint debt on main). Per the hotfix scope, those are out of band and belong in a separate hygiene pass.

## Test plan
- [x] `cargo build --workspace` — clean.
- [x] `cargo test --workspace --no-run` — clean (was failing in phantom-session before).
- [x] `cargo test -p phantom-session` — 88 passed, 0 failed.
- [x] `cargo clippy -p phantom-protocol --all-targets -- -D warnings` — clean (was 11 errors before).
- [x] `./scripts/pre-pr-check.sh phantom-protocol` — all gates pass.
- [ ] `./scripts/pre-pr-check.sh phantom-session` — fails on transitive clippy errors in phantom-memory / phantom-context / phantom-semantic that pre-date this PR. The phantom-session crate's own gates (build, test, clippy on phantom-session itself) pass; the failure is upstream-dependency lint debt and out of scope here.

## Closes
- closes #357