### PR TITLE
feat: pane lineage model for parent/child terminal relationships (closes #365)

### DIFF
--- a/crates/phantom-app/src/coordinator.rs
+++ b/crates/phantom-app/src/coordinator.rs
@@ -16,6 +16,8 @@ use phantom_scene::tree::SceneTree;
 use phantom_ui::arbiter::LayoutArbiter;
 use phantom_ui::layout::{LayoutEngine, PaneId};
 
+use crate::lineage::PaneLineage;
+
 /// A set of position allocations produced by the layout arbiter or Taffy.
 pub struct LayoutPlan {
     pub allocations: HashMap<AppId, Rect>,
@@ -45,6 +47,11 @@ pub struct AppCoordinator {
     floating: HashSet<AppId>,
     /// Pixel-space rects for floating panes.
     float_rects: HashMap<AppId, Rect>,
+    /// Parent/child relationships between panes (issue #365).
+    ///
+    /// Starts empty — all panes are roots.  The process-detach subsystem
+    /// (#367/#368/#369) populates this when a subprocess pane is created.
+    lineage: PaneLineage,
 }
 
 impl AppCoordinator {
@@ -67,6 +74,7 @@ impl AppCoordinator {
             dirty_adapters: HashSet::new(),
             floating: HashSet::new(),
             float_rects: HashMap::new(),
+            lineage: PaneLineage::new(),
         }
     }
 
@@ -253,6 +261,9 @@ impl AppCoordinator {
 
     /// Remove an adapter: kill it, strip layout pane and scene node,
     /// shift focus if the removed adapter was focused.
+    ///
+    /// Also removes the adapter from the pane lineage tree (issue #365):
+    /// its parent link is severed and any children are orphaned back to roots.
     pub fn remove_adapter(
         &mut self,
         app_id: AppId,
@@ -282,6 +293,10 @@ impl AppCoordinator {
         self.dirty_adapters.remove(&app_id);
         self.floating.remove(&app_id);
         self.float_rects.remove(&app_id);
+
+        // Clean up lineage references.  Children are orphaned (become roots);
+        // the parent's child list no longer includes this adapter.
+        self.lineage.remove(app_id);
     }
 
     /// Update all running adapters whose cadence fires this frame.
@@ -919,6 +934,53 @@ impl AppCoordinator {
     /// when a `CommandComplete` event fires (issue #226).
     pub fn terminal_output_buf(&self, app_id: AppId) -> Option<String> {
         self.registry.get_adapter(app_id)?.output_buf_snapshot()
+    }
+
+    // -----------------------------------------------------------------------
+    // Pane lineage API (issue #365)
+    // -----------------------------------------------------------------------
+
+    /// Record `child` as a subprocess child of `parent`.
+    ///
+    /// Used by the process-detach subsystem when a subprocess pane is spawned
+    /// from an existing terminal pane.  Panes that are never detached remain
+    /// roots and do not appear in the lineage tree.
+    pub fn lineage_attach(&mut self, parent: AppId, child: AppId) {
+        self.lineage.attach(parent, child);
+        log::debug!("Lineage: {child} attached under {parent}");
+    }
+
+    /// The parent pane of `pane`, if any.
+    ///
+    /// Returns `None` for root panes (those never attached to a parent).
+    pub fn lineage_parent_of(&self, pane: AppId) -> Option<AppId> {
+        self.lineage.parent_of(pane)
+    }
+
+    /// The ordered children of `pane` (insertion order).
+    ///
+    /// Returns an empty slice when `pane` has no children.
+    pub fn lineage_children_of(&self, pane: AppId) -> &[AppId] {
+        self.lineage.children_of(pane)
+    }
+
+    /// Whether `pane` is a root (has no parent).
+    pub fn lineage_is_root(&self, pane: AppId) -> bool {
+        self.lineage.is_root(pane)
+    }
+
+    /// Full ancestry chain from the tree root down to `pane` (inclusive).
+    ///
+    /// Returns `vec![pane]` for root panes.
+    pub fn lineage_chain(&self, pane: AppId) -> Vec<AppId> {
+        self.lineage.lineage(pane)
+    }
+
+    /// The subtree rooted at `pane` in depth-first pre-order.
+    ///
+    /// Includes `pane` itself as the first element.
+    pub fn lineage_subtree(&self, pane: AppId) -> Vec<AppId> {
+        self.lineage.subtree(pane)
     }
 
     /// Test-only constructor that skips layout/scene requirements.

--- a/crates/phantom-app/src/lib.rs
+++ b/crates/phantom-app/src/lib.rs
@@ -19,6 +19,7 @@ mod inspector;
 pub mod jobs;
 #[allow(dead_code)]
 mod keystroke_fx;
+pub mod lineage;
 pub mod logging;
 mod mouse;
 pub mod notifications;

--- a/crates/phantom-app/src/lineage.rs
+++ b/crates/phantom-app/src/lineage.rs
@@ -1,0 +1,314 @@
+//! Pane lineage model — parent/child relationships for terminal panes.
+//!
+//! This module implements the pane tree required by Phase 4 process-detach work
+//! (issue #365). Every pane in the system starts as a root (no parent, no
+//! children). When a subprocess is detached into its own pane the caller
+//! records the relationship here; downstream issues (#367, #368, #369) consume
+//! the tree to drive tether rendering, lifecycle harding, and nested detach.
+//!
+//! # Degenerate case
+//!
+//! Panes that have never been attached or detached have no entry in this tree
+//! and behave identically to how they did before this module existed. All
+//! queries on an unknown pane return sensible empty results rather than errors.
+//!
+//! # Tree invariants
+//!
+//! * Every pane has at most one parent.
+//! * Children are ordered by registration time (insertion order).
+//! * Removing a pane automatically unlinks it from its parent's child list and
+//!   orphans its children (their `parent` becomes `None`).  Callers that need a
+//!   different orphan policy can reparent children before removal.
+
+use phantom_adapter::AppId;
+use std::collections::HashMap;
+
+// ---------------------------------------------------------------------------
+// PaneLineage
+// ---------------------------------------------------------------------------
+
+/// The pane lineage registry.
+///
+/// Stored on [`AppCoordinator`](crate::coordinator::AppCoordinator) and
+/// updated via its `lineage` accessor methods rather than directly.
+#[derive(Debug, Default)]
+pub struct PaneLineage {
+    /// Maps each pane to its parent, if any.
+    parent: HashMap<AppId, AppId>,
+    /// Maps each pane to its ordered list of children.
+    children: HashMap<AppId, Vec<AppId>>,
+}
+
+impl PaneLineage {
+    /// Create an empty lineage registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    // -----------------------------------------------------------------------
+    // Mutation
+    // -----------------------------------------------------------------------
+
+    /// Attach `child` as a child of `parent`.
+    ///
+    /// If `child` already has a parent, the old relationship is removed before
+    /// the new one is established — a pane can only have one parent at a time.
+    ///
+    /// No-op when `child == parent`.
+    pub fn attach(&mut self, parent: AppId, child: AppId) {
+        if parent == child {
+            return;
+        }
+
+        // Remove any prior parent link for `child`.
+        self.detach_from_parent(child);
+
+        self.parent.insert(child, parent);
+        self.children.entry(parent).or_default().push(child);
+    }
+
+    /// Remove `pane` from the registry and clean up all lineage references.
+    ///
+    /// * Unlinks `pane` from its parent's children list.
+    /// * Orphans all of `pane`'s children (their parent pointer is cleared, but
+    ///   they remain in the registry as roots).
+    /// * Removes `pane`'s own entries.
+    pub fn remove(&mut self, pane: AppId) {
+        // Unlink from parent.
+        self.detach_from_parent(pane);
+
+        // Orphan children.
+        let children = self.children.remove(&pane).unwrap_or_default();
+        for child in &children {
+            self.parent.remove(child);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Query
+    // -----------------------------------------------------------------------
+
+    /// The parent of `pane`, if any.
+    #[must_use]
+    pub fn parent_of(&self, pane: AppId) -> Option<AppId> {
+        self.parent.get(&pane).copied()
+    }
+
+    /// The ordered children of `pane` (insertion order).
+    ///
+    /// Returns an empty slice when `pane` has no children.
+    #[must_use]
+    pub fn children_of(&self, pane: AppId) -> &[AppId] {
+        self.children.get(&pane).map(Vec::as_slice).unwrap_or(&[])
+    }
+
+    /// Whether `pane` is a root (has no parent).
+    #[must_use]
+    pub fn is_root(&self, pane: AppId) -> bool {
+        !self.parent.contains_key(&pane)
+    }
+
+    /// The full ancestry chain from the tree root down to `pane` (inclusive).
+    ///
+    /// Returns `vec![pane]` when `pane` is a root.  The walk is bounded by the
+    /// number of registered panes; a cycle (which the `attach` logic prevents)
+    /// would terminate at the cycle-detection limit anyway.
+    #[must_use]
+    pub fn lineage(&self, pane: AppId) -> Vec<AppId> {
+        let mut chain = Vec::new();
+        let mut cursor = pane;
+        loop {
+            chain.push(cursor);
+            match self.parent.get(&cursor).copied() {
+                Some(p) => cursor = p,
+                None => break,
+            }
+        }
+        chain.reverse();
+        chain
+    }
+
+    /// The subtree rooted at `pane`: `pane` itself followed by all descendants
+    /// in depth-first pre-order.
+    #[must_use]
+    pub fn subtree(&self, pane: AppId) -> Vec<AppId> {
+        let mut out = Vec::new();
+        self.collect_subtree(pane, &mut out);
+        out
+    }
+
+    // -----------------------------------------------------------------------
+    // Private helpers
+    // -----------------------------------------------------------------------
+
+    fn detach_from_parent(&mut self, pane: AppId) {
+        if let Some(old_parent) = self.parent.remove(&pane) {
+            if let Some(siblings) = self.children.get_mut(&old_parent) {
+                siblings.retain(|&c| c != pane);
+            }
+        }
+    }
+
+    fn collect_subtree(&self, pane: AppId, out: &mut Vec<AppId>) {
+        out.push(pane);
+        for &child in self.children_of(pane) {
+            self.collect_subtree(child, out);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(n: u32) -> AppId {
+        n
+    }
+
+    // -----------------------------------------------------------------------
+    // attach / parent-child basics
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn attach_records_parent_and_child() {
+        let mut lin = PaneLineage::new();
+        lin.attach(id(1), id(2));
+
+        assert_eq!(lin.parent_of(id(2)), Some(id(1)));
+        assert_eq!(lin.children_of(id(1)), &[id(2)]);
+        assert!(lin.is_root(id(1)));
+        assert!(!lin.is_root(id(2)));
+    }
+
+    #[test]
+    fn attach_multiple_children_preserves_insertion_order() {
+        let mut lin = PaneLineage::new();
+        lin.attach(id(0), id(1));
+        lin.attach(id(0), id(2));
+        lin.attach(id(0), id(3));
+
+        assert_eq!(lin.children_of(id(0)), &[id(1), id(2), id(3)]);
+    }
+
+    #[test]
+    fn attach_reparents_child() {
+        let mut lin = PaneLineage::new();
+        lin.attach(id(1), id(3));
+        lin.attach(id(2), id(3)); // reparent 3 under 2
+
+        assert_eq!(lin.parent_of(id(3)), Some(id(2)));
+        assert!(lin.children_of(id(1)).is_empty(), "old parent must drop child");
+        assert_eq!(lin.children_of(id(2)), &[id(3)]);
+    }
+
+    #[test]
+    fn attach_noop_when_same_as_parent() {
+        let mut lin = PaneLineage::new();
+        lin.attach(id(1), id(1));
+        assert!(lin.is_root(id(1)));
+        assert!(lin.children_of(id(1)).is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // remove
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn remove_unlinks_from_parent() {
+        let mut lin = PaneLineage::new();
+        lin.attach(id(1), id(2));
+        lin.remove(id(2));
+
+        assert_eq!(lin.parent_of(id(2)), None);
+        assert!(lin.children_of(id(1)).is_empty());
+        assert!(lin.is_root(id(1)));
+    }
+
+    #[test]
+    fn remove_orphans_children() {
+        let mut lin = PaneLineage::new();
+        lin.attach(id(0), id(1));
+        lin.attach(id(1), id(2));
+
+        lin.remove(id(1));
+
+        // 1 is gone; 2 is now a root.
+        assert_eq!(lin.parent_of(id(1)), None);
+        assert_eq!(lin.parent_of(id(2)), None);
+        assert!(lin.is_root(id(2)));
+        // 0 no longer lists 1 as a child.
+        assert!(lin.children_of(id(0)).is_empty());
+    }
+
+    #[test]
+    fn remove_unknown_pane_is_noop() {
+        let mut lin = PaneLineage::new();
+        lin.remove(id(99)); // must not panic
+        assert_eq!(lin.parent_of(id(99)), None);
+        assert!(lin.children_of(id(99)).is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // lineage walk
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn lineage_root_returns_self() {
+        let lin = PaneLineage::new();
+        assert_eq!(lin.lineage(id(5)), vec![id(5)]);
+    }
+
+    #[test]
+    fn lineage_walks_root_to_leaf() {
+        let mut lin = PaneLineage::new();
+        lin.attach(id(1), id(2));
+        lin.attach(id(2), id(3));
+
+        assert_eq!(lin.lineage(id(3)), vec![id(1), id(2), id(3)]);
+    }
+
+    #[test]
+    fn lineage_mid_chain() {
+        let mut lin = PaneLineage::new();
+        lin.attach(id(1), id(2));
+        lin.attach(id(2), id(3));
+        lin.attach(id(3), id(4));
+
+        assert_eq!(lin.lineage(id(3)), vec![id(1), id(2), id(3)]);
+    }
+
+    // -----------------------------------------------------------------------
+    // subtree
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn subtree_leaf_returns_self() {
+        let lin = PaneLineage::new();
+        assert_eq!(lin.subtree(id(7)), vec![id(7)]);
+    }
+
+    #[test]
+    fn subtree_depth_first_preorder() {
+        let mut lin = PaneLineage::new();
+        // Tree: 1 → {2, 3}, 2 → {4}
+        lin.attach(id(1), id(2));
+        lin.attach(id(1), id(3));
+        lin.attach(id(2), id(4));
+
+        assert_eq!(lin.subtree(id(1)), vec![id(1), id(2), id(4), id(3)]);
+    }
+
+    // -----------------------------------------------------------------------
+    // children_of on unknown pane
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn children_of_unknown_returns_empty_slice() {
+        let lin = PaneLineage::new();
+        assert!(lin.children_of(id(42)).is_empty());
+    }
+}

--- a/crates/phantom-app/src/lineage.rs
+++ b/crates/phantom-app/src/lineage.rs
@@ -21,7 +21,7 @@
 //!   different orphan policy can reparent children before removal.
 
 use phantom_adapter::AppId;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 // ---------------------------------------------------------------------------
 // PaneLineage
@@ -54,10 +54,27 @@ impl PaneLineage {
     /// If `child` already has a parent, the old relationship is removed before
     /// the new one is established — a pane can only have one parent at a time.
     ///
-    /// No-op when `child == parent`.
+    /// No-op (and the existing tree is left unchanged) when either:
+    /// * `child == parent`, or
+    /// * attaching would create a cycle — i.e., `child` is already an ancestor
+    ///   of `parent` in the current tree.  The cycle check walks the parent
+    ///   chain of `parent` upward; if `child` is encountered, the attach is
+    ///   silently rejected.  This makes `PaneLineage` invariant-safe: callers
+    ///   that try `attach(b, a)` after `attach(a, b)` are quietly refused.
     pub fn attach(&mut self, parent: AppId, child: AppId) {
         if parent == child {
             return;
+        }
+
+        // Cycle guard: walk the ancestor chain of `parent`.  If `child`
+        // already appears, the requested edge would form a cycle — reject it.
+        let mut cursor = parent;
+        loop {
+            match self.parent.get(&cursor).copied() {
+                Some(p) if p == child => return, // cycle detected
+                Some(p) => cursor = p,
+                None => break,
+            }
         }
 
         // Remove any prior parent link for `child`.
@@ -110,14 +127,22 @@ impl PaneLineage {
 
     /// The full ancestry chain from the tree root down to `pane` (inclusive).
     ///
-    /// Returns `vec![pane]` when `pane` is a root.  The walk is bounded by the
-    /// number of registered panes; a cycle (which the `attach` logic prevents)
-    /// would terminate at the cycle-detection limit anyway.
+    /// Returns `vec![pane]` when `pane` is a root.
+    ///
+    /// The walk is guarded by a visited set so it terminates even if the
+    /// internal state is somehow corrupt.  Under normal operation the tree is
+    /// acyclic because [`attach`](Self::attach) rejects edges that would form
+    /// a cycle, so the visited set is never exercised.
     #[must_use]
     pub fn lineage(&self, pane: AppId) -> Vec<AppId> {
         let mut chain = Vec::new();
+        let mut visited = HashSet::new();
         let mut cursor = pane;
         loop {
+            if !visited.insert(cursor) {
+                // Cycle in internal state — stop rather than loop forever.
+                break;
+            }
             chain.push(cursor);
             match self.parent.get(&cursor).copied() {
                 Some(p) => cursor = p,
@@ -130,10 +155,15 @@ impl PaneLineage {
 
     /// The subtree rooted at `pane`: `pane` itself followed by all descendants
     /// in depth-first pre-order.
+    ///
+    /// The traversal uses a visited set so it terminates even on corrupt
+    /// internal state.  Under normal operation the children graph is acyclic
+    /// because [`attach`](Self::attach) rejects cycle-creating edges.
     #[must_use]
     pub fn subtree(&self, pane: AppId) -> Vec<AppId> {
         let mut out = Vec::new();
-        self.collect_subtree(pane, &mut out);
+        let mut visited = HashSet::new();
+        self.collect_subtree(pane, &mut out, &mut visited);
         out
     }
 
@@ -149,10 +179,14 @@ impl PaneLineage {
         }
     }
 
-    fn collect_subtree(&self, pane: AppId, out: &mut Vec<AppId>) {
+    fn collect_subtree(&self, pane: AppId, out: &mut Vec<AppId>, visited: &mut HashSet<AppId>) {
+        if !visited.insert(pane) {
+            // Already visited — cycle in internal state; stop here.
+            return;
+        }
         out.push(pane);
         for &child in self.children_of(pane) {
-            self.collect_subtree(child, out);
+            self.collect_subtree(child, out, visited);
         }
     }
 }
@@ -310,5 +344,48 @@ mod tests {
     fn children_of_unknown_returns_empty_slice() {
         let lin = PaneLineage::new();
         assert!(lin.children_of(id(42)).is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // Cycle prevention — regression tests for DoD §4 safety fix
+    // -----------------------------------------------------------------------
+
+    /// Calling attach(1, 2) then attach(2, 1) must not create a cycle.
+    /// The second attach is rejected: the original relationship (parent[2]=1)
+    /// is preserved and lineage/subtree queries must terminate.
+    #[test]
+    fn attach_refuses_to_create_cycle() {
+        let mut lin = PaneLineage::new();
+
+        lin.attach(id(1), id(2)); // parent[2] = 1
+        lin.attach(id(2), id(1)); // would make parent[1] = 2 — cycle; must be rejected
+
+        // Original relationship untouched.
+        assert_eq!(lin.parent_of(id(2)), Some(id(1)));
+        // Reverse edge was NOT inserted.
+        assert_eq!(lin.parent_of(id(1)), None, "cycle edge must be rejected");
+        assert!(lin.is_root(id(1)));
+
+        // lineage() and subtree() must terminate and return correct results.
+        assert_eq!(lin.lineage(id(2)), vec![id(1), id(2)]);
+        assert_eq!(lin.subtree(id(1)), vec![id(1), id(2)]);
+    }
+
+    /// Three-node transitive cycle: 1→2→3, then attach(3, 1) would close the
+    /// cycle.  The third attach must be rejected.
+    #[test]
+    fn attach_refuses_transitive_cycle() {
+        let mut lin = PaneLineage::new();
+
+        lin.attach(id(1), id(2)); // parent[2] = 1
+        lin.attach(id(2), id(3)); // parent[3] = 2
+        lin.attach(id(3), id(1)); // would close 1→2→3→1; must be rejected
+
+        assert_eq!(lin.parent_of(id(1)), None, "1 must remain a root");
+        assert_eq!(lin.parent_of(id(2)), Some(id(1)));
+        assert_eq!(lin.parent_of(id(3)), Some(id(2)));
+
+        assert_eq!(lin.lineage(id(3)), vec![id(1), id(2), id(3)]);
+        assert_eq!(lin.subtree(id(1)), vec![id(1), id(2), id(3)]);
     }
 }


### PR DESCRIPTION
## Summary

- Adds `phantom_app::lineage::PaneLineage` — an `AppId`-keyed tree that models parent/child pane relationships independently of rendering or PTY implementation
- Integrates `PaneLineage` into `AppCoordinator` with 5 public query methods and an `attach` mutator; `remove_adapter` automatically cleans up lineage references (severing parent link, orphaning children)
- Degenerate case (no parent, no children) is zero-cost — unknown panes return empty results without error, so no existing pane paths are affected

## Acceptance Criteria

- [x] pane tree exists independently of rendering
- [x] nested subprocess chains can be represented without corruption
- [x] pane close/remove paths preserve tree integrity
- [x] tests cover parent/child creation and teardown semantics

## API surface for downstream issues (#367/#368/#369)

```rust
coordinator.lineage_attach(parent, child);
coordinator.lineage_parent_of(pane)    // -> Option<AppId>
coordinator.lineage_children_of(pane)  // -> &[AppId]
coordinator.lineage_is_root(pane)      // -> bool
coordinator.lineage_chain(pane)        // -> Vec<AppId> (root → leaf)
coordinator.lineage_subtree(pane)      // -> Vec<AppId> (DFS pre-order)
```

## Test plan

- [x] 13 unit tests in `lineage.rs`: attach, reparent, multi-child insertion order, remove/orphan, lineage walk, subtree DFS, degenerate cases
- [x] `cargo build -p phantom-app` — clean
- [x] `cargo test -p phantom-app` — 389 tests pass, 0 failures
- [x] Rebased onto `origin/main` — 0 conflicts

## Warnings

- File overlap with PR #351 (Cartographer): both touch `coordinator.rs` and `pane.rs`. This PR adds a new field (`lineage: PaneLineage`) and new methods to `AppCoordinator`, and adds 5 lines to `remove_adapter`. PR #351 modifies different sections of `coordinator.rs`. Merge order: this should merge before or after #351 — reviewer should check diff against current main after #351 merges.
- Pre-existing clippy failures in `phantom-protocol` (tracked by #407) cause `pre-pr-check.sh` to exit non-zero. Build and test gates are clean.