### PR TITLE
fix: preserve color emoji glyphs from foreground tint (closes #356)

### DIFF
--- a/crates/phantom-app/src/app.rs
+++ b/crates/phantom-app/src/app.rs
@@ -14,7 +14,7 @@ use anyhow::Result;
 use log::{debug, info, trace, warn};
 
 use phantom_protocol::AppMessage;
-use phantom_renderer::atlas::GlyphAtlas;
+use phantom_renderer::atlas::{ColorGlyphAtlas, GlyphAtlas};
 use phantom_renderer::gpu::GpuContext;
 use phantom_renderer::grid::GridRenderer;
 use phantom_renderer::postfx::PostFxPipeline;
@@ -108,9 +108,15 @@ pub struct App {
     // -- GPU subsystems --
     pub gpu: GpuContext,
     pub(crate) atlas: GlyphAtlas,
+    /// Color emoji atlas (Rgba8UnormSrgb). Stores SwashContent::Color bitmaps
+    /// un-tinted so emoji render in full color across all themes (fixes #356).
+    pub(crate) color_atlas: ColorGlyphAtlas,
     pub(crate) text_renderer: TextRenderer,
     pub(crate) quad_renderer: QuadRenderer,
     pub(crate) grid_renderer: GridRenderer,
+    /// Grid renderer for full-color emoji glyphs (text_color.wgsl pipeline).
+    /// Draws instances from the Rgba8UnormSrgb color atlas without FG tinting.
+    pub(crate) color_grid_renderer: GridRenderer,
     pub(crate) postfx: PostFxPipeline,
 
     // -- UI --
@@ -246,6 +252,8 @@ pub struct App {
     // -- Render pools (reused each frame via clear() to avoid per-frame allocs) --
     pub(crate) pool_quads: Vec<QuadInstance>,
     pub(crate) pool_glyphs: Vec<phantom_renderer::text::GlyphInstance>,
+    /// Color-glyph instances (Rgba8UnormSrgb atlas, no FG tint). Fixes #356.
+    pub(crate) pool_color_glyphs: Vec<phantom_renderer::text::GlyphInstance>,
     pub(crate) pool_chrome_quads: Vec<QuadInstance>,
     pub(crate) pool_chrome_glyphs: Vec<phantom_renderer::text::GlyphInstance>,
 
@@ -541,10 +549,13 @@ impl App {
 
         // -- Atlas --
         let atlas = GlyphAtlas::new(&gpu.device, &gpu.queue);
+        let color_atlas = ColorGlyphAtlas::new(&gpu.device, &gpu.queue);
 
         // -- Renderers --
         let quad_renderer = QuadRenderer::new(&gpu.device, format);
         let grid_renderer = GridRenderer::new(&gpu.device, format, atlas.bind_group_layout());
+        let color_grid_renderer =
+            GridRenderer::new_color(&gpu.device, format, color_atlas.bind_group_layout());
         let postfx = PostFxPipeline::new(&gpu.device, format, width, height);
         let video_renderer = VideoRenderer::new(&gpu.device, format);
 
@@ -1032,9 +1043,11 @@ impl App {
         Ok(Self {
             gpu,
             atlas,
+            color_atlas,
             text_renderer,
             quad_renderer,
             grid_renderer,
+            color_grid_renderer,
             postfx,
             layout,
             keybinds,
@@ -1081,6 +1094,7 @@ impl App {
             _mcp_listener: mcp_listener,
             pool_quads: Vec::with_capacity(256),
             pool_glyphs: Vec::with_capacity(4096),
+            pool_color_glyphs: Vec::with_capacity(64),
             pool_chrome_quads: Vec::with_capacity(32),
             pool_chrome_glyphs: Vec::with_capacity(256),
             fullscreen_pane: None,

--- a/crates/phantom-app/src/render.rs
+++ b/crates/phantom-app/src/render.rs
@@ -65,33 +65,40 @@ impl App {
         // Reuse pooled Vecs (clear + retain capacity instead of allocating).
         let mut all_quads = std::mem::take(&mut self.pool_quads);
         let mut all_glyphs = std::mem::take(&mut self.pool_glyphs);
+        // Color-emoji instances (Rgba8UnormSrgb atlas, no FG tint — fixes #356).
+        let mut all_color_glyphs = std::mem::take(&mut self.pool_color_glyphs);
         let mut chrome_quads = std::mem::take(&mut self.pool_chrome_quads);
         let mut chrome_glyphs = std::mem::take(&mut self.pool_chrome_glyphs);
         all_quads.clear();
         all_glyphs.clear();
+        all_color_glyphs.clear();
         chrome_quads.clear();
         chrome_glyphs.clear();
 
         match self.state {
             AppState::Boot => {
-                self.render_boot(screen_size, &mut all_quads, &mut all_glyphs);
+                self.render_boot(screen_size, &mut all_quads, &mut all_glyphs, &mut all_color_glyphs);
             }
             AppState::Terminal => {
                 self.render_terminal(
                     screen_size,
                     &mut all_quads,
                     &mut all_glyphs,
+                    &mut all_color_glyphs,
                     &mut chrome_quads,
                     &mut chrome_glyphs,
                 );
             }
         }
 
-        // Upload to GPU.
+        // Upload to GPU — monochrome pipeline.
         self.quad_renderer
             .prepare(&self.gpu.device, &self.gpu.queue, &all_quads, screen_size);
         self.grid_renderer
             .prepare(&self.gpu.device, &self.gpu.queue, &all_glyphs, screen_size);
+        // Upload color-emoji instances to the RGBA pipeline (fixes #356).
+        self.color_grid_renderer
+            .prepare(&self.gpu.device, &self.gpu.queue, &all_color_glyphs, screen_size);
 
         // -----------------------------------------------------------------
         // Scene pass: render into the PostFx offscreen texture
@@ -123,9 +130,13 @@ impl App {
             // Draw quads (backgrounds, cursor, UI chrome).
             self.quad_renderer.render(&mut pass);
 
-            // Draw glyphs (text).
+            // Draw monochrome glyphs (text, Nerd Font icons).
             self.grid_renderer
                 .render(&mut pass, self.atlas.bind_group());
+
+            // Draw full-color emoji glyphs (no FG tint — fixes #356).
+            self.color_grid_renderer
+                .render(&mut pass, self.color_atlas.bind_group());
 
             // Draw video frame (goes through CRT post-processing).
             if self.video_renderer.has_frame() {
@@ -259,6 +270,7 @@ impl App {
         // Return pooled Vecs for reuse next frame (retains capacity).
         self.pool_quads = all_quads;
         self.pool_glyphs = all_glyphs;
+        self.pool_color_glyphs = all_color_glyphs;
         self.pool_chrome_quads = chrome_quads;
         self.pool_chrome_glyphs = chrome_glyphs;
 
@@ -279,22 +291,19 @@ impl App {
         _screen_size: [f32; 2],
         _quads: &mut Vec<QI>,
         glyphs: &mut Vec<phantom_renderer::text::GlyphInstance>,
+        color_glyphs: &mut Vec<phantom_renderer::text::GlyphInstance>,
     ) {
         let boot_lines = self.boot.visible_text();
         let opacity = self.boot.screen_opacity();
 
         // Convert boot text lines to grid cells and render them.
-        // Each BootTextLine has a row, text, color, and chars_visible.
-        // We render them as positioned text using the text renderer.
         for line in &boot_lines {
             if line.chars_visible == 0 {
                 continue;
             }
 
-            // Truncate text to chars_visible for the typewriter effect.
             let visible_text: String = line.text.chars().take(line.chars_visible).collect();
 
-            // Convert to TerminalCells for the text renderer.
             let cells: Vec<phantom_renderer::text::TerminalCell> = visible_text
                 .chars()
                 .map(|ch| phantom_renderer::text::TerminalCell {
@@ -314,19 +323,21 @@ impl App {
 
             let cols = cells.len();
             let origin = (
-                self.cell_size.0 * 2.0, // left margin
+                self.cell_size.0 * 2.0,
                 self.cell_size.1 * line.row as f32,
             );
 
-            let mut line_glyphs = self.text_renderer.prepare_glyphs(
+            let batch = self.text_renderer.prepare_glyphs(
                 &mut self.atlas,
+                &mut self.color_atlas,
                 &self.gpu.queue,
                 &cells,
                 cols,
                 origin,
             );
 
-            glyphs.append(&mut line_glyphs);
+            glyphs.extend(batch.mono);
+            color_glyphs.extend(batch.color);
         }
     }
 
@@ -340,6 +351,7 @@ impl App {
         screen_size: [f32; 2],
         quads: &mut Vec<QI>,
         glyphs: &mut Vec<phantom_renderer::text::GlyphInstance>,
+        color_glyphs: &mut Vec<phantom_renderer::text::GlyphInstance>,
         chrome_quads: &mut Vec<QI>,
         chrome_glyphs: &mut Vec<phantom_renderer::text::GlyphInstance>,
     ) {
@@ -363,18 +375,20 @@ impl App {
                             bg: tc.bg,
                         }));
 
-                    let (mut bg_quads, mut glyph_instances) = GridRenderData::prepare(
+                    let (mut bg_quads, batch) = GridRenderData::prepare(
                         &self.pool_grid_cells,
                         grid.cols,
                         grid.rows,
                         &mut self.text_renderer,
                         &mut self.atlas,
+                        &mut self.color_atlas,
                         &self.gpu.queue,
                         origin,
                         self.cell_size,
                     );
                     quads.append(&mut bg_quads);
-                    glyphs.append(&mut glyph_instances);
+                    glyphs.extend(batch.mono);
+                    color_glyphs.extend(batch.color);
 
                     if let Some(ref cursor) = grid.cursor {
                         let blink_visible = !cursor.blinking || self.cursor_blink.is_visible();
@@ -640,18 +654,20 @@ impl App {
                     }));
 
                 let origin = (grid.origin.0, grid.origin.1);
-                let (mut bg_quads, mut glyph_instances) = GridRenderData::prepare(
+                let (mut bg_quads, batch) = GridRenderData::prepare(
                     &self.pool_grid_cells,
                     grid.cols,
                     grid.rows,
                     &mut self.text_renderer,
                     &mut self.atlas,
+                    &mut self.color_atlas,
                     &self.gpu.queue,
                     origin,
                     self.cell_size,
                 );
                 quads.append(&mut bg_quads);
-                glyphs.append(&mut glyph_instances);
+                glyphs.extend(batch.mono);
+                color_glyphs.extend(batch.color);
 
                 // Render cursor.
                 // The cursor is drawn only when:
@@ -797,15 +813,17 @@ impl App {
             let cols = self.text_cell_buf.len();
             let origin = (seg.x, seg.y);
 
-            let mut seg_glyphs = self.text_renderer.prepare_glyphs(
+            let batch = self.text_renderer.prepare_glyphs(
                 &mut self.atlas,
+                &mut self.color_atlas,
                 &self.gpu.queue,
                 &self.text_cell_buf,
                 cols,
                 origin,
             );
 
-            glyphs.append(&mut seg_glyphs);
+            // Widget text segments are always monochrome; color batch is empty.
+            glyphs.extend(batch.mono);
         }
     }
 }

--- a/crates/phantom-app/src/render_overlay.rs
+++ b/crates/phantom-app/src/render_overlay.rs
@@ -227,14 +227,15 @@ impl App {
         if !cells.is_empty() {
             let cols = cells.len();
             let origin = (box_x + padding, box_y + padding);
-            let mut g = self.text_renderer.prepare_glyphs(
+            let batch = self.text_renderer.prepare_glyphs(
                 &mut self.atlas,
+                &mut self.color_atlas,
                 &self.gpu.queue,
                 &cells,
                 cols,
                 origin,
             );
-            glyphs.append(&mut g);
+            glyphs.extend(batch.mono);
         }
 
         // Option labels.
@@ -252,14 +253,15 @@ impl App {
                     box_x + padding,
                     box_y + padding + (i as f32 + 1.0) * line_height,
                 );
-                let mut g = self.text_renderer.prepare_glyphs(
+                let batch = self.text_renderer.prepare_glyphs(
                     &mut self.atlas,
+                    &mut self.color_atlas,
                     &self.gpu.queue,
                     &opt_cells,
                     cols,
                     origin,
                 );
-                glyphs.append(&mut g);
+                glyphs.extend(batch.mono);
             }
         }
     }
@@ -762,14 +764,15 @@ impl App {
             .collect();
         if !cells.is_empty() {
             let cols = cells.len();
-            let mut g = self.text_renderer.prepare_glyphs(
+            let batch = self.text_renderer.prepare_glyphs(
                 &mut self.atlas,
+                &mut self.color_atlas,
                 &self.gpu.queue,
                 &cells,
                 cols,
                 (x, y),
             );
-            glyphs.append(&mut g);
+            glyphs.extend(batch.mono);
         }
     }
 

--- a/crates/phantom-renderer/src/atlas.rs
+++ b/crates/phantom-renderer/src/atlas.rs
@@ -75,6 +75,7 @@ pub struct GlyphAtlas {
 
 impl GlyphAtlas {
     /// Create a new glyph atlas with the given GPU device.
+    #[must_use]
     pub fn new(device: &Device, _queue: &Queue) -> Self {
         let width = ATLAS_SIZE;
         let height = ATLAS_SIZE;
@@ -294,26 +295,31 @@ impl GlyphAtlas {
     /// The bind group layout for the atlas texture + sampler.
     ///
     /// Bind at group index appropriate for your pipeline (typically group 1).
+    #[must_use]
     pub fn bind_group_layout(&self) -> &BindGroupLayout {
         &self.bind_group_layout
     }
 
     /// The bind group containing the atlas texture view and sampler.
+    #[must_use]
     pub fn bind_group(&self) -> &BindGroup {
         &self.bind_group
     }
 
     /// The texture view, in case you need it outside the standard bind group.
+    #[must_use]
     pub fn texture_view(&self) -> &TextureView {
         &self.view
     }
 
     /// Atlas dimensions in pixels.
+    #[must_use]
     pub fn size(&self) -> (u32, u32) {
         (self.width, self.height)
     }
 
     /// Number of cached glyphs.
+    #[must_use]
     pub fn glyph_count(&self) -> usize {
         self.cache.len()
     }
@@ -354,6 +360,7 @@ pub struct ColorGlyphAtlas {
 
 impl ColorGlyphAtlas {
     /// Create a new color glyph atlas with the given GPU device.
+    #[must_use]
     pub fn new(device: &Device, _queue: &Queue) -> Self {
         let width = COLOR_ATLAS_SIZE;
         let height = COLOR_ATLAS_SIZE;
@@ -548,26 +555,31 @@ impl ColorGlyphAtlas {
     }
 
     /// The bind group layout for the color atlas texture + sampler.
+    #[must_use]
     pub fn bind_group_layout(&self) -> &BindGroupLayout {
         &self.bind_group_layout
     }
 
     /// The bind group containing the color atlas texture view and sampler.
+    #[must_use]
     pub fn bind_group(&self) -> &BindGroup {
         &self.bind_group
     }
 
     /// The texture view for the color atlas.
+    #[must_use]
     pub fn texture_view(&self) -> &TextureView {
         &self.view
     }
 
     /// Color atlas dimensions in pixels.
+    #[must_use]
     pub fn size(&self) -> (u32, u32) {
         (self.width, self.height)
     }
 
     /// Number of cached color glyphs.
+    #[must_use]
     pub fn glyph_count(&self) -> usize {
         self.cache.len()
     }

--- a/crates/phantom-renderer/src/atlas.rs
+++ b/crates/phantom-renderer/src/atlas.rs
@@ -1,8 +1,16 @@
-// Glyph atlas: alpha-only GPU texture, bin-packed via etagere.
+// Glyph atlas: alpha-only GPU texture (R8Unorm) for monochrome glyphs plus a
+// separate RGBA atlas (Rgba8UnormSrgb) for color emoji and other color glyphs.
 //
-// Caches rasterized glyphs (from cosmic-text/swash) into a single R8Unorm
-// texture. The text renderer looks up cached glyphs by `CacheKey` and gets
-// back UV coordinates for instanced quad rendering.
+// Caches rasterized glyphs (from cosmic-text/swash) into two GPU textures:
+//   - `GlyphAtlas`      — R8Unorm, single-channel alpha mask. Monochrome text,
+//                          icon fonts, SubpixelMask glyphs.
+//   - `ColorGlyphAtlas` — Rgba8UnormSrgb, full-color RGBA. SwashContent::Color
+//                          glyphs (emoji, CBDT/COLR/sbix bitmaps). Rendered
+//                          WITHOUT foreground tinting so colors are preserved.
+//
+// The text renderer looks up cached glyphs by `CacheKey` and gets back UV
+// coordinates plus an `is_color` flag that tells the draw caller which atlas
+// (and which shader pipeline) to use for a given instance.
 
 use std::collections::HashMap;
 
@@ -16,10 +24,22 @@ use wgpu::{
     TextureView, TextureViewDimension,
 };
 
-/// Initial atlas dimensions. 1024x1024 single-channel = 1 MiB.
+/// Initial alpha atlas dimensions. 1024x1024 single-channel = 1 MiB.
 const ATLAS_SIZE: u32 = 1024;
 
-/// Cached glyph location in the atlas.
+/// Initial color atlas dimensions. 512x512 RGBA = 1 MiB.
+///
+/// Color emoji glyphs are typically larger than monochrome glyphs, but there
+/// are far fewer of them in typical terminal output. 512x512 gives 64 KiB of
+/// layout area — enough for ~256 16x16 emoji or ~64 32x32 emoji — without
+/// blowing the memory budget of the alpha atlas.
+const COLOR_ATLAS_SIZE: u32 = 512;
+
+/// Cached glyph location in an atlas.
+///
+/// `is_color` indicates which atlas (and shader pipeline) to use:
+/// - `false` → `GlyphAtlas` (R8Unorm, alpha mask, apply foreground tint)
+/// - `true`  → `ColorGlyphAtlas` (Rgba8UnormSrgb, full color, NO tint)
 #[derive(Debug, Clone, Copy)]
 pub struct GlyphEntry {
     /// Pixel rectangle in atlas (x, y, w, h).
@@ -33,6 +53,12 @@ pub struct GlyphEntry {
     /// Glyph placement offset (pixels from pen position).
     pub left: i32,
     pub top: i32,
+    /// True when this entry lives in the color atlas (Rgba8UnormSrgb).
+    ///
+    /// When `true`, the caller MUST route this instance through the color-glyph
+    /// shader pipeline (which samples RGBA and skips the foreground tint
+    /// multiply). When `false` the standard alpha-mask pipeline applies.
+    pub is_color: bool,
 }
 
 /// Alpha-only glyph atlas backed by a wgpu R8Unorm texture.
@@ -202,10 +228,17 @@ impl GlyphAtlas {
         }
 
         // Extract alpha channel depending on content type.
+        // Color glyphs are NOT handled here — callers should use
+        // `ColorGlyphAtlas::get_or_insert` for `SwashContent::Color` images.
+        // If a color glyph somehow reaches this path, fall back to alpha-only
+        // by extracting the alpha channel, preserving correctness at the cost
+        // of losing color (same as the previous behaviour, better than a panic).
         let alpha_data: Vec<u8> = match image.content {
             SwashContent::Mask => image.data.clone(),
             SwashContent::Color => {
-                // RGBA — take the alpha byte from each pixel.
+                // Fall-back: alpha-only extraction.
+                // Callers that care about emoji color should route color glyphs
+                // through `ColorGlyphAtlas` before reaching this point.
                 image.data.chunks_exact(4).map(|px| px[3]).collect()
             }
             SwashContent::SubpixelMask => {
@@ -251,6 +284,7 @@ impl GlyphAtlas {
             ],
             left: placement_left,
             top: placement_top,
+            is_color: false,
         };
 
         self.cache.insert(cache_key, entry);
@@ -289,6 +323,256 @@ impl GlyphAtlas {
     /// The GPU texture is not cleared — old data is simply overwritten as new
     /// glyphs are allocated. This is safe because we always upload before
     /// sampling a region.
+    pub fn clear(&mut self) {
+        self.cache.clear();
+        self.allocator.clear();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ColorGlyphAtlas — Rgba8UnormSrgb texture for full-color emoji glyphs
+// ---------------------------------------------------------------------------
+
+/// Full-color glyph atlas backed by a wgpu `Rgba8UnormSrgb` texture.
+///
+/// Stores `SwashContent::Color` glyphs (CBDT, COLR, sbix bitmaps) in their
+/// native RGBA form. The associated shader pipeline samples all four channels
+/// and does NOT multiply by the foreground tint color, so emoji render with
+/// their original colors across all themes.
+///
+/// Memory: `COLOR_ATLAS_SIZE²` × 4 bytes = 1 MiB at the default 512×512 size.
+pub struct ColorGlyphAtlas {
+    texture: Texture,
+    view: TextureView,
+    allocator: AtlasAllocator,
+    cache: HashMap<CacheKey, GlyphEntry>,
+    bind_group: BindGroup,
+    bind_group_layout: BindGroupLayout,
+    width: u32,
+    height: u32,
+}
+
+impl ColorGlyphAtlas {
+    /// Create a new color glyph atlas with the given GPU device.
+    pub fn new(device: &Device, _queue: &Queue) -> Self {
+        let width = COLOR_ATLAS_SIZE;
+        let height = COLOR_ATLAS_SIZE;
+
+        let texture = device.create_texture(&TextureDescriptor {
+            label: Some("color-glyph-atlas"),
+            size: Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: TextureDimension::D2,
+            format: TextureFormat::Rgba8UnormSrgb,
+            usage: TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+
+        let view = texture.create_view(&Default::default());
+
+        let sampler = device.create_sampler(&SamplerDescriptor {
+            label: Some("color-glyph-atlas-sampler"),
+            address_mode_u: AddressMode::ClampToEdge,
+            address_mode_v: AddressMode::ClampToEdge,
+            mag_filter: FilterMode::Linear,
+            min_filter: FilterMode::Linear,
+            ..Default::default()
+        });
+
+        let bind_group_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+            label: Some("color-glyph-atlas-layout"),
+            entries: &[
+                BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: ShaderStages::FRAGMENT,
+                    ty: BindingType::Texture {
+                        sample_type: TextureSampleType::Float { filterable: true },
+                        view_dimension: TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: ShaderStages::FRAGMENT,
+                    ty: BindingType::Sampler(SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
+        });
+
+        let bind_group = device.create_bind_group(&BindGroupDescriptor {
+            label: Some("color-glyph-atlas-bind-group"),
+            layout: &bind_group_layout,
+            entries: &[
+                BindGroupEntry {
+                    binding: 0,
+                    resource: BindingResource::TextureView(&view),
+                },
+                BindGroupEntry {
+                    binding: 1,
+                    resource: BindingResource::Sampler(&sampler),
+                },
+            ],
+        });
+
+        let allocator = AtlasAllocator::new(size2(width as i32, height as i32));
+
+        Self {
+            texture,
+            view,
+            allocator,
+            cache: HashMap::new(),
+            bind_group,
+            bind_group_layout,
+            width,
+            height,
+        }
+    }
+
+    /// Try to allocate a rectangular region in the color atlas.
+    pub fn allocate(&mut self, width: u32, height: u32) -> Option<Allocation> {
+        if width == 0 || height == 0 {
+            return None;
+        }
+        self.allocator.allocate(size2(width as i32, height as i32))
+    }
+
+    /// Upload RGBA glyph bitmap data into a previously allocated region.
+    ///
+    /// `data` must be `rect_width * rect_height * 4` bytes of RGBA pixel data.
+    pub fn upload(&self, queue: &Queue, x: u32, y: u32, width: u32, height: u32, data: &[u8]) {
+        debug_assert_eq!(
+            data.len(),
+            (width * height * 4) as usize,
+            "color upload size mismatch: expected {}x{}x4={}, got {}",
+            width,
+            height,
+            width * height * 4,
+            data.len(),
+        );
+
+        queue.write_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: &self.texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d { x, y, z: 0 },
+                aspect: wgpu::TextureAspect::All,
+            },
+            data,
+            wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(width * 4),
+                rows_per_image: None,
+            },
+            Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+        );
+    }
+
+    /// Look up a color glyph in the cache, or rasterize + allocate + upload it.
+    ///
+    /// Only `SwashContent::Color` images are stored; other content types return
+    /// `None` so the caller falls through to the monochrome `GlyphAtlas`.
+    ///
+    /// Returns a `GlyphEntry` with `is_color = true` on success.
+    pub fn get_or_insert(
+        &mut self,
+        queue: &Queue,
+        font_system: &mut FontSystem,
+        swash_cache: &mut SwashCache,
+        cache_key: CacheKey,
+    ) -> Option<GlyphEntry> {
+        // Fast path: already cached.
+        if let Some(&entry) = self.cache.get(&cache_key) {
+            return Some(entry);
+        }
+
+        // Rasterize via swash.
+        let image = swash_cache.get_image(font_system, cache_key).as_ref()?;
+
+        // Only handle RGBA color bitmaps; fall through for everything else.
+        if image.content != SwashContent::Color {
+            return None;
+        }
+
+        let glyph_width = image.placement.width;
+        let glyph_height = image.placement.height;
+
+        if glyph_width == 0 || glyph_height == 0 {
+            return None;
+        }
+
+        let rgba_data = image.data.clone();
+        let placement_left = image.placement.left;
+        let placement_top = image.placement.top;
+
+        // Allocate space in the color atlas.
+        let allocation = self.allocate(glyph_width, glyph_height)?;
+        let rect = allocation.rectangle;
+
+        let x = rect.min.x as u32;
+        let y = rect.min.y as u32;
+
+        // Upload the full RGBA bitmap.
+        self.upload(queue, x, y, glyph_width, glyph_height, &rgba_data);
+
+        // Compute normalized UV coordinates.
+        let atlas_w = self.width as f32;
+        let atlas_h = self.height as f32;
+        let entry = GlyphEntry {
+            x,
+            y,
+            width: glyph_width,
+            height: glyph_height,
+            uv_min: [x as f32 / atlas_w, y as f32 / atlas_h],
+            uv_max: [
+                (x + glyph_width) as f32 / atlas_w,
+                (y + glyph_height) as f32 / atlas_h,
+            ],
+            left: placement_left,
+            top: placement_top,
+            is_color: true,
+        };
+
+        self.cache.insert(cache_key, entry);
+        Some(entry)
+    }
+
+    /// The bind group layout for the color atlas texture + sampler.
+    pub fn bind_group_layout(&self) -> &BindGroupLayout {
+        &self.bind_group_layout
+    }
+
+    /// The bind group containing the color atlas texture view and sampler.
+    pub fn bind_group(&self) -> &BindGroup {
+        &self.bind_group
+    }
+
+    /// The texture view for the color atlas.
+    pub fn texture_view(&self) -> &TextureView {
+        &self.view
+    }
+
+    /// Color atlas dimensions in pixels.
+    pub fn size(&self) -> (u32, u32) {
+        (self.width, self.height)
+    }
+
+    /// Number of cached color glyphs.
+    pub fn glyph_count(&self) -> usize {
+        self.cache.len()
+    }
+
+    /// Evict all cached color glyphs and reset the allocator.
     pub fn clear(&mut self) {
         self.cache.clear();
         self.allocator.clear();

--- a/crates/phantom-renderer/src/clip.rs
+++ b/crates/phantom-renderer/src/clip.rs
@@ -42,11 +42,13 @@ impl ClipRect {
     ///
     /// `(x, y)` is the top-left corner; `(w, h)` is the size. If either
     /// `w` or `h` is non-positive, this rect is the "no clip" sentinel.
+    #[must_use]
     pub const fn new(x: f32, y: f32, w: f32, h: f32) -> Self {
         Self { xywh: [x, y, w, h] }
     }
 
     /// Convenience constructor returning the "no clip" sentinel.
+    #[must_use]
     pub const fn none() -> Self {
         Self::NONE
     }
@@ -56,6 +58,7 @@ impl ClipRect {
     /// The contract: any non-positive width or height means "no clip".
     /// This matches the fragment shader test
     /// `clip.z > 0.0 && clip.w > 0.0`.
+    #[must_use]
     pub fn is_none(&self) -> bool {
         self.xywh[2] <= 0.0 || self.xywh[3] <= 0.0
     }
@@ -65,6 +68,7 @@ impl ClipRect {
     /// Uses `shader_location = 4`, reserved across both quad and glyph
     /// pipelines for the clip-rect attribute. The stride must equal
     /// `size_of::<ClipRect>() == 16`.
+    #[must_use]
     pub fn buffer_layout() -> VertexBufferLayout<'static> {
         const ATTRS: &[VertexAttribute] = &[VertexAttribute {
             format: VertexFormat::Float32x4,

--- a/crates/phantom-renderer/src/debug_draw.rs
+++ b/crates/phantom-renderer/src/debug_draw.rs
@@ -12,6 +12,7 @@ pub struct Vec2 {
 }
 
 impl Vec2 {
+    #[must_use]
     pub fn new(x: f32, y: f32) -> Self {
         Self { x, y }
     }
@@ -51,16 +52,19 @@ impl Default for DrawOptions {
 }
 
 impl DrawOptions {
+    #[must_use]
     pub fn color(mut self, color: [f32; 4]) -> Self {
         self.color = color;
         self
     }
 
+    #[must_use]
     pub fn line_width(mut self, width: f32) -> Self {
         self.line_width = width;
         self
     }
 
+    #[must_use]
     pub fn red() -> Self {
         Self {
             color: [1.0, 0.0, 0.0, 1.0],
@@ -68,10 +72,12 @@ impl DrawOptions {
         }
     }
 
+    #[must_use]
     pub fn green() -> Self {
         Self::default()
     }
 
+    #[must_use]
     pub fn blue() -> Self {
         Self {
             color: [0.0, 0.0, 1.0, 1.0],
@@ -79,6 +85,7 @@ impl DrawOptions {
         }
     }
 
+    #[must_use]
     pub fn yellow() -> Self {
         Self {
             color: [1.0, 1.0, 0.0, 1.0],
@@ -86,6 +93,7 @@ impl DrawOptions {
         }
     }
 
+    #[must_use]
     pub fn white() -> Self {
         Self {
             color: [1.0, 1.0, 1.0, 1.0],
@@ -93,6 +101,7 @@ impl DrawOptions {
         }
     }
 
+    #[must_use]
     pub fn cyan() -> Self {
         Self {
             color: [0.0, 1.0, 1.0, 1.0],
@@ -116,6 +125,7 @@ pub struct DebugDrawManager {
 }
 
 impl DebugDrawManager {
+    #[must_use]
     pub fn new() -> Self {
         Self {
             queue: Vec::new(),
@@ -127,6 +137,7 @@ impl DebugDrawManager {
         self.enabled = enabled;
     }
 
+    #[must_use]
     pub fn is_enabled(&self) -> bool {
         self.enabled
     }
@@ -214,6 +225,7 @@ impl DebugDrawManager {
     }
 
     /// Number of primitives currently in the queue.
+    #[must_use]
     pub fn primitive_count(&self) -> usize {
         self.queue.len()
     }

--- a/crates/phantom-renderer/src/glyph_clip.rs
+++ b/crates/phantom-renderer/src/glyph_clip.rs
@@ -33,11 +33,13 @@ impl GlyphClipRect {
     pub const NONE: GlyphClipRect = GlyphClipRect { xywh: [0.0; 4] };
 
     /// Construct a glyph clip rect from explicit pixel dimensions.
+    #[must_use]
     pub const fn new(x: f32, y: f32, w: f32, h: f32) -> Self {
         Self { xywh: [x, y, w, h] }
     }
 
     /// Convenience constructor returning the "no clip" sentinel.
+    #[must_use]
     pub const fn none() -> Self {
         Self::NONE
     }
@@ -46,6 +48,7 @@ impl GlyphClipRect {
     ///
     /// Mirrors `ClipRect::is_none`: any non-positive width or height means
     /// "no clip", which matches the (future) fragment-shader test.
+    #[must_use]
     pub fn is_none(&self) -> bool {
         self.xywh[2] <= 0.0 || self.xywh[3] <= 0.0
     }
@@ -55,6 +58,7 @@ impl GlyphClipRect {
     /// `shader_location = 4` is reserved across both quad and glyph
     /// pipelines for the clip-rect attribute. Stride matches
     /// `size_of::<GlyphClipRect>() == 16`.
+    #[must_use]
     pub fn buffer_layout() -> VertexBufferLayout<'static> {
         const ATTRS: &[VertexAttribute] = &[VertexAttribute {
             format: VertexFormat::Float32x4,

--- a/crates/phantom-renderer/src/grid.rs
+++ b/crates/phantom-renderer/src/grid.rs
@@ -8,9 +8,9 @@
 // and uniform buffer. It renders textured glyph quads from the atlas using
 // instanced drawing with GlyphInstance data from the TextRenderer.
 
-use crate::atlas::GlyphAtlas;
+use crate::atlas::{ColorGlyphAtlas, GlyphAtlas};
 use crate::quads::QuadInstance;
-use crate::text::{GlyphInstance, TerminalCell, TextRenderer};
+use crate::text::{GlyphBatch, GlyphInstance, TerminalCell, TextRenderer};
 
 use wgpu::{
     util::{BufferInitDescriptor, DeviceExt},
@@ -26,12 +26,11 @@ use wgpu::{
 // WGSL shader for textured glyph quad rendering
 // ---------------------------------------------------------------------------
 
-/// WGSL source for the glyph atlas text pipeline, loaded from the shared
-/// `shaders/text.wgsl` file at compile time.
-///
-/// Extracting the shader to a standalone file enables syntax highlighting,
-/// offline naga validation, and cleaner diffs when the pipeline changes.
+/// WGSL source for the monochrome glyph atlas text pipeline.
 const GLYPH_SHADER_SRC: &str = include_str!("../../../shaders/text.wgsl");
+
+/// WGSL source for the full-color emoji glyph pipeline (no FG tint, fixes #356).
+const COLOR_GLYPH_SHADER_SRC: &str = include_str!("../../../shaders/text_color.wgsl");
 
 // ---------------------------------------------------------------------------
 // Uniform buffer
@@ -182,6 +181,110 @@ impl GridRenderer {
         }
     }
 
+    /// Create the full-color emoji glyph rendering pipeline (fixes #356).
+    ///
+    /// Uses `shaders/text_color.wgsl` which samples RGBA directly from the
+    /// `ColorGlyphAtlas` (Rgba8UnormSrgb) without applying the foreground tint
+    /// multiply. Bind group layout must come from `ColorGlyphAtlas::bind_group_layout()`.
+    pub fn new_color(
+        device: &Device,
+        format: TextureFormat,
+        color_atlas_bind_group_layout: &BindGroupLayout,
+    ) -> Self {
+        let shader = device.create_shader_module(ShaderModuleDescriptor {
+            label: Some("color-glyph-shader"),
+            source: wgpu::ShaderSource::Wgsl(COLOR_GLYPH_SHADER_SRC.into()),
+        });
+
+        let uniform_bind_group_layout =
+            device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+                label: Some("color-grid-uniform-layout"),
+                entries: &[BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: ShaderStages::VERTEX,
+                    ty: BindingType::Buffer {
+                        ty: BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                }],
+            });
+
+        let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
+            label: Some("color-grid-pipeline-layout"),
+            bind_group_layouts: &[&uniform_bind_group_layout, color_atlas_bind_group_layout],
+            push_constant_ranges: &[],
+        });
+
+        let pipeline = device.create_render_pipeline(&RenderPipelineDescriptor {
+            label: Some("color-glyph-pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                compilation_options: Default::default(),
+                buffers: &[GlyphInstance::buffer_layout()],
+            },
+            fragment: Some(FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                compilation_options: Default::default(),
+                targets: &[Some(ColorTargetState {
+                    format,
+                    blend: Some(BlendState::ALPHA_BLENDING),
+                    write_mask: ColorWrites::ALL,
+                })],
+            }),
+            primitive: PrimitiveState {
+                topology: PrimitiveTopology::TriangleList,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: MultisampleState::default(),
+            multiview: None,
+            cache: None,
+        });
+
+        let uniforms = Uniforms {
+            screen_size: [1.0, 1.0],
+            _pad: [0.0; 2],
+        };
+        let uniform_buf = device.create_buffer_init(&BufferInitDescriptor {
+            label: Some("color-grid-uniform-buf"),
+            contents: bytemuck::bytes_of(&uniforms),
+            usage: BufferUsages::UNIFORM | BufferUsages::COPY_DST,
+        });
+
+        let uniform_bind_group = device.create_bind_group(&BindGroupDescriptor {
+            label: Some("color-grid-uniform-bind-group"),
+            layout: &uniform_bind_group_layout,
+            entries: &[BindGroupEntry {
+                binding: 0,
+                resource: uniform_buf.as_entire_binding(),
+            }],
+        });
+
+        // Color emoji glyphs are fewer; start with a smaller buffer (256).
+        const COLOR_GLYPH_CAPACITY: u32 = 256;
+        let instance_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("color-glyph-instance-buf"),
+            size: (COLOR_GLYPH_CAPACITY as u64) * (std::mem::size_of::<GlyphInstance>() as u64),
+            usage: BufferUsages::VERTEX | BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        Self {
+            pipeline,
+            instance_buf,
+            uniform_buf,
+            uniform_bind_group,
+            uniform_bind_group_layout,
+            instance_count: 0,
+            instance_capacity: COLOR_GLYPH_CAPACITY,
+        }
+    }
+
     /// Upload glyph instances and screen-size uniform for the current frame.
     ///
     /// Call once per frame before `render`. If the instance buffer is too small
@@ -325,13 +428,14 @@ fn is_default_bg(bg: &[f32; 4]) -> bool {
 /// usage:
 ///
 /// ```ignore
-/// let (bg_quads, glyph_instances) = GridRenderData::prepare(
+/// let (bg_quads, glyph_batch) = GridRenderData::prepare(
 ///     &grid_cells, cols, rows,
-///     &mut text_renderer, &mut atlas, queue,
+///     &mut text_renderer, &mut atlas, &mut color_atlas, queue,
 ///     origin, cell_size,
 /// );
 /// quad_renderer.prepare(device, queue, &bg_quads, screen_size);
-/// grid_renderer.prepare(device, queue, &glyph_instances, screen_size);
+/// grid_renderer.prepare(device, queue, &glyph_batch.mono, screen_size);
+/// color_grid_renderer.prepare(device, queue, &glyph_batch.color, screen_size);
 /// ```
 pub struct GridRenderData;
 
@@ -343,27 +447,30 @@ impl GridRenderData {
     ///   - Delegates glyph rasterization/placement to `TextRenderer::prepare_glyphs`.
     ///
     /// # Arguments
-    /// * `cells` — row-major grid of `GridCell` (`rows * cols` elements).
-    /// * `cols` — number of columns per row.
-    /// * `rows` — number of rows.
+    /// * `cells`       — row-major grid of `GridCell` (`rows * cols` elements).
+    /// * `cols`        — number of columns per row.
+    /// * `rows`        — number of rows.
     /// * `text_renderer` — the text shaping/rasterization engine.
-    /// * `atlas` — the glyph atlas for caching rasterized glyphs on the GPU.
-    /// * `queue` — wgpu queue for atlas texture uploads.
-    /// * `origin` — top-left pixel coordinate of the grid: (x, y).
-    /// * `cell_size` — monospace cell dimensions: (width, height) in pixels.
+    /// * `atlas`       — the monochrome R8Unorm glyph atlas.
+    /// * `color_atlas` — the RGBA Rgba8UnormSrgb color emoji atlas.
+    /// * `queue`       — wgpu queue for atlas texture uploads.
+    /// * `origin`      — top-left pixel coordinate of the grid: (x, y).
+    /// * `cell_size`   — monospace cell dimensions: (width, height) in pixels.
     ///
     /// # Returns
-    /// `(background_quads, glyph_instances)` ready for `QuadRenderer` and `GridRenderer`.
+    /// `(background_quads, glyph_batch)`. Route `glyph_batch.mono` to the
+    /// monochrome pipeline and `glyph_batch.color` to the color pipeline.
     pub fn prepare(
         cells: &[GridCell],
         cols: usize,
         rows: usize,
         text_renderer: &mut TextRenderer,
         atlas: &mut GlyphAtlas,
+        color_atlas: &mut ColorGlyphAtlas,
         queue: &Queue,
         origin: (f32, f32),
         cell_size: (f32, f32),
-    ) -> (Vec<QuadInstance>, Vec<GlyphInstance>) {
+    ) -> (Vec<QuadInstance>, GlyphBatch) {
         let total = cols * rows;
         debug_assert!(
             cells.len() >= total,
@@ -402,10 +509,16 @@ impl GridRenderData {
         let terminal_cells: Vec<TerminalCell> =
             cells[..total].iter().map(|c| c.as_terminal_cell()).collect();
 
-        let glyph_instances =
-            text_renderer.prepare_glyphs(atlas, queue, &terminal_cells, cols, origin);
+        let glyph_batch = text_renderer.prepare_glyphs(
+            atlas,
+            color_atlas,
+            queue,
+            &terminal_cells,
+            cols,
+            origin,
+        );
 
-        (bg_quads, glyph_instances)
+        (bg_quads, glyph_batch)
     }
 
     /// Optimized variant that merges adjacent cells with the same background
@@ -418,10 +531,11 @@ impl GridRenderData {
         rows: usize,
         text_renderer: &mut TextRenderer,
         atlas: &mut GlyphAtlas,
+        color_atlas: &mut ColorGlyphAtlas,
         queue: &Queue,
         origin: (f32, f32),
         cell_size: (f32, f32),
-    ) -> (Vec<QuadInstance>, Vec<GlyphInstance>) {
+    ) -> (Vec<QuadInstance>, GlyphBatch) {
         let total = cols * rows;
         debug_assert!(
             cells.len() >= total,
@@ -475,10 +589,16 @@ impl GridRenderData {
         let terminal_cells: Vec<TerminalCell> =
             cells[..total].iter().map(|c| c.as_terminal_cell()).collect();
 
-        let glyph_instances =
-            text_renderer.prepare_glyphs(atlas, queue, &terminal_cells, cols, origin);
+        let glyph_batch = text_renderer.prepare_glyphs(
+            atlas,
+            color_atlas,
+            queue,
+            &terminal_cells,
+            cols,
+            origin,
+        );
 
-        (bg_quads, glyph_instances)
+        (bg_quads, glyph_batch)
     }
 }
 

--- a/crates/phantom-renderer/src/grid.rs
+++ b/crates/phantom-renderer/src/grid.rs
@@ -77,6 +77,7 @@ impl GridRenderer {
     /// * `format` — surface texture format for the color target.
     /// * `atlas_bind_group_layout` — bind group layout from `GlyphAtlas::bind_group_layout()`,
     ///   bound at group 1 (texture + sampler).
+    #[must_use]
     pub fn new(
         device: &Device,
         format: TextureFormat,
@@ -186,6 +187,7 @@ impl GridRenderer {
     /// Uses `shaders/text_color.wgsl` which samples RGBA directly from the
     /// `ColorGlyphAtlas` (Rgba8UnormSrgb) without applying the foreground tint
     /// multiply. Bind group layout must come from `ColorGlyphAtlas::bind_group_layout()`.
+    #[must_use]
     pub fn new_color(
         device: &Device,
         format: TextureFormat,
@@ -357,11 +359,13 @@ impl GridRenderer {
     }
 
     /// Number of glyphs that will be drawn on the next `render` call.
+    #[must_use]
     pub fn glyph_count(&self) -> u32 {
         self.instance_count
     }
 
     /// Current instance buffer capacity in number of glyphs.
+    #[must_use]
     pub fn capacity(&self) -> u32 {
         self.instance_capacity
     }
@@ -460,6 +464,8 @@ impl GridRenderData {
     /// # Returns
     /// `(background_quads, glyph_batch)`. Route `glyph_batch.mono` to the
     /// monochrome pipeline and `glyph_batch.color` to the color pipeline.
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
     pub fn prepare(
         cells: &[GridCell],
         cols: usize,
@@ -525,6 +531,8 @@ impl GridRenderData {
     /// color into wider quads, reducing draw overhead for colored rows.
     ///
     /// Otherwise identical to `prepare`.
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
     pub fn prepare_merged(
         cells: &[GridCell],
         cols: usize,

--- a/crates/phantom-renderer/src/images.rs
+++ b/crates/phantom-renderer/src/images.rs
@@ -155,6 +155,7 @@ pub struct DecodedImage {
 
 impl DecodedImage {
     /// Decode a PNG file from raw bytes into an RGBA `DecodedImage`.
+    #[must_use]
     pub fn from_png(png_bytes: &[u8]) -> Option<Self> {
         let decoder = png::Decoder::new(png_bytes);
         let mut reader = decoder.read_info().ok()?;
@@ -208,6 +209,7 @@ impl DecodedImage {
     }
 
     /// Create a `DecodedImage` from raw RGB data (24-bit, no alpha).
+    #[must_use]
     pub fn from_rgb(width: u32, height: u32, rgb: &[u8]) -> Option<Self> {
         let expected = (width * height * 3) as usize;
         if rgb.len() < expected {
@@ -228,6 +230,7 @@ impl DecodedImage {
     }
 
     /// Create a `DecodedImage` from raw RGBA data (32-bit).
+    #[must_use]
     pub fn from_rgba(width: u32, height: u32, rgba: Vec<u8>) -> Option<Self> {
         let expected = (width * height * 4) as usize;
         if rgba.len() < expected {
@@ -292,6 +295,7 @@ pub struct ImageManager {
 
 impl ImageManager {
     /// Create the image rendering pipeline.
+    #[must_use]
     pub fn new(device: &Device, format: TextureFormat) -> Self {
         // -- Shader module --
         let shader = device.create_shader_module(ShaderModuleDescriptor {
@@ -542,6 +546,7 @@ impl ImageManager {
     }
 
     /// Number of placed images.
+    #[must_use]
     pub fn image_count(&self) -> usize {
         self.images.len()
     }
@@ -607,6 +612,7 @@ impl ImageManager {
     }
 
     /// Get a reference to a placed image by ID.
+    #[must_use]
     pub fn get(&self, id: u32) -> Option<&ImagePlacement> {
         self.images.get(&id)
     }

--- a/crates/phantom-renderer/src/postfx.rs
+++ b/crates/phantom-renderer/src/postfx.rs
@@ -114,6 +114,8 @@ const _: () = assert!(size_of::<PostFxParams>() == 64);
 
 impl PostFxParams {
     /// Create params from theme shader params, elapsed time, and screen dimensions.
+    #[must_use]
+    #[allow(clippy::too_many_arguments)]
     pub fn from_theme(
         scanline_intensity: f32,
         bloom_intensity: f32,
@@ -176,6 +178,7 @@ impl PostFxPipeline {
     ///
     /// The offscreen texture is created at the given dimensions and matches the
     /// surface format so the scene can render directly into it.
+    #[must_use]
     pub fn new(device: &Device, surface_format: TextureFormat, width: u32, height: u32) -> Self {
         // -- Shader module --
         // `crt_wgsl_source()` returns the embedded compile-time copy in
@@ -341,6 +344,7 @@ impl PostFxPipeline {
     /// The scene pass uses this as its color attachment. After the scene pass
     /// completes, call [`render`](Self::render) to composite the CRT effects
     /// onto the final surface.
+    #[must_use]
     pub fn scene_view(&self) -> &TextureView {
         &self.offscreen_view
     }
@@ -350,6 +354,7 @@ impl PostFxPipeline {
     /// The texture is created with `COPY_SRC` usage so it can be copied into
     /// a staging buffer for PNG encoding. This is the pre-CRT scene — clean
     /// pixels, useful for UI debugging without shader distortion.
+    #[must_use]
     pub fn scene_texture(&self) -> &Texture {
         &self.offscreen_texture
     }

--- a/crates/phantom-renderer/src/quads.rs
+++ b/crates/phantom-renderer/src/quads.rs
@@ -244,6 +244,7 @@ const INITIAL_CAPACITY: u32 = 1024;
 
 impl QuadRenderer {
     /// Create the quad renderer: compiles shaders, creates pipeline and buffers.
+    #[must_use]
     pub fn new(device: &Device, format: TextureFormat) -> Self {
         // -- Shader module --
         let shader = device.create_shader_module(ShaderModuleDescriptor {

--- a/crates/phantom-renderer/src/screenshot.rs
+++ b/crates/phantom-renderer/src/screenshot.rs
@@ -50,7 +50,7 @@ pub fn capture_frame(
     let bytes_per_pixel = 4u32;
     let unpadded_bytes_per_row = width * bytes_per_pixel;
     let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
-    let padded_bytes_per_row = (unpadded_bytes_per_row + align - 1) / align * align;
+    let padded_bytes_per_row = unpadded_bytes_per_row.div_ceil(align) * align;
 
     let buffer_size = (padded_bytes_per_row * height) as u64;
 

--- a/crates/phantom-renderer/src/text.rs
+++ b/crates/phantom-renderer/src/text.rs
@@ -72,6 +72,7 @@ impl GlyphInstance {
         3 => Float32x2,
     ];
 
+    #[must_use]
     pub fn buffer_layout() -> wgpu::VertexBufferLayout<'static> {
         wgpu::VertexBufferLayout {
             array_stride: std::mem::size_of::<GlyphInstance>() as wgpu::BufferAddress,
@@ -134,6 +135,7 @@ impl TextRenderer {
     ///
     /// Initializes the system font database and configures for monospace rendering.
     /// Line height is set to 1.2x the font size by default, suitable for terminal use.
+    #[must_use]
     pub fn new(font_size: f32) -> Self {
         let font_system = FontSystem::new();
         let swash_cache = SwashCache::new();
@@ -150,6 +152,7 @@ impl TextRenderer {
     }
 
     /// Access the underlying font system.
+    #[must_use]
     pub fn font_system(&self) -> &FontSystem {
         &self.font_system
     }
@@ -165,11 +168,13 @@ impl TextRenderer {
     }
 
     /// Get the configured font size.
+    #[must_use]
     pub fn font_size(&self) -> f32 {
         self.font_size
     }
 
     /// Get the configured line height.
+    #[must_use]
     pub fn line_height(&self) -> f32 {
         self.line_height
     }
@@ -364,6 +369,7 @@ impl TextRenderer {
 
     /// Shape a single character through cosmic-text ONCE and return the cache key
     /// + positioning offsets. Returns None if the character produces no glyphs.
+    #[allow(clippy::must_use_candidate)]
     fn shape_char(&mut self, ch: char, cell_w: f32, cell_h: f32) -> Option<(CacheKey, f32, f32)> {
         let metrics = Metrics::new(self.font_size, self.line_height);
         let attrs = Attrs::new().family(Family::Monospace);
@@ -379,7 +385,7 @@ impl TextRenderer {
         buffer.shape_until_scroll(&mut self.font_system, true);
 
         for run in buffer.layout_runs() {
-            for glyph in run.glyphs.iter() {
+            if let Some(glyph) = run.glyphs.iter().next() {
                 let physical = glyph.physical((0.0, 0.0), 1.0);
                 return Some((physical.cache_key, run.line_y, physical.x as f32));
             }

--- a/crates/phantom-renderer/src/text.rs
+++ b/crates/phantom-renderer/src/text.rs
@@ -13,7 +13,7 @@
 // `crates/phantom-renderer/src/glyph_clip.rs` for the canonical home.
 pub use crate::glyph_clip::GlyphClipRect;
 
-use crate::atlas::{GlyphAtlas, GlyphEntry};
+use crate::atlas::{ColorGlyphAtlas, GlyphAtlas, GlyphEntry};
 use cosmic_text::{
     Attrs, Buffer, CacheKey, Family, FontSystem, LayoutGlyph, Metrics, Shaping, SwashCache,
 };
@@ -22,6 +22,11 @@ use cosmic_text::{
 ///
 /// Each visible glyph in the terminal grid becomes one of these,
 /// uploaded to a vertex buffer and drawn as an instanced quad.
+///
+/// Both the monochrome pipeline (`text.wgsl`) and the color pipeline
+/// (`text_color.wgsl`) share this layout. The `is_color` field is not exposed
+/// to the shader as an attribute — it is a CPU-side tag used to split
+/// instances into two draw batches before upload.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, bytemuck::Pod, bytemuck::Zeroable)]
 pub struct GlyphInstance {
@@ -30,13 +35,32 @@ pub struct GlyphInstance {
     /// UV rectangle in the atlas: [min_u, min_v, max_u, max_v].
     pub uv_rect: [f32; 4],
     /// RGBA color, linear.
+    ///
+    /// For monochrome glyphs (`is_color == 0`) this is multiplied by the
+    /// atlas alpha mask to produce the final fragment color.
+    /// For color glyphs (`is_color == 1`) this field is present only for
+    /// buffer-layout compatibility and is **ignored** by the color shader.
     pub color: [f32; 4],
     /// Size of the glyph quad in pixels: [width, height].
     pub size: [f32; 2],
+    /// `1` when this glyph lives in the `ColorGlyphAtlas` (Rgba8UnormSrgb),
+    /// `0` for the monochrome `GlyphAtlas` (R8Unorm).
+    ///
+    /// Used by the CPU-side batching logic in `TextRenderer::prepare_glyphs`
+    /// to split instances into `GlyphBatch::mono` and `GlyphBatch::color`
+    /// before uploading to separate GPU pipelines. Not an attribute in WGSL.
+    pub is_color: u32,
+    /// Explicit padding so `size_of::<GlyphInstance>()` stays a multiple of
+    /// 16 bytes (required by `bytemuck::Pod`).
+    pub _pad: u32,
 }
 
 impl GlyphInstance {
     /// Vertex buffer layout for instanced rendering.
+    ///
+    /// Attributes match both `text.wgsl` and `text_color.wgsl`. The `is_color`
+    /// and `_pad` fields are not exposed as shader attributes — they are
+    /// tail-padding used only by the CPU split step.
     pub const ATTRIBS: [wgpu::VertexAttribute; 4] = wgpu::vertex_attr_array![
         // position
         0 => Float32x2,
@@ -55,6 +79,22 @@ impl GlyphInstance {
             attributes: &Self::ATTRIBS,
         }
     }
+}
+
+/// Two batches of glyph instances produced by `TextRenderer::prepare_glyphs`.
+///
+/// `mono` contains instances for the monochrome R8Unorm atlas pipeline
+/// (`text.wgsl`, foreground tint applied). `color` contains instances for the
+/// `Rgba8UnormSrgb` color atlas pipeline (`text_color.wgsl`, no tint).
+///
+/// Draw callers upload and draw each batch with its corresponding pipeline and
+/// atlas bind group.
+#[derive(Debug, Default)]
+pub struct GlyphBatch {
+    /// Instances that live in `GlyphAtlas` (R8Unorm, monochrome text).
+    pub mono: Vec<GlyphInstance>,
+    /// Instances that live in `ColorGlyphAtlas` (Rgba8UnormSrgb, color emoji).
+    pub color: Vec<GlyphInstance>,
 }
 
 /// A single terminal cell with character and color data.
@@ -186,16 +226,28 @@ impl TextRenderer {
         size
     }
 
-    /// Rasterize a single glyph and upload it to the atlas.
+    /// Rasterize a single glyph and upload it to the appropriate atlas.
     ///
-    /// Returns the atlas entry with UV coordinates and placement offsets,
-    /// or `None` if the glyph could not be rasterized (whitespace, missing, atlas full).
+    /// Tries the `ColorGlyphAtlas` first for `SwashContent::Color` bitmaps,
+    /// falling back to the monochrome `GlyphAtlas`. Returns the `GlyphEntry`
+    /// (with `is_color` set) or `None` if the glyph could not be rasterized.
     pub fn rasterize_glyph(
         &mut self,
         atlas: &mut GlyphAtlas,
+        color_atlas: &mut ColorGlyphAtlas,
         queue: &wgpu::Queue,
         cache_key: CacheKey,
     ) -> Option<GlyphEntry> {
+        // Try color atlas first; if the glyph is not SwashContent::Color it
+        // returns None and we fall through to the monochrome atlas.
+        if let Some(entry) = color_atlas.get_or_insert(
+            queue,
+            &mut self.font_system,
+            &mut self.swash_cache,
+            cache_key,
+        ) {
+            return Some(entry);
+        }
         atlas.get_or_insert(
             queue,
             &mut self.font_system,
@@ -206,32 +258,37 @@ impl TextRenderer {
 
     /// Prepare glyph instances for a grid of terminal cells.
     ///
-    /// Given a 2D grid of cells (row-major, `rows * cols` elements), produces a
-    /// `Vec<GlyphInstance>` suitable for GPU instanced rendering. Each non-whitespace
-    /// glyph is rasterized (if not already cached) and positioned on the pixel grid.
+    /// Returns a `GlyphBatch` with two instance lists:
+    /// - `GlyphBatch::mono`  — monochrome R8Unorm atlas instances (foreground tint).
+    /// - `GlyphBatch::color` — full-color Rgba8UnormSrgb atlas instances (no tint).
     ///
     /// # Arguments
-    /// * `atlas` - The glyph atlas for caching rasterized glyphs.
-    /// * `queue` - The wgpu queue for atlas texture uploads.
-    /// * `cells` - Row-major grid of terminal cells (`rows * cols` elements).
-    /// * `cols` - Number of columns per row.
-    /// * `origin` - Top-left pixel offset for the grid: (x, y).
+    /// * `atlas`       - The monochrome glyph atlas.
+    /// * `color_atlas` - The RGBA color glyph atlas for emoji.
+    /// * `queue`       - The wgpu queue for atlas texture uploads.
+    /// * `cells`       - Row-major grid of terminal cells (`rows * cols` elements).
+    /// * `cols`        - Number of columns per row.
+    /// * `origin`      - Top-left pixel offset for the grid: (x, y).
     pub fn prepare_glyphs(
         &mut self,
         atlas: &mut GlyphAtlas,
+        color_atlas: &mut ColorGlyphAtlas,
         queue: &wgpu::Queue,
         cells: &[TerminalCell],
         cols: usize,
         origin: (f32, f32),
-    ) -> Vec<GlyphInstance> {
+    ) -> GlyphBatch {
         if cols == 0 {
-            return Vec::new();
+            return GlyphBatch::default();
         }
 
         let (cell_w, cell_h) = self.measure_cell();
         let rows = cells.len() / cols;
 
-        let mut instances = Vec::with_capacity(cells.len());
+        let mut batch = GlyphBatch {
+            mono: Vec::with_capacity(cells.len()),
+            color: Vec::new(),
+        };
 
         for row in 0..rows {
             for col in 0..cols {
@@ -256,18 +313,30 @@ impl TextRenderer {
                     continue;
                 };
 
-                if let Some(entry) = atlas.get_or_insert(
-                    queue,
-                    &mut self.font_system,
-                    &mut self.swash_cache,
-                    cache_key,
-                ) {
+                // Try color atlas first, then monochrome.
+                let entry = color_atlas
+                    .get_or_insert(
+                        queue,
+                        &mut self.font_system,
+                        &mut self.swash_cache,
+                        cache_key,
+                    )
+                    .or_else(|| {
+                        atlas.get_or_insert(
+                            queue,
+                            &mut self.font_system,
+                            &mut self.swash_cache,
+                            cache_key,
+                        )
+                    });
+
+                if let Some(entry) = entry {
                     let cell_x = origin.0 + (col as f32) * cell_w;
                     let baseline_y = origin.1 + (row as f32) * cell_h + line_y;
                     let px = cell_x + phys_x + entry.left as f32;
                     let py = baseline_y - entry.top as f32;
 
-                    instances.push(GlyphInstance {
+                    let instance = GlyphInstance {
                         position: [px, py],
                         uv_rect: [
                             entry.uv_min[0],
@@ -277,12 +346,20 @@ impl TextRenderer {
                         ],
                         color: cell.fg,
                         size: [entry.width as f32, entry.height as f32],
-                    });
+                        is_color: u32::from(entry.is_color),
+                        _pad: 0,
+                    };
+
+                    if entry.is_color {
+                        batch.color.push(instance);
+                    } else {
+                        batch.mono.push(instance);
+                    }
                 }
             }
         }
 
-        instances
+        batch
     }
 
     /// Shape a single character through cosmic-text ONCE and return the cache key
@@ -313,28 +390,34 @@ impl TextRenderer {
     /// Prepare glyph instances from a pre-shaped cosmic-text `Buffer`.
     ///
     /// Lower-level method for cases where the caller already has a shaped buffer
-    /// (e.g., UI overlays, debug text, non-grid text).
+    /// (e.g., UI overlays, debug text, non-grid text). Returns a `GlyphBatch`
+    /// with separate mono and color instance lists, same as `prepare_glyphs`.
     pub fn prepare_glyphs_from_buffer(
         &mut self,
         atlas: &mut GlyphAtlas,
+        color_atlas: &mut ColorGlyphAtlas,
         queue: &wgpu::Queue,
         buffer: &Buffer,
         default_color: [f32; 4],
         origin: (f32, f32),
-    ) -> Vec<GlyphInstance> {
-        let mut instances = Vec::new();
+    ) -> GlyphBatch {
+        let mut batch = GlyphBatch::default();
 
         for run in buffer.layout_runs() {
             for glyph in run.glyphs.iter() {
                 let physical = glyph.physical((origin.0, origin.1), 1.0);
 
-                if let Some(entry) = self.rasterize_glyph(atlas, queue, physical.cache_key) {
+                if let Some(entry) =
+                    self.rasterize_glyph(atlas, color_atlas, queue, physical.cache_key)
+                {
+                    // For color glyphs the fragment shader ignores the color
+                    // attribute, so we pass it anyway for layout compatibility.
                     let color = glyph_color(glyph, default_color);
 
                     let px = physical.x as f32 + entry.left as f32;
                     let py = run.line_y + physical.y as f32 - entry.top as f32;
 
-                    instances.push(GlyphInstance {
+                    let instance = GlyphInstance {
                         position: [px, py],
                         uv_rect: [
                             entry.uv_min[0],
@@ -344,12 +427,20 @@ impl TextRenderer {
                         ],
                         color,
                         size: [entry.width as f32, entry.height as f32],
-                    });
+                        is_color: u32::from(entry.is_color),
+                        _pad: 0,
+                    };
+
+                    if entry.is_color {
+                        batch.color.push(instance);
+                    } else {
+                        batch.mono.push(instance);
+                    }
                 }
             }
         }
 
-        instances
+        batch
     }
 }
 
@@ -380,11 +471,13 @@ mod tests {
             uv_rect: [0.0, 0.0, 1.0, 1.0],
             color: [1.0, 1.0, 1.0, 1.0],
             size: [10.0, 20.0],
+            is_color: 0,
+            _pad: 0,
         };
         let bytes = bytemuck::bytes_of(&instance);
         assert_eq!(bytes.len(), std::mem::size_of::<GlyphInstance>());
-        // 12 floats * 4 bytes = 48
-        assert_eq!(std::mem::size_of::<GlyphInstance>(), 48);
+        // 12 floats (48 bytes) + is_color (4 bytes) + _pad (4 bytes) = 56 bytes
+        assert_eq!(std::mem::size_of::<GlyphInstance>(), 56);
     }
 
     #[test]
@@ -426,8 +519,145 @@ mod tests {
     #[test]
     fn buffer_layout_stride() {
         let layout = GlyphInstance::buffer_layout();
-        assert_eq!(layout.array_stride, 48);
+        // array_stride covers the full struct including is_color + _pad.
+        assert_eq!(layout.array_stride, 56);
         assert_eq!(layout.step_mode, wgpu::VertexStepMode::Instance);
         assert_eq!(layout.attributes.len(), 4);
+    }
+
+    // -------------------------------------------------------------------------
+    // Regression tests: color-glyph tint preservation (closes #356)
+    // -------------------------------------------------------------------------
+
+    /// A `GlyphInstance` tagged `is_color = 1` must round-trip through
+    /// `bytemuck` without corruption, and the `is_color` byte must survive.
+    ///
+    /// This is the CPU-side contract: the draw caller reads `is_color` to split
+    /// instances into mono vs. color batches. If bytemuck silently mangles the
+    /// field, the routing breaks and color glyphs will be sent to the wrong
+    /// pipeline, tinting them with the foreground color (regression of #356).
+    #[test]
+    fn color_glyph_instance_roundtrips_through_bytemuck() {
+        let instance = GlyphInstance {
+            position: [10.0, 20.0],
+            uv_rect: [0.1, 0.2, 0.9, 0.8],
+            // Deliberately non-white foreground — if color glyphs were tinted by
+            // this value the emoji would appear as solid phosphor-green, which
+            // is the exact symptom of #356.
+            color: [0.0, 1.0, 0.0, 1.0],
+            size: [32.0, 32.0],
+            is_color: 1,
+            _pad: 0,
+        };
+
+        let bytes = bytemuck::bytes_of(&instance);
+        assert_eq!(bytes.len(), 56, "struct must be 56 bytes");
+
+        let recovered: &GlyphInstance = bytemuck::from_bytes(bytes);
+        assert_eq!(recovered.is_color, 1, "is_color must survive bytemuck round-trip");
+        assert_eq!(recovered.position, instance.position);
+        assert_eq!(recovered.uv_rect, instance.uv_rect);
+        assert_eq!(recovered.color, instance.color);
+        assert_eq!(recovered.size, instance.size);
+    }
+
+    /// `GlyphBatch` must correctly separate mono and color instances so that
+    /// color glyphs are never fed to the foreground-tint pipeline.
+    ///
+    /// Simulates what `prepare_glyphs` does internally: two instances, one
+    /// mono, one color. Verifies the split is correct and that the color
+    /// instance carries `is_color = 1`.
+    #[test]
+    fn glyph_batch_separates_mono_and_color_instances() {
+        let mono_inst = GlyphInstance {
+            position: [0.0, 0.0],
+            uv_rect: [0.0, 0.0, 0.5, 0.5],
+            color: [0.0, 1.0, 0.0, 1.0], // phosphor green — should tint mono
+            size: [8.0, 16.0],
+            is_color: 0,
+            _pad: 0,
+        };
+        let color_inst = GlyphInstance {
+            position: [8.0, 0.0],
+            uv_rect: [0.0, 0.0, 0.25, 0.25],
+            color: [0.0, 1.0, 0.0, 1.0], // ignored by color shader
+            size: [32.0, 32.0],
+            is_color: 1,
+            _pad: 0,
+        };
+
+        let mut batch = GlyphBatch::default();
+        if mono_inst.is_color == 0 {
+            batch.mono.push(mono_inst);
+        } else {
+            batch.color.push(mono_inst);
+        }
+        if color_inst.is_color == 0 {
+            batch.mono.push(color_inst);
+        } else {
+            batch.color.push(color_inst);
+        }
+
+        assert_eq!(batch.mono.len(), 1, "one monochrome glyph");
+        assert_eq!(batch.color.len(), 1, "one color glyph");
+        assert_eq!(batch.mono[0].is_color, 0);
+        assert_eq!(batch.color[0].is_color, 1);
+
+        // The foreground-tint color is present in the color instance's `color`
+        // field but must NOT be applied by the draw call. This is enforced by
+        // routing through `text_color.wgsl`, which discards `color` in the
+        // fragment shader. The test documents the invariant: a color glyph's
+        // `color` field is irrelevant — the atlas RGBA is the ground truth.
+        let emoji_atlas_rgba = [1.0_f32, 0.7, 0.1, 1.0]; // hypothetical beer emoji pixel
+        let fg_tint = batch.color[0].color; // [0, 1, 0, 1] — phosphor green
+        // If the wrong pipeline were used: emoji_atlas_rgba * fg_tint → wrong color.
+        let would_be_wrong = [
+            emoji_atlas_rgba[0] * fg_tint[0],
+            emoji_atlas_rgba[1] * fg_tint[1],
+            emoji_atlas_rgba[2] * fg_tint[2],
+            emoji_atlas_rgba[3] * fg_tint[3],
+        ];
+        // Confirm the tinted result differs from the original atlas color.
+        assert_ne!(
+            would_be_wrong, emoji_atlas_rgba,
+            "tinting a color glyph by FG must change its color (proves the \
+             guard matters — color pipeline must NOT apply this multiply)"
+        );
+    }
+
+    /// `GlyphEntry` with `is_color = false` must never be routed to the color
+    /// atlas pipeline. This is the complementary regression guard: monochrome
+    /// glyphs (Nerd Font icons, regular ASCII) must continue to be tinted.
+    #[test]
+    fn monochrome_glyph_entry_is_not_color() {
+        let entry = GlyphEntry {
+            x: 0,
+            y: 0,
+            width: 8,
+            height: 16,
+            uv_min: [0.0, 0.0],
+            uv_max: [0.5, 0.5],
+            left: 0,
+            top: 0,
+            is_color: false,
+        };
+        assert!(!entry.is_color, "monochrome entry must not set is_color");
+    }
+
+    /// `GlyphEntry` with `is_color = true` identifies a color bitmap glyph.
+    #[test]
+    fn color_glyph_entry_is_color() {
+        let entry = GlyphEntry {
+            x: 0,
+            y: 0,
+            width: 32,
+            height: 32,
+            uv_min: [0.0, 0.0],
+            uv_max: [0.5, 0.5],
+            left: 0,
+            top: 0,
+            is_color: true,
+        };
+        assert!(entry.is_color, "color emoji entry must set is_color");
     }
 }

--- a/crates/phantom-renderer/src/video.rs
+++ b/crates/phantom-renderer/src/video.rs
@@ -73,6 +73,7 @@ pub struct VideoRenderer {
 }
 
 impl VideoRenderer {
+    #[must_use]
     pub fn new(device: &Device, format: TextureFormat) -> Self {
         let shader = device.create_shader_module(ShaderModuleDescriptor {
             label: Some("video-shader"),
@@ -294,6 +295,7 @@ impl VideoRenderer {
     }
 
     /// Whether a frame has been uploaded.
+    #[must_use]
     pub fn has_frame(&self) -> bool {
         self.texture.is_some()
     }

--- a/crates/phantom-renderer/tests/text_color_shader.rs
+++ b/crates/phantom-renderer/tests/text_color_shader.rs
@@ -1,0 +1,84 @@
+// Naga compile-time validation for shaders/text_color.wgsl (closes #356).
+//
+// Parses and validates the WGSL source for the color-glyph pipeline through
+// naga's full validation pipeline without requiring a GPU device.
+//
+// Additionally checks that the fragment shader does NOT reference a `color`
+// output multiply — i.e. that the foreground-tint operation is absent from the
+// color pipeline (the root cause of #356 in text.wgsl).
+
+/// Color glyph shader source — the same bytes wgpu sees at runtime.
+const COLOR_SHADER_SRC: &str = include_str!("../../../shaders/text_color.wgsl");
+
+#[test]
+fn text_color_wgsl_parses_and_validates() {
+    use naga::valid::{Capabilities, ValidationFlags, Validator};
+
+    let module = naga::front::wgsl::parse_str(COLOR_SHADER_SRC)
+        .expect("shaders/text_color.wgsl must parse without errors");
+
+    let mut validator = Validator::new(ValidationFlags::all(), Capabilities::empty());
+    validator
+        .validate(&module)
+        .expect("shaders/text_color.wgsl must pass naga validation");
+}
+
+#[test]
+fn text_color_wgsl_has_vertex_and_fragment_entry_points() {
+    use naga::ShaderStage;
+
+    let module = naga::front::wgsl::parse_str(COLOR_SHADER_SRC)
+        .expect("shaders/text_color.wgsl must parse");
+
+    let stages: Vec<ShaderStage> = module
+        .entry_points
+        .iter()
+        .map(|ep| ep.stage)
+        .collect();
+
+    assert!(
+        stages.contains(&ShaderStage::Vertex),
+        "shaders/text_color.wgsl must declare a @vertex entry point"
+    );
+    assert!(
+        stages.contains(&ShaderStage::Fragment),
+        "shaders/text_color.wgsl must declare a @fragment entry point"
+    );
+}
+
+/// Regression guard for #356: the color-glyph fragment shader must NOT
+/// multiply the sampled RGBA by a foreground `color` attribute.
+///
+/// The monochrome shader (`text.wgsl`) produces:
+///   `vec4<f32>(in.color.rgb, in.color.a * atlas_alpha)`
+/// which tints every glyph — including color emoji — by the theme foreground.
+///
+/// The color shader must sample all four channels and return them unchanged:
+///   `textureSample(atlas_texture, atlas_sampler, in.uv)`
+///
+/// This test checks that the shader source contains the correct `textureSample`
+/// call and does NOT contain `in.color` in the fragment function (which would
+/// indicate the tint multiply is still present).
+#[test]
+fn text_color_wgsl_fragment_does_not_tint_by_foreground_color() {
+    // The fragment function must sample the full RGBA atlas color directly.
+    assert!(
+        COLOR_SHADER_SRC.contains("textureSample(atlas_texture, atlas_sampler, in.uv)"),
+        "color shader fs_main must return textureSample directly (no tint multiply)"
+    );
+
+    // The color shader's VertexOutput must NOT propagate `color` to the fragment
+    // stage (no `@location(1) color` in VertexOutput for the color pipeline).
+    // We verify the fragment function body does not reference `in.color`.
+    // Locate the fs_main body by finding everything after `fn fs_main`.
+    let fs_start = COLOR_SHADER_SRC
+        .find("fn fs_main")
+        .expect("color shader must have fn fs_main");
+    let fs_body = &COLOR_SHADER_SRC[fs_start..];
+
+    assert!(
+        !fs_body.contains("in.color"),
+        "color shader fs_main must NOT reference in.color — \
+         applying foreground tint to color emoji is the bug fixed by #356"
+    );
+}

--- a/shaders/text_color.wgsl
+++ b/shaders/text_color.wgsl
@@ -1,0 +1,94 @@
+// Color-glyph atlas text rendering pipeline.
+//
+// Renders per-glyph textured quads sampled from an Rgba8UnormSrgb color atlas.
+// Used exclusively for SwashContent::Color glyphs (CBDT/COLR/sbix bitmaps,
+// i.e. full-color emoji).
+//
+// Unlike the monochrome text pipeline (text.wgsl), the fragment shader samples
+// all four RGBA channels and does NOT multiply by the per-instance foreground
+// color. This preserves the original glyph colors across all themes.
+//
+// CRT post-processing (scanlines, bloom, curvature) is applied on top of the
+// composed frame, so color emoji still picks up the retro aesthetic.
+//
+// Bind groups
+// -----------
+//   group(0) binding(0) — screen-size uniform  (VERTEX stage)
+//   group(1) binding(0) — atlas_texture         (FRAGMENT stage, Rgba8UnormSrgb)
+//   group(1) binding(1) — atlas_sampler         (FRAGMENT stage)
+//
+// Per-instance vertex attributes (step mode: Instance)
+// -------------------------------------------------------
+//   location(0) position : vec2<f32>   — top-left pixel coordinate
+//   location(1) uv_rect  : vec4<f32>   — [min_u, min_v, max_u, max_v]
+//   location(2) color    : vec4<f32>   — unused (ignored); kept for layout
+//                                        compatibility with the mono pipeline
+//   location(3) size     : vec2<f32>   — glyph quad size in pixels [w, h]
+
+// ---- Uniforms (group 0) ----
+struct Uniforms {
+    screen_size: vec2<f32>,
+};
+
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+
+// ---- Color atlas texture + sampler (group 1) ----
+@group(1) @binding(0) var atlas_texture: texture_2d<f32>;
+@group(1) @binding(1) var atlas_sampler: sampler;
+
+// ---- Per-instance glyph data (same layout as mono pipeline) ----
+struct GlyphInstance {
+    @location(0) position: vec2<f32>,
+    @location(1) uv_rect: vec4<f32>,    // [min_u, min_v, max_u, max_v]
+    @location(2) color: vec4<f32>,      // ignored for color glyphs
+    @location(3) size: vec2<f32>,
+};
+
+struct VertexOutput {
+    @builtin(position) clip_pos: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+};
+
+// Unit quad: two triangles covering (0,0) to (1,1).
+var<private> UNIT_QUAD: array<vec2<f32>, 6> = array<vec2<f32>, 6>(
+    vec2<f32>(0.0, 0.0),
+    vec2<f32>(1.0, 0.0),
+    vec2<f32>(0.0, 1.0),
+    vec2<f32>(1.0, 0.0),
+    vec2<f32>(1.0, 1.0),
+    vec2<f32>(0.0, 1.0),
+);
+
+@vertex
+fn vs_main(
+    @builtin(vertex_index) vertex_idx: u32,
+    instance: GlyphInstance,
+) -> VertexOutput {
+    let corner = UNIT_QUAD[vertex_idx];
+
+    // Expand unit quad to glyph pixel dimensions at the instance position.
+    let pixel_pos = instance.position + corner * instance.size;
+
+    // Convert pixel coordinates to NDC (y flipped: (0,0) is top-left).
+    let ndc = vec2<f32>(
+        (pixel_pos.x / uniforms.screen_size.x) * 2.0 - 1.0,
+        1.0 - (pixel_pos.y / uniforms.screen_size.y) * 2.0,
+    );
+
+    // Interpolate UV from the atlas sub-rectangle.
+    let uv = mix(instance.uv_rect.xy, instance.uv_rect.zw, corner);
+
+    var out: VertexOutput;
+    out.clip_pos = vec4<f32>(ndc, 0.0, 1.0);
+    out.uv = uv;
+    return out;
+}
+
+@fragment
+fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
+    // Sample all four RGBA channels from the color atlas.
+    // Do NOT tint by foreground color — the bitmap already contains the
+    // correct emoji colors (CBDT/COLR/sbix). Applying the foreground
+    // multiply is exactly the bug this shader variant is here to prevent.
+    return textureSample(atlas_texture, atlas_sampler, in.uv);
+}


### PR DESCRIPTION
## Summary

- **Root cause**: `GlyphAtlas` stored `SwashContent::Color` bitmaps in an `R8Unorm` atlas by extracting only the alpha byte, then the `text.wgsl` fragment shader multiplied by the foreground tint color — turning every emoji a flat phosphor-green.
- **Fix**: Route `SwashContent::Color` glyphs to a new `ColorGlyphAtlas` (`Rgba8UnormSrgb`, 512×512, 1 MiB) and draw them with a new `text_color.wgsl` shader that samples full RGBA without applying the FG tint multiply. Monochrome glyphs (regular text, Nerd Font icons) continue through the existing alpha-mask pipeline unchanged.
- **Batching**: `GlyphEntry` gains an `is_color` flag; `prepare_glyphs` returns a `GlyphBatch { mono, color }` so callers separate instances at the CPU before upload. A second `GridRenderer` (`color_grid_renderer`) draws the color batch using the color atlas bind group.

## Changed files

| File | Change |
|------|--------|
| `crates/phantom-renderer/src/atlas.rs` | Add `GlyphEntry::is_color`; add `ColorGlyphAtlas` (Rgba8UnormSrgb) |
| `crates/phantom-renderer/src/text.rs` | Add `GlyphBatch`; route via color atlas first in `prepare_glyphs`/`rasterize_glyph`; update `GlyphInstance` size (48→56 bytes) |
| `crates/phantom-renderer/src/grid.rs` | Add `GridRenderer::new_color`; update `GridRenderData::prepare` signature to thread `color_atlas` and return `GlyphBatch` |
| `shaders/text_color.wgsl` | New shader — samples RGBA atlas directly, no FG tint |
| `crates/phantom-app/src/app.rs` | Add `color_atlas`, `color_grid_renderer`, `pool_color_glyphs` fields |
| `crates/phantom-app/src/render.rs` | Thread color pipeline through scene+overlay passes |
| `crates/phantom-app/src/render_overlay.rs` | Update `prepare_glyphs` call sites |
| `crates/phantom-renderer/tests/text_color_shader.rs` | New: naga validation + FG-tint-absence regression tests |

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test -p phantom-renderer` — 43/43 unit tests + 3 new color shader tests pass
- [x] `crates/phantom-renderer/tests/text_color_shader.rs` — validates `text_color.wgsl` via naga and asserts `fs_main` does not reference `in.color`
- [x] New unit tests: `color_glyph_instance_roundtrips_through_bytemuck`, `glyph_batch_separates_mono_and_color_instances`, `monochrome_glyph_entry_is_not_color`, `color_glyph_entry_is_color`
- [x] Existing `buffer_layout_stride` test updated to reflect new `GlyphInstance` size (56 bytes)
- [x] Clippy failures are pre-existing `must_use` tech-debt (covered by #407)
- [ ] Visual: run `brew upgrade` in Phantom and verify beer mug/sparkles render in full color across phosphor/amber/blood/vapor themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)