### PR TITLE
feat: phantom-hub crate scaffold + Railway deploy (closes #394)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,6 +570,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-future"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1e7e457ea78e524f48639f551fd79703ac3f2237f5ecccdf4708f8a75ad373"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,6 +601,92 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
+]
+
+[[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "base64",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite 0.24.0",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-test"
+version = "15.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac63648e380fd001402a02ec804e7686f9c4751f8cad85b7de0b53dae483a128"
+dependencies = [
+ "anyhow",
+ "auto-future",
+ "axum",
+ "bytes",
+ "cookie",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "mime",
+ "pretty_assertions",
+ "reserve-port",
+ "rust-multipart-rfc7578_2",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "tokio",
+ "tower",
+ "url",
 ]
 
 [[package]]
@@ -2188,6 +2280,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3000,7 +3098,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -3133,6 +3231,17 @@ checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -3148,7 +3257,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -3159,7 +3268,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
+ "http 1.4.0",
  "http-body",
  "pin-project-lite",
 ]
@@ -3169,6 +3278,12 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
@@ -3187,9 +3302,10 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
+ "http 1.4.0",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -3203,7 +3319,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
+ "http 1.4.0",
  "hyper",
  "hyper-util",
  "rustls",
@@ -3239,7 +3355,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "hyper",
  "ipnet",
@@ -4073,7 +4189,7 @@ dependencies = [
  "chrono",
  "deepsize",
  "futures",
- "http",
+ "http 1.4.0",
  "lance-arrow",
  "lance-core",
  "lance-namespace",
@@ -4537,6 +4653,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matrixmultiply"
@@ -5241,7 +5363,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
- "http",
+ "http 1.4.0",
  "humantime",
  "itertools 0.14.0",
  "parking_lot",
@@ -5671,6 +5793,25 @@ dependencies = [
  "serde_json",
  "tempfile",
  "uuid",
+]
+
+[[package]]
+name = "phantom-hub"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "axum-test",
+ "env_logger",
+ "log",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -6115,6 +6256,16 @@ name = "presser"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
 
 [[package]]
 name = "prettyplease"
@@ -6612,7 +6763,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -6646,6 +6797,15 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "reserve-port"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94070964579245eb2f76e62a7668fe87bd9969ed6c41256f3bf614e3323dd3cc"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6691,6 +6851,22 @@ dependencies = [
  "libsqlite3-sys",
  "serde_json",
  "smallvec",
+]
+
+[[package]]
+name = "rust-multipart-rfc7578_2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b748410c0afdef2ebbe3685a6a862e2ee937127cdaae623336a459451c8d57"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "mime",
+ "mime_guess",
+ "rand 0.8.6",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7035,6 +7211,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -8065,6 +8252,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -8078,7 +8266,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "iri-string",
@@ -8088,6 +8276,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -8108,6 +8297,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -8222,7 +8412,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand 0.8.6",
@@ -8239,7 +8429,7 @@ checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
  "native-tls",
@@ -8380,7 +8570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
 ]
@@ -9874,6 +10064,12 @@ name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yazi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ members = [
     "crates/phantom-relay",
     # Network identity bootstrap, relay client, and signed message envelope (issue #5).
     "crates/phantom-net",
+    # Railway-hosted MCP fleet control hub (issue #394).
+    "crates/phantom-hub",
 ]
 resolver = "2"
 

--- a/crates/phantom-hub/Cargo.toml
+++ b/crates/phantom-hub/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "phantom-hub"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Railway-hosted MCP fleet control hub — connection broker, auth, and JSON-RPC router"
+
+[lib]
+name = "phantom_hub"
+path = "src/lib.rs"
+
+[[bin]]
+name = "phantom-hub"
+path = "src/main.rs"
+
+[dependencies]
+log.workspace = true
+env_logger.workspace = true
+anyhow.workspace = true
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+
+tokio = { version = "1", features = ["full"] }
+axum = { version = "0.7", features = ["ws"] }
+tower = "0.5"
+tower-http = { version = "0.6", features = ["trace", "cors"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+axum-test = "15"
+tokio = { version = "1", features = ["full", "test-util"] }
+
+[lints]
+workspace = true

--- a/crates/phantom-hub/Dockerfile
+++ b/crates/phantom-hub/Dockerfile
@@ -1,0 +1,65 @@
+# syntax=docker/dockerfile:1
+#
+# Multi-stage Dockerfile for phantom-hub.
+#
+# Stage 1: dependency caching via cargo-chef
+#   Caches the full workspace dep compile so that subsequent builds only
+#   recompile changed crates.
+#
+# Stage 2: application build
+#   Inherits the dep cache from stage 1 and builds phantom-hub --release.
+#
+# Stage 3: minimal runtime image
+#   Copies only the compiled binary into a distroless/debian-slim image.
+#
+# Railway auto-detects this Dockerfile. The START_COMMAND in railway.toml
+# overrides CMD if needed.
+
+# ── Stage 1: chef planner ────────────────────────────────────────────────────
+FROM rust:1.87-slim AS planner
+WORKDIR /app
+
+RUN cargo install cargo-chef --locked
+
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# ── Stage 2: dependency cook ─────────────────────────────────────────────────
+FROM rust:1.87-slim AS cook
+WORKDIR /app
+
+RUN cargo install cargo-chef --locked
+
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+
+# ── Stage 3: builder ─────────────────────────────────────────────────────────
+FROM rust:1.87-slim AS builder
+WORKDIR /app
+
+# Copy pre-built deps from cook stage.
+COPY --from=cook /app/target target
+COPY --from=cook /usr/local/cargo /usr/local/cargo
+
+# Copy full source tree.
+COPY . .
+
+# Build only phantom-hub (avoids GPU crates that need X11/Vulkan headers).
+RUN cargo build --release -p phantom-hub
+
+# ── Stage 4: runtime ─────────────────────────────────────────────────────────
+FROM debian:bookworm-slim AS runtime
+
+# Non-root user for principle of least privilege.
+RUN addgroup --system phantom && adduser --system --ingroup phantom phantom
+USER phantom
+
+WORKDIR /app
+
+COPY --from=builder /app/target/release/phantom-hub /app/phantom-hub
+
+# Railway injects PORT; default to 8080 for local testing.
+ENV PORT=8080
+EXPOSE 8080
+
+CMD ["/app/phantom-hub"]

--- a/crates/phantom-hub/src/auth.rs
+++ b/crates/phantom-hub/src/auth.rs
@@ -1,0 +1,83 @@
+//! Authentication — device token and API key verification.
+//!
+//! # SCAFFOLD — issue #398 fills this in
+//!
+//! Phase 1: type definitions only. No tokens are validated; every extraction
+//! returns a placeholder. Issue #398 wires real JWT verification and key
+//! lookup.
+//!
+//! # Token model (planned)
+//!
+//! Two principal types:
+//!
+//! - **Device token** — long-lived JWT issued to a Phantom instance at
+//!   registration. Presented in `Authorization: Bearer <token>` on the
+//!   `GET /phantom/connect` WebSocket upgrade.
+//!
+//! - **API key** — short-lived or static key issued to a Claude session
+//!   (operator). Presented in `X-Api-Key: <key>` or
+//!   `Authorization: Bearer <key>` on MCP endpoints.
+
+use axum::http::HeaderMap;
+
+/// The authenticated identity of a Phantom device.
+///
+/// SCAFFOLD: fields are present but `phantom_id` is always a placeholder.
+/// Issue #398 populates from a verified JWT claim.
+#[derive(Debug, Clone)]
+pub struct DeviceIdentity {
+    /// Phantom identifier, matches `PhantomId` in the registry.
+    pub phantom_id: String,
+    // TODO(#398): add `issued_at: std::time::SystemTime`
+    // TODO(#398): add `scopes: Vec<String>`
+}
+
+/// The authenticated identity of a Claude session (MCP caller).
+///
+/// SCAFFOLD: fields are present but unvalidated. Issue #398 adds lookup.
+#[derive(Debug, Clone)]
+pub struct SessionIdentity {
+    /// Opaque API key string (will become a key-id reference post-#398).
+    pub api_key: String,
+    // TODO(#398): add `allowed_phantom_ids: Option<Vec<String>>` for scoped access
+}
+
+/// Extract a bearer token from `Authorization` header.
+///
+/// SCAFFOLD: returns the raw header value, no signature verification.
+/// Issue #398 adds JWT parsing and validation.
+pub fn extract_bearer(headers: &HeaderMap) -> Option<String> {
+    let value = headers.get("Authorization")?.to_str().ok()?;
+    value.strip_prefix("Bearer ").map(str::to_owned)
+}
+
+/// Validate a device token and return the identity.
+///
+/// SCAFFOLD: always returns `Err` — no validation yet. Issue #398 wires
+/// Ed25519/JWT verification.
+pub fn validate_device_token(_token: &str) -> Result<DeviceIdentity, AuthError> {
+    Err(AuthError::NotImplemented)
+}
+
+/// Validate an API key and return the session identity.
+///
+/// SCAFFOLD: always returns `Err` — no lookup yet. Issue #398 wires
+/// the key store.
+pub fn validate_api_key(_key: &str) -> Result<SessionIdentity, AuthError> {
+    Err(AuthError::NotImplemented)
+}
+
+/// Authentication errors.
+#[derive(Debug, thiserror::Error)]
+pub enum AuthError {
+    #[error("not implemented (issue #398)")]
+    NotImplemented,
+    #[error("missing or malformed Authorization header")]
+    MissingToken,
+    #[error("token signature invalid")]
+    InvalidSignature,
+    #[error("token expired")]
+    Expired,
+    #[error("unknown API key")]
+    UnknownKey,
+}

--- a/crates/phantom-hub/src/health.rs
+++ b/crates/phantom-hub/src/health.rs
@@ -1,0 +1,51 @@
+//! `GET /healthz` — liveness / readiness probe.
+//!
+//! Returns `200 OK` with a JSON body. Railway and load balancers poll this to
+//! determine whether the instance is alive.
+
+use axum::{Json, response::IntoResponse};
+use serde::Serialize;
+
+/// Response body for `GET /healthz`.
+#[derive(Debug, Serialize)]
+pub struct HealthResponse {
+    pub status: &'static str,
+    pub version: &'static str,
+}
+
+/// Handler for `GET /healthz`.
+///
+/// Always returns `200 OK` while the process is alive. A future issue can
+/// extend this to check downstream dependencies (e.g., Postgres connectivity).
+pub async fn healthz() -> impl IntoResponse {
+    Json(HealthResponse {
+        status: "ok",
+        version: env!("CARGO_PKG_VERSION"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        Router,
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn healthz_returns_200() {
+        let app = Router::new().route("/healthz", axum::routing::get(healthz));
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/healthz")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+}

--- a/crates/phantom-hub/src/lib.rs
+++ b/crates/phantom-hub/src/lib.rs
@@ -1,0 +1,53 @@
+//! `phantom-hub` — Railway-hosted MCP fleet control hub.
+//!
+//! # Phase 1 scope
+//!
+//! This crate is a **scaffold only**. It stands up an HTTP server with the
+//! correct route layout so subsequent issues can fill in logic without
+//! restructuring. The following modules are intentionally stubbed:
+//!
+//! - [`registry`] — connection registry (issue #396)
+//! - [`router`] — JSON-RPC frame router (issue #396)
+//! - [`auth`] — device-token authentication (issue #398)
+//!
+//! The only production-ready endpoint is `GET /healthz`.
+
+pub mod auth;
+pub mod health;
+pub mod mcp_endpoint;
+pub mod phantom_endpoint;
+pub mod registry;
+pub mod router;
+
+use anyhow::Result;
+use axum::Router;
+use std::net::SocketAddr;
+use tokio::net::TcpListener;
+use tracing::info;
+
+/// Build the application router.
+///
+/// Route layout:
+/// - `GET /healthz` — liveness / readiness probe
+/// - `GET /phantom/connect` — Phantom-side WSS dial-in (stub, issue #396)
+/// - `POST /mcp` — Claude-side MCP JSON-RPC (stub, issue #396/#397)
+/// - `GET /mcp/sse` — Claude-side MCP SSE transport (stub, issue #397)
+pub fn build_router() -> Router {
+    Router::new()
+        .route("/healthz", axum::routing::get(health::healthz))
+        .route(
+            "/phantom/connect",
+            axum::routing::get(phantom_endpoint::connect),
+        )
+        .route("/mcp", axum::routing::post(mcp_endpoint::handle_jsonrpc))
+        .route("/mcp/sse", axum::routing::get(mcp_endpoint::handle_sse))
+}
+
+/// Bind and serve the hub on `addr` until the process is killed.
+pub async fn serve(addr: SocketAddr) -> Result<()> {
+    let app = build_router();
+    let listener = TcpListener::bind(addr).await?;
+    info!("phantom-hub listening on {}", addr);
+    axum::serve(listener, app).await?;
+    Ok(())
+}

--- a/crates/phantom-hub/src/main.rs
+++ b/crates/phantom-hub/src/main.rs
@@ -1,0 +1,32 @@
+//! `phantom-hub` binary entry point.
+//!
+//! Reads `PORT` from the environment (Railway convention) and starts the hub
+//! server. Falls back to port 8080 when `PORT` is unset (local development).
+//!
+//! ```text
+//! RUST_LOG=phantom_hub=debug cargo run --bin phantom-hub
+//! curl localhost:8080/healthz
+//! ```
+
+use anyhow::{Context, Result};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "phantom_hub=info,tower_http=debug".into()),
+        )
+        .init();
+
+    let port: u16 = std::env::var("PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(8080);
+
+    let addr = format!("0.0.0.0:{port}")
+        .parse()
+        .with_context(|| format!("parsing bind address 0.0.0.0:{port}"))?;
+
+    phantom_hub::serve(addr).await
+}

--- a/crates/phantom-hub/src/mcp_endpoint.rs
+++ b/crates/phantom-hub/src/mcp_endpoint.rs
@@ -1,0 +1,44 @@
+//! `POST /mcp` and `GET /mcp/sse` — Claude-side MCP transport.
+//!
+//! # SCAFFOLD — issues #396/#397 fill this in
+//!
+//! Phase 1 acceptance: both routes are registered and return `501 Not
+//! Implemented`. Real MCP handling lands in issues #396 (JSON-RPC frame
+//! routing) and #397 (SSE streaming transport).
+//!
+//! Expected flow once implemented:
+//!
+//! ## `POST /mcp` (JSON-RPC 2.0 batch/single)
+//! 1. Validate API key via [`crate::auth`].
+//! 2. Parse the JSON-RPC envelope.
+//! 3. Resolve the target Phantom via `phantom_id` parameter.
+//! 4. Forward the frame through [`crate::router`].
+//! 5. Await the response and return it as JSON.
+//!
+//! ## `GET /mcp/sse` (Server-Sent Events)
+//! 1. Validate API key via [`crate::auth`].
+//! 2. Open an SSE stream.
+//! 3. Push JSON-RPC responses as `data:` events as they arrive from the router.
+
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+
+/// Handler for `POST /mcp` — Claude-side JSON-RPC 2.0 endpoint.
+///
+/// SCAFFOLD: returns `501 Not Implemented`. Real router in issue #396.
+pub async fn handle_jsonrpc() -> impl IntoResponse {
+    (
+        StatusCode::NOT_IMPLEMENTED,
+        "mcp: not yet implemented (issue #396)",
+    )
+}
+
+/// Handler for `GET /mcp/sse` — Claude-side SSE transport.
+///
+/// SCAFFOLD: returns `501 Not Implemented`. Real SSE stream in issue #397.
+pub async fn handle_sse() -> impl IntoResponse {
+    (
+        StatusCode::NOT_IMPLEMENTED,
+        "mcp/sse: not yet implemented (issue #397)",
+    )
+}

--- a/crates/phantom-hub/src/phantom_endpoint.rs
+++ b/crates/phantom-hub/src/phantom_endpoint.rs
@@ -1,0 +1,29 @@
+//! `GET /phantom/connect` — Phantom-side WSS dial-in.
+//!
+//! # SCAFFOLD — issue #396 fills this in
+//!
+//! Phase 1 acceptance: the route is registered and returns `501 Not
+//! Implemented`. The real upgrade logic (WebSocket handshake, device-token
+//! validation, registry insertion) lands in issue #396.
+//!
+//! Expected flow once implemented:
+//! 1. Validate `Authorization: Bearer <device-token>` via [`crate::auth`].
+//! 2. Upgrade HTTP connection to WebSocket.
+//! 3. Insert a [`crate::registry::PhantomHandle`] into the
+//!    [`crate::registry::Registry`].
+//! 4. Drive the read/write loop, forwarding JSON-RPC frames via
+//!    [`crate::router`].
+//! 5. Remove the handle from the registry on disconnect.
+
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+
+/// Handler for `GET /phantom/connect`.
+///
+/// SCAFFOLD: returns `501 Not Implemented`. Real WSS upgrade in issue #396.
+pub async fn connect() -> impl IntoResponse {
+    (
+        StatusCode::NOT_IMPLEMENTED,
+        "phantom/connect: not yet implemented (issue #396)",
+    )
+}

--- a/crates/phantom-hub/src/registry.rs
+++ b/crates/phantom-hub/src/registry.rs
@@ -1,0 +1,83 @@
+//! Connection registry — tracks live Phantom WebSocket connections.
+//!
+//! # SCAFFOLD — issue #396 fills this in
+//!
+//! Phase 1: type definitions only. The registry holds no state and all
+//! operations are unimplemented stubs. Issue #396 wires real insertion,
+//! lookup, and eviction.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// Opaque identifier for a connected Phantom instance.
+///
+/// Assigned at device registration time and persisted in the device-token
+/// JWT. Issue #398 refines the identity model.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PhantomId(pub String);
+
+impl std::fmt::Display for PhantomId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// A live connection handle to a single Phantom instance.
+///
+/// SCAFFOLD: fields will be populated in issue #396 (WebSocket sink, metadata).
+#[derive(Debug)]
+pub struct PhantomHandle {
+    pub id: PhantomId,
+    // TODO(#396): add `ws_tx: tokio::sync::mpsc::Sender<String>` for outbound frames.
+    // TODO(#396): add `connected_at: std::time::Instant`.
+    // TODO(#396): add `labels: HashMap<String, String>` for fleet queries.
+}
+
+impl PhantomHandle {
+    /// Create a new handle.
+    ///
+    /// SCAFFOLD: currently only stores the id. Real construction in issue #396.
+    #[must_use]
+    pub fn new(id: PhantomId) -> Self {
+        Self { id }
+    }
+}
+
+/// Shared registry of live Phantom connections.
+///
+/// SCAFFOLD: the inner map is present but no operations are implemented.
+/// Issue #396 adds `register`, `unregister`, `get`, and `list`.
+#[derive(Debug, Default)]
+pub struct Registry {
+    phantoms: HashMap<PhantomId, PhantomHandle>,
+}
+
+impl Registry {
+    /// Create an empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return the number of currently registered Phantom instances.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.phantoms.len()
+    }
+
+    /// Return `true` when no Phantom instances are registered.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.phantoms.is_empty()
+    }
+}
+
+/// Convenience type alias for a thread-safe shared registry.
+pub type SharedRegistry = Arc<Mutex<Registry>>;
+
+/// Create a new empty [`SharedRegistry`].
+#[must_use]
+pub fn new_shared() -> SharedRegistry {
+    Arc::new(Mutex::new(Registry::new()))
+}

--- a/crates/phantom-hub/src/router.rs
+++ b/crates/phantom-hub/src/router.rs
@@ -1,0 +1,97 @@
+//! JSON-RPC frame router — routes MCP tool calls to the right Phantom.
+//!
+//! # SCAFFOLD — issue #396 fills this in
+//!
+//! Phase 1: type definitions only. The router accepts no real frames.
+//! Issue #396 wires the full forwarding pipeline:
+//! `mcp_endpoint` → `Router::dispatch` → `PhantomHandle::send` → response.
+
+use crate::registry::PhantomId;
+use serde::{Deserialize, Serialize};
+
+/// A JSON-RPC 2.0 request frame.
+///
+/// SCAFFOLD: used as the canonical in-memory type. Issue #396 adds
+/// deserialization from the HTTP body and forwarding logic.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct JsonRpcRequest {
+    pub jsonrpc: String,
+    pub id: serde_json::Value,
+    pub method: String,
+    #[serde(default)]
+    pub params: serde_json::Value,
+}
+
+/// A JSON-RPC 2.0 response frame.
+///
+/// SCAFFOLD: issue #396 constructs real instances from Phantom replies.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct JsonRpcResponse {
+    pub jsonrpc: String,
+    pub id: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+}
+
+/// A JSON-RPC 2.0 error object.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct JsonRpcError {
+    pub code: i64,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+impl JsonRpcError {
+    /// Standard "method not found" error (code -32601).
+    #[must_use]
+    pub fn method_not_found(method: &str) -> Self {
+        Self {
+            code: -32601,
+            message: format!("Method not found: {method}"),
+            data: None,
+        }
+    }
+
+    /// Standard "not implemented yet" error for scaffold stubs.
+    #[must_use]
+    pub fn not_implemented(issue: &str) -> Self {
+        Self {
+            code: -32000,
+            message: format!("Not implemented (see issue {issue})"),
+            data: None,
+        }
+    }
+}
+
+/// Frame router.
+///
+/// SCAFFOLD: no dispatch logic yet. Issue #396 adds:
+/// - `dispatch(&self, phantom_id: &PhantomId, request: JsonRpcRequest) -> JsonRpcResponse`
+/// - Timeout handling
+/// - Correlation-id tracking for in-flight requests
+#[derive(Debug, Default)]
+pub struct FrameRouter;
+
+impl FrameRouter {
+    /// Create a new router.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Placeholder — returns "not implemented" for every call.
+    ///
+    /// SCAFFOLD: real dispatch in issue #396.
+    #[must_use]
+    pub fn dispatch(&self, _phantom_id: &PhantomId, request: &JsonRpcRequest) -> JsonRpcResponse {
+        JsonRpcResponse {
+            jsonrpc: "2.0".into(),
+            id: request.id.clone(),
+            result: None,
+            error: Some(JsonRpcError::not_implemented("#396")),
+        }
+    }
+}

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,21 @@
+# railway.toml — phantom-hub Railway service configuration.
+#
+# Railway reads this file from the repo root. Adjust `build.dockerfilePath`
+# if the Docker context root moves.
+#
+# Reference: https://docs.railway.app/reference/config-as-code
+
+[build]
+builder      = "DOCKERFILE"
+dockerfilePath = "crates/phantom-hub/Dockerfile"
+
+[deploy]
+startCommand = "/app/phantom-hub"
+healthcheckPath = "/healthz"
+healthcheckTimeout = 10          # seconds
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3
+
+# Railway environment variables.
+# Set PORT in the Railway dashboard (or leave unset — Railway injects it).
+# For staging, no additional env vars are needed for Phase 1.


### PR DESCRIPTION
## Summary

- New crate `crates/phantom-hub` — Railway-hosted MCP fleet-control hub, Phase 1 scaffold only
- `GET /healthz` → 200 OK with `{"status":"ok","version":"0.1.0"}` (production-ready)
- `GET /phantom/connect`, `POST /mcp`, `GET /mcp/sse` → 501 Not Implemented (stubs, per AC)
- Stub modules with correct types: `registry` (#396), `router` (#396), `auth` (#398), `phantom_endpoint` (#396), `mcp_endpoint` (#396/#397)
- `crates/phantom-hub/Dockerfile` — multi-stage build with `cargo-chef` dep layer caching, non-root runtime user
- `railway.toml` at repo root — Dockerfile builder, healthcheck `/healthz`, restart policy
- Root `Cargo.toml` updated: added `crates/phantom-hub` workspace member

## Acceptance criteria check

- [x] `crates/phantom-hub/` with `Cargo.toml`, `src/main.rs`, `src/lib.rs`
- [x] Added to workspace members
- [x] Bin target name `phantom-hub`
- [x] Listens on `0.0.0.0:$PORT` (default 8080)
- [x] `WSS /phantom/connect` stub (501)
- [x] `POST /mcp` and `GET /mcp/sse` stubs (501)
- [x] `GET /healthz` returns 200 with JSON `{"status":"ok","version":"..."}`
- [x] Dockerfile (multi-stage, release binary)
- [x] `railway.toml` with build + start command

## Test plan

- [x] `cargo build -p phantom-hub` — clean
- [x] `cargo test -p phantom-hub` — 1 test passes (`healthz_returns_200`)
- [x] `cargo clippy -p phantom-hub --all-targets -- -D warnings` — clean
- [x] `./scripts/pre-pr-check.sh phantom-hub` — PASS
- [ ] Deploy to Railway staging, hit `/healthz`, verify 200 (post-merge, no Railway credentials in CI yet)

## Notes for reviewer

- Root `Cargo.toml` gains a new workspace member. CLAUDE.md crate-count drift is tracked separately in issue #408.
- `axum-test` dev-dependency brought in `http v0.2` alongside `http v1`; this is a known Rust ecosystem split and doesn't affect the production binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)