### PR TITLE
refactor(phantom-agents): AgentManager::router pub(crate) + delegation methods (closes #456)

### DIFF
--- a/crates/phantom-agents/src/manager.rs
+++ b/crates/phantom-agents/src/manager.rs
@@ -27,7 +27,7 @@ pub struct AgentManager {
     next_id: AgentId,
     max_concurrent: usize,
     /// Cross-peer routing state (optional relay connection + remote agent cache).
-    pub router: AgentRouter,
+    pub(crate) router: AgentRouter,
 }
 
 impl AgentManager {
@@ -45,8 +45,8 @@ impl AgentManager {
     /// Resolve an [`AnyAgentRef`] to a local agent.
     ///
     /// Returns the local [`Agent`] when `any_ref` is `Local` and the id is
-    /// known. Returns `None` for `Remote` refs — the caller must use
-    /// `self.router` for remote delivery.
+    /// known. Returns `None` for `Remote` refs — remote delivery is handled
+    /// inside the brain's own [`crate::peer_routing::AgentRouter`] instance.
     #[must_use]
     pub fn resolve(&self, any_ref: &AnyAgentRef) -> Option<&Agent> {
         match any_ref {


### PR DESCRIPTION
## Summary

- Changes `AgentManager::router` from `pub` to `pub(crate)` per rubric §8.1 — internal helpers must not be `pub`
- Audited all callers across the workspace; zero external call sites access `manager.router` directly
- `remote_agents()` already serves as the only delegation method needed; no new methods required
- Updates stale doc comment on `resolve` that incorrectly told external callers to use `self.router`

## Delegation methods

No new delegation methods were added because no external call sites exist that access `AgentManager::router` directly. The existing `remote_agents()` method (line 64–66 of `manager.rs`) already covers the single external use case.

## Call sites updated

None — the grep across `crates/` produced zero results for `agent_manager.router`, `manager.router`, `agents.router`, or `mgr.router` from outside `phantom-agents/src/manager.rs`. The only `.router` accesses are internal (`self.router.remote_agents()`) and in `phantom-brain` where `brain.rs` owns a separate local `AgentRouter` variable — not `AgentManager::router`.

## Signature changes (API surface)

- `AgentManager::router: pub AgentRouter` → `pub(crate) AgentRouter`
  - This is a breaking change to the field's visibility. No code outside the crate was using it; confirmed by exhaustive grep.

## Test plan

- [x] `./scripts/pre-pr-check.sh phantom-agents` — PASS
- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace --no-run` — all test executables built
- [x] `cargo test -p phantom-agents -p phantom-brain -p phantom-app` — all pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero warnings

Closes #456

🤖 Generated with [Claude Code](https://claude.com/claude-code)