### PR TITLE
chore(phantom-nlp): add #![forbid(unsafe_op_in_unsafe_fn)] (closes #469)

### DIFF
--- a/crates/phantom-nlp/src/lib.rs
+++ b/crates/phantom-nlp/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_op_in_unsafe_fn)]
+
 pub mod interpreter;
 pub mod llm_export;
 pub mod translate;


### PR DESCRIPTION
## Summary

- Adds `#![forbid(unsafe_op_in_unsafe_fn)]` at the top of `crates/phantom-nlp/src/lib.rs`
- Closes the enforcement gap flagged in PR #466 review — code was already correct, this makes the lint a compile-time gate
- Minimal diff: 2 lines (attribute + blank line)

## Self-check results

- `cargo build --workspace` — clean, zero errors
- `cargo test -p phantom-nlp` — 80 unit + 5 integration + 1 doctest, all pass; zero unsafe-op compile errors surfaced
- `cargo clippy --workspace --all-targets -- -D warnings` — clean

## Test plan

- [ ] CI passes (build + test + clippy)
- [ ] Diff confirms only `crates/phantom-nlp/src/lib.rs` is touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)