### PR TITLE
tests(phantom-plugins): adversarial WASM sandbox — misspelled namespace + memory export (closes #380)

### DIFF
--- a/crates/phantom-plugins/tests/wasm_sandbox.rs
+++ b/crates/phantom-plugins/tests/wasm_sandbox.rs
@@ -10,6 +10,7 @@
 //!
 //! # Issue reference
 //! Closes #186 — WASM plugin sandbox: adversarial tests.
+//! Closes #380 — extra adversarial WASM sandbox tests (misspelled namespace + memory export).
 
 use phantom_plugins::{SandboxViolation, WasmHost};
 
@@ -66,6 +67,44 @@ fn wasm_with_custom_namespace() -> Vec<u8> {
     "#,
     )
     .expect("custom-namespace WAT should parse")
+}
+
+/// Test 4A — WASM module that imports from a *misspelled* Phantom namespace.
+///
+/// `phantom_hots` is a one-character typo of `phantom_host`.  The sandbox must
+/// reject it: no whitelisted namespace should be reachable through a spelling
+/// variant, and the rejection must identify both the namespace and the name.
+fn wasm_with_misspelled_namespace() -> Vec<u8> {
+    wat::parse_str(
+        r#"
+        (module
+          (import "phantom_hots" "do_thing"
+            (func (param i32) (result i32)))
+        )
+    "#,
+    )
+    .expect("misspelled-namespace WAT should parse")
+}
+
+/// Test 4B — WASM module that exports its own linear memory and the `ph_init`
+/// ABI entry point.
+///
+/// Exporting memory is not itself malicious; the fixture is designed to verify
+/// that the *host* does not gain a back-channel into plugin-side memory and
+/// that no sentinel symbol (`__phantom_host_ptr`) is present in the export
+/// table.
+fn wasm_with_memory_export() -> Vec<u8> {
+    wat::parse_str(
+        r#"
+        (module
+          (memory (export "memory") 1)
+          (func $ph_init (export "ph_init") (result i32)
+            i32.const 0
+          )
+        )
+    "#,
+    )
+    .expect("memory-export WAT should parse")
 }
 
 // ---------------------------------------------------------------------------
@@ -185,5 +224,114 @@ fn custom_namespace_rejected() {
     assert!(
         !err.to_string().is_empty(),
         "rejection must include a diagnostic message"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 4A — Reject imports from misspelled / unknown custom namespace (#380)
+// ---------------------------------------------------------------------------
+
+/// A module that imports from `phantom_hots` (one-character typo of
+/// `phantom_host`) must be rejected at instantiation time.
+///
+/// The invariant: only explicitly whitelisted namespaces are accessible.
+/// Spelling variants that are not in the whitelist must not silently succeed —
+/// a user who misspells the namespace name must see a clear error, not
+/// undefined behaviour from an unresolved import linking into arbitrary host
+/// state.
+///
+/// # Containment gap noted (do not modify host code in this PR)
+///
+/// The issue spec requested that the [`SandboxViolation`] message identify
+/// both `namespace = "phantom_hots"` and `name = "do_thing"`.  In practice,
+/// wasmtime 44 uses the error format `"expected N imports, found 0"` — it does
+/// not include the import namespace or name in the string that reaches
+/// `SandboxViolation::UnsupportedImport`.  The sandbox correctly *rejects* the
+/// module (the primary security property holds), but the diagnostic message
+/// does not carry the offending namespace/name detail.
+///
+/// This is a diagnosability gap to be addressed in `wasm_host.rs` by
+/// inspecting `module.imports()` before instantiation and constructing a
+/// richer message — tracked separately; not fixed in this tests-only PR.
+#[test]
+fn misspelled_namespace_rejected_with_sandbox_violation() {
+    let host = WasmHost::new().expect("WasmHost::new");
+    let result = host.load(&wasm_with_misspelled_namespace());
+
+    assert!(
+        result.is_err(),
+        "import from misspelled namespace 'phantom_hots' must be rejected — \
+         namespace spelling variants must not reach the host"
+    );
+
+    let err = result.unwrap_err();
+    assert!(
+        is_sandbox_violation(&err),
+        "rejection of a misspelled namespace must surface as \
+         SandboxViolation::UnsupportedImport, got: {err}"
+    );
+
+    // The message must be non-empty so the caller receives some diagnostic.
+    // NOTE: wasmtime 44 does not include namespace/name in the error string
+    // (it reports "expected N imports, found 0").  The diagnosability gap is
+    // documented above; the containment property (Err + SandboxViolation) is
+    // what this test enforces.
+    let msg = err.to_string();
+    assert!(
+        !msg.is_empty(),
+        "SandboxViolation message must not be empty, got empty string"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 4B — Memory export does not expose host memory (#380)
+// ---------------------------------------------------------------------------
+
+/// A plugin that exports its linear memory loads successfully but must not
+/// give the host access to plugin-side memory via a host-pointer sentinel, and
+/// must not export a `__phantom_host_ptr` symbol.
+///
+/// Exporting memory is a normal WASM pattern for host–guest data exchange.
+/// This test verifies three properties:
+///
+/// 1. **Load succeeds** — a memory export alone is not a sandbox violation.
+/// 2. **`ph_init` callable and returns 0** — the module ABI works normally.
+/// 3. **No `__phantom_host_ptr` function export** — this sentinel name is
+///    used by some runtimes to expose a raw pointer into host address space;
+///    its absence confirms the sandbox does not leak host pointers to the
+///    plugin, and the plugin does not declare such a symbol.
+///
+/// Note: `has_export` checks only *function* exports (via `get_func`).
+/// A memory export named `__phantom_host_ptr` would not be found by
+/// `has_export` — which is the correct containment property: memory exports
+/// are not callable function entry points and cannot be invoked through the
+/// Phantom ABI.
+#[test]
+fn memory_export_loads_but_does_not_expose_host_pointer_sentinel() {
+    let host = WasmHost::new().expect("WasmHost::new");
+
+    // Property 1: the module must load — a memory export is not a violation.
+    let mut rt = host
+        .load(&wasm_with_memory_export())
+        .expect("module that exports memory must load successfully");
+
+    // Property 2: the ABI entry point works and returns the expected value.
+    let results = rt
+        .call("ph_init", &[])
+        .expect("ph_init must be callable after load");
+    assert_eq!(results.len(), 1, "ph_init must return exactly one value");
+    assert_eq!(
+        results[0].unwrap_i32(),
+        0,
+        "ph_init must return 0 (success) per the WAT fixture"
+    );
+
+    // Property 3: no host-pointer sentinel function export is present.
+    // `__phantom_host_ptr` appearing as a callable function export would
+    // indicate host address-space leakage into plugin land.
+    assert!(
+        !rt.has_export("__phantom_host_ptr"),
+        "plugin must not export a '__phantom_host_ptr' function — \
+         host pointer leakage sentinel detected in export table"
     );
 }


### PR DESCRIPTION
## Summary

Adds tests 4A and 4B to `crates/phantom-plugins/tests/wasm_sandbox.rs`, extending the adversarial suite from #186 / PR #334 (tests 1–3 already merged).

## Adversarial scenarios covered

### Test 4A — Misspelled namespace rejected (`misspelled_namespace_rejected_with_sandbox_violation`)

- WAT fixture imports from `phantom_hots` (one-character typo of `phantom_host`).
- Asserts `host.load(...)` returns `Err`.
- Asserts the error downcasts to `SandboxViolation::UnsupportedImport`.
- Asserts the diagnostic message is non-empty.

**Containment gap found (diagnosability, not containment):** wasmtime 44 reports the instantiation failure as `"expected 1 imports, found 0"` — it does not include the namespace or function name in the string. The sandbox correctly *blocks* the load (the security property holds), but `SandboxViolation::UnsupportedImport` cannot carry the offending namespace/name without `wasm_host.rs` inspecting `module.imports()` before calling `Instance::new`. This is a diagnosability gap (not a containment failure); it is documented in the test's doc-comment and flagged here for the security reviewer. Fix requires modifying `wasm_host.rs` — out of scope for this tests-only PR.

### Test 4B — Memory export does not expose host pointer sentinel (`memory_export_loads_but_does_not_expose_host_pointer_sentinel`)

- WAT fixture: `(memory (export "memory") 1)` + `ph_init` export returning 0.
- Asserts module loads successfully (exporting memory is not a violation).
- Asserts `ph_init()` is callable and returns 0.
- Asserts `has_export("__phantom_host_ptr")` is false — no host-pointer sentinel in the function export table.

## Sandbox containment gaps found

One diagnosability gap in `SandboxViolation::UnsupportedImport`: wasmtime 44 does not include the import namespace/name in its instantiation error string, so the typed error cannot surface them without pre-instantiation import inspection in `wasm_host.rs`. The sandbox *blocks* the load correctly — this is purely a diagnostic quality issue.

## Test count

7 total tests in `wasm_sandbox.rs` (5 pre-existing + 2 new). All 7 pass.

## Checklist

- [x] Tests 4A and 4B added to `crates/phantom-plugins/tests/wasm_sandbox.rs`
- [x] `cargo test -p phantom-plugins --test wasm_sandbox` passes (7/7)
- [x] `cargo build --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] Rebased onto `origin/main`

Closes #380. Closes #379.

🤖 Generated with [Claude Code](https://claude.com/claude-code)