### PR TITLE
feat(phantom-app): wire real DagExplorerContext at Cartographer spawn (closes #437)

### DIFF
--- a/crates/phantom-app/src/agent_pane/dispatch_ctx.rs
+++ b/crates/phantom-app/src/agent_pane/dispatch_ctx.rs
@@ -89,6 +89,18 @@ impl AgentPane {
             None
         };
 
+        // Issue #437: forward the real DagExplorerContext for Cartographer
+        // panes. The context is populated at spawn time by
+        // `App::spawn_agent_pane_with_opts` via `set_dag_explorer_context`.
+        // For all non-Cartographer panes, and for Cartographer panes spawned
+        // without App wiring (headless / test), this remains `None` — the
+        // dispatch gate returns the graceful error string rather than panicking.
+        let dag_explorer = if self.role == phantom_agents::role::AgentRole::Cartographer {
+            self.dag_explorer.clone()
+        } else {
+            None
+        };
+
         Some(phantom_agents::dispatch::DispatchContext {
             self_ref,
             role: self.role,
@@ -104,12 +116,7 @@ impl AgentPane {
             correlation_id: None,
             ticket_dispatcher,
             runtime_mode: phantom_agents::dispatch::RuntimeMode::Normal,
-            // Issue #67: DAG explorer context for the Cartographer role.
-            // `None` for all non-Cartographer panes and for Cartographer panes
-            // whose parent App has not yet wired a DagExplorerContext (Phase 2
-            // wiring; the Cartographer pane will populate this when the DAG
-            // viewer surface is available).
-            dag_explorer: None,
+            dag_explorer,
         })
     }
 }

--- a/crates/phantom-app/src/agent_pane/mod.rs
+++ b/crates/phantom-app/src/agent_pane/mod.rs
@@ -244,6 +244,21 @@ pub(crate) struct AgentPane {
     /// `None` for legacy / test callers that do not wire a quarantine registry;
     /// the gate skips the check (fail-open) so old paths are unaffected.
     pub(super) quarantine: Option<Arc<Mutex<phantom_agents::quarantine::QuarantineRegistry>>>,
+
+    /// Issue #437: DAG explorer context for the Cartographer role.
+    ///
+    /// Populated at spawn time when the pane's role is
+    /// [`phantom_agents::role::AgentRole::Cartographer`]. The context holds an
+    /// `Arc<Mutex<DagStore>>` shared across all dispatch turns for this pane so
+    /// every Cartographer tool call (list_nodes, mark_complete, annotate, …)
+    /// operates on the same in-memory task DAG for the lifetime of the session.
+    ///
+    /// `None` for all non-Cartographer panes and for any Cartographer pane
+    /// spawned before the wiring is applied (legacy / headless). When `None`,
+    /// the DAG tools return the canonical `"dag explorer not available"` error
+    /// string instead of panicking — the graceful fallback is always preserved.
+    pub(super) dag_explorer:
+        Option<phantom_agents::dag_explorer::DagExplorerContext>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -303,6 +318,7 @@ impl AgentPane {
             agent_capture: None,
             capture_session_uuid: uuid::Uuid::nil(),
             capture_tool_calls: Vec::new(),
+            dag_explorer: None,
         }
     }
 
@@ -483,6 +499,7 @@ impl AgentPane {
             capture_session_uuid: uuid::Uuid::nil(),
             capture_tool_calls: Vec::new(),
             quarantine: None,
+            dag_explorer: None,
         }
     }
 
@@ -531,6 +548,23 @@ impl AgentPane {
         dispatcher: Arc<phantom_agents::dispatcher::GhTicketDispatcher>,
     ) {
         self.ticket_dispatcher = Some(dispatcher);
+    }
+
+    /// Wire the DAG explorer context for Cartographer-role panes.
+    ///
+    /// Called by `App::spawn_agent_pane_with_opts` when the pane's role is
+    /// [`phantom_agents::role::AgentRole::Cartographer`] and a shared
+    /// `DagStore` is available. The context is then forwarded into every
+    /// `DispatchContext` this pane creates so that Cartographer tool calls
+    /// (dag_list_nodes, dag_mark_complete, etc.) operate on a real store
+    /// instead of returning the graceful `"dag explorer not available"` error.
+    ///
+    /// `None` is the safe default — all non-Cartographer panes keep `None`.
+    pub(crate) fn set_dag_explorer_context(
+        &mut self,
+        ctx: phantom_agents::dag_explorer::DagExplorerContext,
+    ) {
+        self.dag_explorer = Some(ctx);
     }
 
     /// Wire the history capture sidecar into this pane.

--- a/crates/phantom-app/src/agent_pane/spawn.rs
+++ b/crates/phantom-app/src/agent_pane/spawn.rs
@@ -151,6 +151,17 @@ impl App {
             }
         }
 
+        // Issue #437: wire a real DagExplorerContext for Cartographer-role panes.
+        // A fresh DagStore is created per-pane so each Cartographer session
+        // operates on its own isolated task DAG. The graceful error-string
+        // fallback is preserved: if the inspector adapter is absent the DAG
+        // viewer commands simply will not fire, but the Cartographer's in-memory
+        // task-management tools (list, annotate, mark_complete, …) still work.
+        if agent_pane.role == phantom_agents::role::AgentRole::Cartographer {
+            let dag_ctx = phantom_agents::dag_explorer::DagExplorerContext::empty();
+            agent_pane.set_dag_explorer_context(dag_ctx);
+        }
+
         // Wire the history capture sidecar so this agent's tool calls and
         // output are recorded in the session's agents.jsonl sidecar.
         if let Some(ref capture) = self.agent_capture {

--- a/crates/phantom-app/src/agent_pane/tests.rs
+++ b/crates/phantom-app/src/agent_pane/tests.rs
@@ -68,6 +68,7 @@ fn agent_with_handle() -> (AgentPane, mpsc::Sender<ApiEvent>) {
         agent_capture: None,
         capture_session_uuid: uuid::Uuid::nil(),
         capture_tool_calls: Vec::new(),
+        dag_explorer: None,
     };
     (pane, tx)
 }
@@ -169,6 +170,7 @@ fn poll_returns_false_when_no_handle() {
         agent_capture: None,
         capture_session_uuid: uuid::Uuid::nil(),
         capture_tool_calls: Vec::new(),
+        dag_explorer: None,
     };
     assert!(!pane.poll());
 }
@@ -1043,6 +1045,7 @@ fn spawn_agent_pane_task_matches_prompt() {
         agent_capture: None,
         capture_session_uuid: uuid::Uuid::nil(),
         capture_tool_calls: Vec::new(),
+        dag_explorer: None,
     };
     let _ = tx; // keep sender alive so handle stays live
     assert_eq!(pane.task, "fix the failing tests");
@@ -1343,5 +1346,242 @@ fn resolve_api_config_claude_rejects_wrong_key() {
     assert!(
         result.is_none(),
         "Claude model + only OPENAI_API_KEY set → must return None"
+    );
+}
+
+// =========================================================================
+// Issue #437: Cartographer DAG tool dispatch end-to-end tests
+// =========================================================================
+
+/// A Cartographer-role pane with a wired DagExplorerContext must produce a
+/// DispatchContext whose `dag_explorer` field is `Some`.  This is the
+/// acceptance test for the production call site (dispatch_ctx.rs line that
+/// previously always returned `None`).
+#[test]
+fn cartographer_pane_with_dag_context_has_some_in_dispatch_ctx() {
+    use phantom_agents::dag_explorer::DagExplorerContext;
+    use phantom_agents::role::{AgentRef, AgentRole, SpawnSource};
+    use phantom_memory::event_log::EventLog;
+    use std::sync::{Arc, Mutex};
+    use tempfile::TempDir;
+
+    let tmp = TempDir::new().unwrap();
+
+    let (mut pane, _tx) = agent_with_handle();
+
+    let registry = Arc::new(Mutex::new(phantom_agents::inbox::AgentRegistry::new()));
+    let event_log = Arc::new(Mutex::new(
+        EventLog::open(&tmp.path().join("events.jsonl")).unwrap(),
+    ));
+    let pending_spawn = phantom_agents::composer_tools::new_spawn_subagent_queue();
+    let self_ref =
+        AgentRef::new(10, AgentRole::Cartographer, "cartographer-1", SpawnSource::User);
+
+    pane.set_substrate_handles(
+        registry,
+        event_log,
+        pending_spawn,
+        self_ref,
+        AgentRole::Cartographer,
+        Arc::new(Mutex::new(
+            phantom_agents::quarantine::QuarantineRegistry::default(),
+        )),
+    );
+
+    // Wire the DAG explorer context — this is the new path under test.
+    pane.set_dag_explorer_context(DagExplorerContext::empty());
+
+    let ctx = pane
+        .build_dispatch_context()
+        .expect("build_dispatch_context must return Some for a wired pane");
+
+    assert!(
+        ctx.dag_explorer.is_some(),
+        "DispatchContext for a Cartographer pane with a wired DagExplorerContext \
+         must have dag_explorer = Some; previously this was always None (issue #437)"
+    );
+}
+
+/// A Cartographer pane dispatching `dag_list_nodes` against a real DagStore
+/// must receive a successful `Ok` result containing valid JSON, not the
+/// graceful error string.  This is the end-to-end DAG tool call test.
+#[test]
+fn cartographer_dag_list_nodes_reaches_dag_store() {
+    use phantom_agents::dag_explorer::{DagExplorerContext, DagStore};
+    use phantom_agents::dispatch::dispatch_tool;
+    use phantom_agents::role::{AgentRef, AgentRole, SpawnSource};
+    use phantom_memory::event_log::EventLog;
+    use std::sync::{Arc, Mutex};
+    use tempfile::TempDir;
+
+    let tmp = TempDir::new().unwrap();
+
+    let (mut pane, _tx) = agent_with_handle();
+
+    let registry = Arc::new(Mutex::new(phantom_agents::inbox::AgentRegistry::new()));
+    let event_log = Arc::new(Mutex::new(
+        EventLog::open(&tmp.path().join("events.jsonl")).unwrap(),
+    ));
+    let pending_spawn = phantom_agents::composer_tools::new_spawn_subagent_queue();
+    let self_ref =
+        AgentRef::new(11, AgentRole::Cartographer, "cartographer-2", SpawnSource::User);
+
+    pane.set_substrate_handles(
+        registry,
+        event_log,
+        pending_spawn,
+        self_ref,
+        AgentRole::Cartographer,
+        Arc::new(Mutex::new(
+            phantom_agents::quarantine::QuarantineRegistry::default(),
+        )),
+    );
+
+    // Pre-populate the store with one node so the response is non-empty.
+    let store = Arc::new(Mutex::new(DagStore::new()));
+    store
+        .lock()
+        .unwrap()
+        .add_node("bootstrap the workspace", vec![]);
+
+    let ctx_handle = DagExplorerContext::new(Arc::clone(&store));
+    pane.set_dag_explorer_context(ctx_handle);
+
+    let ctx = pane
+        .build_dispatch_context()
+        .expect("build_dispatch_context must return Some");
+
+    // Issue a dag_list_nodes call through the canonical dispatch_tool gate.
+    let result = dispatch_tool("dag_list_nodes", &serde_json::json!({}), &ctx);
+
+    assert!(
+        result.success,
+        "dag_list_nodes must succeed when DagExplorerContext is wired; output: {}",
+        result.output,
+    );
+
+    // The output must be valid JSON containing the node we pre-seeded.
+    let parsed: serde_json::Value = serde_json::from_str(&result.output)
+        .expect("dag_list_nodes output must be valid JSON");
+    let nodes = parsed.as_array().expect("dag_list_nodes must return a JSON array");
+    assert_eq!(
+        nodes.len(),
+        1,
+        "expected 1 node in the response, got {}",
+        nodes.len()
+    );
+    assert_eq!(
+        nodes[0]["description"].as_str(),
+        Some("bootstrap the workspace"),
+        "node description must match what was inserted"
+    );
+}
+
+/// Revocation path: a Cartographer pane WITHOUT a wired DagExplorerContext
+/// (simulating headless mode or a boot failure) must return the graceful
+/// error string rather than panicking.
+#[test]
+fn cartographer_dag_tool_without_context_returns_graceful_error() {
+    use phantom_agents::dispatch::dispatch_tool;
+    use phantom_agents::role::{AgentRef, AgentRole, SpawnSource};
+    use phantom_memory::event_log::EventLog;
+    use std::sync::{Arc, Mutex};
+    use tempfile::TempDir;
+
+    let tmp = TempDir::new().unwrap();
+
+    let (mut pane, _tx) = agent_with_handle();
+
+    let registry = Arc::new(Mutex::new(phantom_agents::inbox::AgentRegistry::new()));
+    let event_log = Arc::new(Mutex::new(
+        EventLog::open(&tmp.path().join("events.jsonl")).unwrap(),
+    ));
+    let pending_spawn = phantom_agents::composer_tools::new_spawn_subagent_queue();
+    let self_ref =
+        AgentRef::new(12, AgentRole::Cartographer, "cartographer-3", SpawnSource::User);
+
+    // Wire all substrate handles but do NOT wire a dag_explorer context.
+    pane.set_substrate_handles(
+        registry,
+        event_log,
+        pending_spawn,
+        self_ref,
+        AgentRole::Cartographer,
+        Arc::new(Mutex::new(
+            phantom_agents::quarantine::QuarantineRegistry::default(),
+        )),
+    );
+    // dag_explorer deliberately not set — simulates headless / boot failure.
+
+    let ctx = pane
+        .build_dispatch_context()
+        .expect("build_dispatch_context must return Some even without dag_explorer");
+
+    assert!(
+        ctx.dag_explorer.is_none(),
+        "DispatchContext for a Cartographer with no wired context must have dag_explorer = None"
+    );
+
+    // The call must not panic and must return success=false with a
+    // human-readable error rather than an empty string or a panic.
+    let result = dispatch_tool("dag_list_nodes", &serde_json::json!({}), &ctx);
+
+    assert!(
+        !result.success,
+        "dag_list_nodes without a DagExplorerContext must return success=false; \
+         output: {}",
+        result.output,
+    );
+    assert!(
+        !result.output.is_empty(),
+        "graceful error output must not be empty"
+    );
+}
+
+/// Non-Cartographer pane must never get a dag_explorer in its dispatch
+/// context, even if one was somehow set on the pane (defence-in-depth).
+#[test]
+fn non_cartographer_pane_always_has_none_dag_explorer_in_ctx() {
+    use phantom_agents::dag_explorer::DagExplorerContext;
+    use phantom_agents::role::{AgentRef, AgentRole, SpawnSource};
+    use phantom_memory::event_log::EventLog;
+    use std::sync::{Arc, Mutex};
+    use tempfile::TempDir;
+
+    let tmp = TempDir::new().unwrap();
+
+    let (mut pane, _tx) = agent_with_handle();
+
+    let registry = Arc::new(Mutex::new(phantom_agents::inbox::AgentRegistry::new()));
+    let event_log = Arc::new(Mutex::new(
+        EventLog::open(&tmp.path().join("events.jsonl")).unwrap(),
+    ));
+    let pending_spawn = phantom_agents::composer_tools::new_spawn_subagent_queue();
+    let self_ref =
+        AgentRef::new(13, AgentRole::Conversational, "conversational-1", SpawnSource::User);
+
+    pane.set_substrate_handles(
+        registry,
+        event_log,
+        pending_spawn,
+        self_ref,
+        AgentRole::Conversational,
+        Arc::new(Mutex::new(
+            phantom_agents::quarantine::QuarantineRegistry::default(),
+        )),
+    );
+
+    // Force a dag_explorer onto a non-Cartographer pane — must be stripped
+    // in build_dispatch_context (capability gate defence-in-depth).
+    pane.set_dag_explorer_context(DagExplorerContext::empty());
+
+    let ctx = pane
+        .build_dispatch_context()
+        .expect("build_dispatch_context must return Some");
+
+    assert!(
+        ctx.dag_explorer.is_none(),
+        "DispatchContext for a non-Cartographer pane must have dag_explorer = None \
+         even when one is set on the pane (defence-in-depth)"
     );
 }


### PR DESCRIPTION
## Summary

- Replaces the `dag_explorer: None` placeholder left in `dispatch_ctx.rs` by PR #351 with a real `DagExplorerContext` for Cartographer-role panes
- A fresh `DagStore` is constructed per-pane at `spawn_agent_pane_with_opts` time, giving each Cartographer session its own isolated task DAG
- Non-Cartographer panes receive `None` in their `DispatchContext` (capability gate + defence-in-depth; unchanged from before)
- Graceful error-string fallback is preserved for headless mode / boot failure (no panic when `dag_explorer` is absent)

## Dependencies

- Depends on PR #441 (DAG viewer command surface — `phantom_app::dag_commands`)
- Depends on PR #431 (pane lineage model)

Both dependencies are now merged. This PR does not introduce any new abstraction layer.

## Files changed

- `crates/phantom-app/src/agent_pane/mod.rs` — new `dag_explorer` field + `set_dag_explorer_context` setter
- `crates/phantom-app/src/agent_pane/dispatch_ctx.rs` — populate field from `self` for Cartographer, hard-None otherwise
- `crates/phantom-app/src/agent_pane/spawn.rs` — construct `DagExplorerContext::empty()` at Cartographer spawn
- `crates/phantom-app/src/agent_pane/tests.rs` — 4 new tests + `dag_explorer: None` in existing struct literals

## Test plan

- [ ] `cartographer_pane_with_dag_context_has_some_in_dispatch_ctx` — wired path yields `Some`
- [ ] `cartographer_dag_list_nodes_reaches_dag_store` — end-to-end DAG tool call returns populated JSON
- [ ] `cartographer_dag_tool_without_context_returns_graceful_error` — absent context returns `success=false`, no panic
- [ ] `non_cartographer_pane_always_has_none_dag_explorer_in_ctx` — defence-in-depth: other roles stay `None`
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [ ] `./scripts/pre-pr-check.sh phantom-app` passed

## Perf observation

The new `DagExplorerContext` (an `Arc<Mutex<DagStore>>`) is allocated once at pane spawn and lives for the pane lifetime. It is only constructed when the role is `Cartographer`; all other spawn paths are zero-cost. No subsystem loads eagerly as a side-effect of this wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)