### PR TITLE
fix(#378): decouple cursor blink from repaint cadence — stop gemini/TUI cursor strobing

### DIFF
--- a/crates/phantom-adapter/src/adapter.rs
+++ b/crates/phantom-adapter/src/adapter.rs
@@ -272,6 +272,11 @@ pub struct CursorData {
     pub row: usize,
     pub shape: CursorShape,
     pub visible: bool,
+    /// Whether the terminal program requested cursor blinking.  The renderer
+    /// uses an independent clock-driven `CursorBlink` timer and suppresses
+    /// the cursor during the "off" half when this is `true`.  When `false`
+    /// the cursor is drawn unconditionally while visible.
+    pub blinking: bool,
 }
 
 /// Cursor visual style.

--- a/crates/phantom-adapter/src/lib.rs
+++ b/crates/phantom-adapter/src/lib.rs
@@ -647,6 +647,7 @@ mod tests {
                 row: 0,
                 shape: CursorShape::Block,
                 visible: true,
+                blinking: false,
             }),
         };
         assert_eq!(grid.cells.len(), 2);

--- a/crates/phantom-app/src/adapters/terminal.rs
+++ b/crates/phantom-app/src/adapters/terminal.rs
@@ -45,6 +45,7 @@ fn convert_cursor(state: &CursorState) -> CursorData {
         row: state.row,
         shape: convert_cursor_shape(state.shape),
         visible: state.visible,
+        blinking: state.blinking,
     }
 }
 

--- a/crates/phantom-app/src/app.rs
+++ b/crates/phantom-app/src/app.rs
@@ -132,6 +132,13 @@ pub struct App {
     pub(crate) start_time: Instant,
     pub(crate) last_frame: Instant,
 
+    // -- Clock-driven terminal cursor blink timer.
+    //    Ticked once per frame with wall-clock milliseconds.  The terminal
+    //    renderer consults `cursor_blink.is_visible()` instead of drawing the
+    //    cursor on every repaint, so rapidly-repainting TUIs (gemini, htop,
+    //    lazygit) no longer cause the cursor quad to strobe.
+    pub(crate) cursor_blink: phantom_ui::CursorBlink,
+
     // -- Cached metrics --
     pub(crate) cell_size: (f32, f32),
 
@@ -1023,6 +1030,7 @@ impl App {
             demo_post_boot_done: false,
             start_time: now,
             last_frame: now,
+            cursor_blink: phantom_ui::CursorBlink::default(),
             cell_size,
             quit_requested: false,
             supervisor,

--- a/crates/phantom-app/src/render.rs
+++ b/crates/phantom-app/src/render.rs
@@ -9,11 +9,29 @@ use phantom_renderer::postfx::PostFxParams;
 use phantom_renderer::quads::QuadInstance as QI;
 use phantom_ui::widgets::Widget;
 
+use phantom_adapter::adapter::CursorShape;
+
 use crate::app::{App, AppState};
 use crate::pane::{
     CONTAINER_PAD_X_CELLS, CONTAINER_TITLE_H_CELLS, container_rect, pane_inner_rect,
     scrollbar_thumb_rect, scrollbar_track_rect,
 };
+
+/// Return the (width, height) of the cursor quad for the given shape.
+///
+/// - `Block`: full cell — the safe default that matches legacy behaviour.
+/// - `Bar`: a 2-pixel-wide vertical bar on the left edge of the cell.
+/// - `Underline`: a 2-pixel-tall horizontal bar at the bottom of the cell.
+///
+/// The caller is responsible for adjusting the Y origin for `Underline` so the
+/// bar sits flush with the cell bottom rather than the cell top.
+fn cursor_shape_size(shape: CursorShape, cell_size: (f32, f32)) -> (f32, f32) {
+    match shape {
+        CursorShape::Block => (cell_size.0, cell_size.1),
+        CursorShape::Bar => (2.0_f32.max(cell_size.0 * 0.1), cell_size.1),
+        CursorShape::Underline => (cell_size.0, 2.0_f32.max(cell_size.1 * 0.1)),
+    }
+}
 
 impl App {
     // Render
@@ -359,12 +377,19 @@ impl App {
                     glyphs.append(&mut glyph_instances);
 
                     if let Some(ref cursor) = grid.cursor {
-                        if cursor.visible {
+                        let blink_visible = !cursor.blinking || self.cursor_blink.is_visible();
+                        if cursor.visible && blink_visible {
                             let cx = margin + cursor.col as f32 * self.cell_size.0;
                             let cy = margin + cursor.row as f32 * self.cell_size.1;
+                            let (cw, ch) = cursor_shape_size(cursor.shape, self.cell_size);
+                            let cy = if matches!(cursor.shape, CursorShape::Underline) {
+                                cy + self.cell_size.1 - ch
+                            } else {
+                                cy
+                            };
                             quads.push(QI {
                                 pos: [cx, cy],
-                                size: [self.cell_size.0, self.cell_size.1],
+                                size: [cw, ch],
                                 color: [
                                     self.theme.colors.cursor[0],
                                     self.theme.colors.cursor[1],
@@ -629,13 +654,28 @@ impl App {
                 glyphs.append(&mut glyph_instances);
 
                 // Render cursor.
+                // The cursor is drawn only when:
+                //   (a) the terminal reports it as visible (DECTCEM on), AND
+                //   (b) the clock-driven blink timer is in the "on" half-cycle
+                //       (or the terminal did not request blinking at all).
+                // This decouples blink timing from repaint frequency so that
+                // spinner-heavy TUIs (gemini, htop, lazygit) that repaint the
+                // prompt row on every frame no longer cause the cursor quad to
+                // strobe through rapid cell churn.
                 if let Some(ref cursor) = grid.cursor {
-                    if cursor.visible {
+                    let blink_visible = !cursor.blinking || self.cursor_blink.is_visible();
+                    if cursor.visible && blink_visible {
                         let cx = grid.origin.0 + cursor.col as f32 * self.cell_size.0;
                         let cy = grid.origin.1 + cursor.row as f32 * self.cell_size.1;
+                        let (cw, ch) = cursor_shape_size(cursor.shape, self.cell_size);
+                        let cy = if matches!(cursor.shape, CursorShape::Underline) {
+                            cy + self.cell_size.1 - ch
+                        } else {
+                            cy
+                        };
                         quads.push(QI {
                             pos: [cx, cy],
-                            size: [self.cell_size.0, self.cell_size.1],
+                            size: [cw, ch],
                             color: self.theme.colors.cursor,
                             border_radius: 0.0,
                         });

--- a/crates/phantom-app/src/update.rs
+++ b/crates/phantom-app/src/update.rs
@@ -425,6 +425,11 @@ impl App {
             .unwrap_or(0);
         self.notifications.tick(now_ms_tick);
 
+        // Advance the clock-driven cursor blink timer.  This runs once per
+        // frame so blink timing is independent of repaint cadence — rapidly
+        // updating TUIs no longer amplify cursor strobing through cell churn.
+        self.cursor_blink.tick(now_ms_tick);
+
         // Poll the live shader reloader (no-op in release builds).
         self.poll_shader_reload(now_ms_tick);
 

--- a/crates/phantom-terminal/src/output.rs
+++ b/crates/phantom-terminal/src/output.rs
@@ -98,6 +98,11 @@ pub struct CursorState {
     pub col: usize,
     pub visible: bool,
     pub shape: CursorShape,
+    /// Whether the terminal program requested cursor blinking (DECSCUSR codes
+    /// 1/3/5 set this; 2/4/6 clear it).  When `true`, the renderer should
+    /// suppress the cursor during the "off" half of the blink cycle.  When
+    /// `false`, the cursor is always drawn while visible.
+    pub blinking: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -345,6 +350,11 @@ fn extract_cursor<T: EventListener>(term: &Term<T>) -> CursorState {
         AlacCursorShape::Hidden => CursorShape::Block, // shape is irrelevant when hidden
     };
 
+    // Blink flag: read from the active cursor style so the renderer can drive
+    // blink timing independently from the repaint cadence.  DECSCUSR codes
+    // 1/3/5 set blinking=true; 2/4/6 leave it false.
+    let blinking = term.cursor_style().blinking;
+
     // The cursor's grid line (0 = top of live screen, negative = scrollback).
     // Convert to viewport row: viewport_row = grid_line + display_offset.
     // Hide the cursor if it falls outside the visible viewport [0, screen_lines).
@@ -360,6 +370,7 @@ fn extract_cursor<T: EventListener>(term: &Term<T>) -> CursorState {
         col,
         visible,
         shape,
+        blinking,
     }
 }
 


### PR DESCRIPTION
## Summary

- **Root cause**: the cursor quad was emitted on every `render()` call unconditionally, making its visibility coupled to repaint frequency rather than a wall-clock blink timer. Spinner-heavy TUIs (Gemini CLI, htop, lazygit) repaint the prompt row every frame; this caused rapid cell churn under the cursor quad, producing a visible flashing/strobe effect.
- **Fix**: add a `CursorBlink` timer (530 ms period, clock-driven) to `App` and gate cursor quad emission in `render.rs` by `blink.is_visible()` when the terminal has requested blinking. Non-blinking cursors continue to draw unconditionally.
- **Blink flag plumbing**: `blinking: bool` is now carried from `alacritty`'s `term.cursor_style().blinking` through `CursorState` → `CursorData` so the renderer knows whether the program actually requested blinking vs. a static cursor.
- **Shape-correct quads**: replaced the always-full-block cursor with `cursor_shape_size()` that emits a 2 px vertical bar for `Bar`, a 2 px bottom strip for `Underline`, and full cell for `Block`. This avoids the compositing mismatch that amplified churn when a TUI uses a bar cursor over rapidly rewritten cells.

## Files changed

| File | Change |
|------|--------|
| `crates/phantom-terminal/src/output.rs` | Add `blinking: bool` to `CursorState`; plumb from `term.cursor_style().blinking` |
| `crates/phantom-adapter/src/adapter.rs` | Add `blinking: bool` to `CursorData` |
| `crates/phantom-adapter/src/lib.rs` | Fix test init for new `blinking` field |
| `crates/phantom-app/src/adapters/terminal.rs` | Plumb `blinking` through `convert_cursor` |
| `crates/phantom-app/src/app.rs` | Add `cursor_blink: CursorBlink` field |
| `crates/phantom-app/src/update.rs` | Tick `cursor_blink` once per frame with wall-clock ms |
| `crates/phantom-app/src/render.rs` | Gate cursor on blink state; add `cursor_shape_size()` |

## Acceptance criteria check

- [x] Cursor protocol state carried through explicitly (`blinking` flag plumbed from alacritty)
- [x] Blink timing is clock-driven and independent of repaint frequency (`CursorBlink::tick` once per frame)
- [x] Spinner-heavy TUIs no longer produce a flashing input cell (cursor only emitted when blink timer is "on")
- [x] Renderer cursor model documented: Block/Underline/Bar quads with explicit size logic

## Test plan

- [x] `cargo build -p phantom-terminal -p phantom-adapter -p phantom-app` — clean
- [x] `cargo test -p phantom-terminal -p phantom-adapter -p phantom-app` — 22 tests pass
- [x] `cargo clippy --no-deps -p phantom-terminal -p phantom-adapter` — 0 warnings in modified code

Pre-existing `phantom-protocol`/`phantom-memory` clippy errors exist on `main` and are not introduced by this PR.

Closes #378.

🤖 Generated with [Claude Code](https://claude.com/claude-code)