### PR TITLE
chore(phantom-renderer): clippy cleanup batch — clone_on_copy + too_many_arguments (closes #461, #462)

### DIFF
--- a/crates/phantom-app/src/render.rs
+++ b/crates/phantom-app/src/render.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use wgpu::CommandEncoderDescriptor;
 
 use phantom_renderer::grid::{GridCell, GridRenderData};
-use phantom_renderer::postfx::PostFxParams;
+use phantom_renderer::postfx::{PostFxParams, PostFxThemeParams};
 use phantom_renderer::quads::QuadInstance as QI;
 use phantom_ui::widgets::Widget;
 
@@ -170,18 +170,18 @@ impl App {
                 1.0
             };
 
-            let params = PostFxParams::from_theme(
-                sp.scanline_intensity * crt_scale,
-                sp.bloom_intensity * crt_scale,
-                sp.chromatic_aberration * crt_scale,
-                sp.curvature * crt_scale,
-                sp.vignette_intensity * crt_scale,
-                sp.noise_intensity * crt_scale,
-                sp.glow_color,
-                elapsed,
+            let params = PostFxParams::from_theme(&PostFxThemeParams {
+                scanline_intensity: sp.scanline_intensity * crt_scale,
+                bloom_intensity: sp.bloom_intensity * crt_scale,
+                chromatic_aberration: sp.chromatic_aberration * crt_scale,
+                curvature: sp.curvature * crt_scale,
+                vignette_intensity: sp.vignette_intensity * crt_scale,
+                noise_intensity: sp.noise_intensity * crt_scale,
+                glow_color: sp.glow_color,
+                time: elapsed,
                 width,
                 height,
-            );
+            });
 
             self.postfx
                 .render(&mut encoder, &surface_view, &self.gpu.queue, &params);

--- a/crates/phantom-renderer/src/postfx.rs
+++ b/crates/phantom-renderer/src/postfx.rs
@@ -71,6 +71,27 @@ fn crt_wgsl_source() -> std::borrow::Cow<'static, str> {
 // Uniform data — must match the WGSL struct layout exactly
 // ---------------------------------------------------------------------------
 
+/// Theme-driven scalar inputs for the CRT post-processing pipeline.
+///
+/// Collects the 10 per-frame CRT parameters that vary by theme and runtime
+/// state (time, screen size). Pass a reference to
+/// [`PostFxParams::from_theme`] to construct the GPU-ready uniform buffer.
+///
+/// All fields are plain `f32` / `[f32; 3]` / `u32` — the struct is `Copy`.
+#[derive(Clone, Copy, Debug)]
+pub struct PostFxThemeParams {
+    pub scanline_intensity: f32,
+    pub bloom_intensity: f32,
+    pub chromatic_aberration: f32,
+    pub curvature: f32,
+    pub vignette_intensity: f32,
+    pub noise_intensity: f32,
+    pub glow_color: [f32; 3],
+    pub time: f32,
+    pub width: u32,
+    pub height: u32,
+}
+
 /// CRT post-processing parameters uploaded to the GPU each frame.
 ///
 /// Layout matches the WGSL `PostFxParams` struct exactly. Padded to satisfy
@@ -113,33 +134,21 @@ pub struct PostFxParams {
 const _: () = assert!(size_of::<PostFxParams>() == 64);
 
 impl PostFxParams {
-    /// Create params from theme shader params, elapsed time, and screen dimensions.
+    /// Create GPU-ready params from a [`PostFxThemeParams`] bundle.
     #[must_use]
-    #[allow(clippy::too_many_arguments)]
-    pub fn from_theme(
-        scanline_intensity: f32,
-        bloom_intensity: f32,
-        chromatic_aberration: f32,
-        curvature: f32,
-        vignette_intensity: f32,
-        noise_intensity: f32,
-        glow_color: [f32; 3],
-        time: f32,
-        width: u32,
-        height: u32,
-    ) -> Self {
+    pub fn from_theme(p: &PostFxThemeParams) -> Self {
         Self {
-            scanline_intensity,
-            bloom_intensity,
-            chromatic_aberration,
-            curvature,
-            vignette_intensity,
-            noise_intensity,
-            time,
+            scanline_intensity: p.scanline_intensity,
+            bloom_intensity: p.bloom_intensity,
+            chromatic_aberration: p.chromatic_aberration,
+            curvature: p.curvature,
+            vignette_intensity: p.vignette_intensity,
+            noise_intensity: p.noise_intensity,
+            time: p.time,
             _pad0: 0.0,
-            glow_color,
+            glow_color: p.glow_color,
             _pad1: 0.0,
-            resolution: [width as f32, height as f32],
+            resolution: [p.width as f32, p.height as f32],
             _pad2: [0.0; 2],
         }
     }

--- a/crates/phantom-renderer/tests/crt_shader.rs
+++ b/crates/phantom-renderer/tests/crt_shader.rs
@@ -103,6 +103,9 @@ fn crt_wgsl_is_not_empty() {
 
 /// Helper: parse CRT_WGSL and return a map from variable name → ResourceBinding.
 ///
+/// `ResourceBinding` is `Copy`, so the binding is copied with `*b` rather than
+/// cloned. `var.name` is a `String` (not `Copy`) and is cloned intentionally.
+///
 /// Panics if parsing fails — the calling test immediately fails with a clear message.
 fn crt_global_bindings() -> std::collections::HashMap<String, ResourceBinding> {
     let module = naga::front::wgsl::parse_str(CRT_WGSL)


### PR DESCRIPTION
## Summary

- **#461** (`crt_shader.rs:117`): `ResourceBinding` is `Copy`; `b.clone()` was already corrected to `*b` on `origin/main`. This PR adds a clarifying doc comment to the `crt_global_bindings` helper to make the intent explicit and formally closes the issue.
- **#462** (`postfx.rs`): Introduced `PostFxThemeParams` struct to bundle the 10 scalar CRT inputs. `PostFxParams::from_theme` now takes `&PostFxThemeParams`, collapsing the argument list to one. The `#[allow(clippy::too_many_arguments)]` suppress is removed. The single caller in `phantom-app/src/render.rs` is updated to construct the bundle inline. No behavior change.

## Files changed

- `crates/phantom-renderer/tests/crt_shader.rs` — doc comment clarification (#461)
- `crates/phantom-renderer/src/postfx.rs` — new `PostFxThemeParams` struct; updated `from_theme` signature; removed allow (#462)
- `crates/phantom-app/src/render.rs` — caller updated to use `PostFxThemeParams` (#462)

## Callers of `PostFxParams::from_theme` updated

1. `crates/phantom-app/src/render.rs:173` — the only call site in the workspace

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace --no-run` — all test executables compile
- [x] `cargo test -p phantom-renderer` — all naga shader validation tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — exit 0, no `too_many_arguments` allow remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)