### PR TITLE
fix: restore NonceCache replay protection (p0 security regression)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5833,6 +5833,7 @@ dependencies = [
  "env_logger",
  "jsonwebtoken",
  "log",
+ "lru",
  "rand 0.8.6",
  "serde",
  "serde_json",

--- a/crates/phantom-hub/Cargo.toml
+++ b/crates/phantom-hub/Cargo.toml
@@ -45,6 +45,10 @@ subtle = "2"
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 rand = "0.8"
 
+# LRU cache for nonce replay protection (issues #398, #499).
+# Evicts oldest entries at capacity — no full-clear, bounded memory.
+lru = "0.12"
+
 [dev-dependencies]
 axum-test = "15"
 tokio = { version = "1", features = ["full", "test-util"] }

--- a/crates/phantom-hub/src/auth.rs
+++ b/crates/phantom-hub/src/auth.rs
@@ -44,23 +44,32 @@
 //!
 //! # Replay mitigation
 //!
-//! The registration flow includes a server-generated nonce (see
-//! `POST /auth/register`).  Phantom signs `(nonce || peer_id)` with its
-//! Ed25519 identity key; the hub verifies the signature before issuing a JWT.
-//! This prevents replay: an attacker who captures a past registration request
-//! cannot replay it because the nonce is single-use and the hub discards it
-//! after verification.
+//! The registration flow requires a nonce (see `POST /auth/register`).
+//! Phantom signs `(nonce || peer_id)` with its Ed25519 identity key; the hub
+//! verifies the signature before issuing a JWT.  After signature verification
+//! the hub calls [`NonceCache::try_claim`] which atomically records the nonce
+//! as consumed and returns `false` on any subsequent replay attempt.  A replay
+//! of the same signed request is rejected with `409 Conflict` before a JWT is
+//! issued.
+//!
+//! [`NonceCache`] is backed by an LRU cache (capacity 10 000, TTL 10 minutes).
+//! Entries are evicted lazily on the oldest-first basis when the cache is full;
+//! there is no full-clear fallback.  The TTL window (10 minutes) is
+//! intentionally much shorter than the JWT lifetime (30 days) — it covers the
+//! realistic registration-to-WSS-connect interval while keeping memory bounded.
 //!
 //! Short-lived replay window on the WSS registration frame: the JWT itself
 //! has a 30-day exp.  Clock skew tolerance is ±5 minutes.  A stolen JWT can
 //! be used until its exp; rotation is via `phantom auth register --renew`
 //! (ticket 09).
 
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::sync::Mutex;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation, decode, encode};
+use lru::LruCache;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
@@ -77,6 +86,104 @@ pub const JWT_EXP_SECS: u64 = 30 * 24 * 60 * 60;
 
 /// Clock skew tolerance for JWT validation (±5 minutes).
 pub const JWT_LEEWAY_SECS: u64 = 5 * 60;
+
+/// Maximum number of nonces tracked simultaneously by [`NonceCache`].
+///
+/// At 10 000 entries the cache uses roughly 640 KB at worst (64-byte nonce
+/// strings + 16-byte `Instant`).  This is well within the hub's memory budget.
+pub const NONCE_CACHE_CAPACITY: usize = 10_000;
+
+/// How long a claimed nonce is remembered before it is eligible for eviction.
+///
+/// Set to 10 minutes — twice the JWT clock-skew leeway (5 min) and well within
+/// any realistic registration-to-WSS-connect window.
+pub const NONCE_CACHE_TTL: Duration = Duration::from_secs(10 * 60);
+
+// ---------------------------------------------------------------------------
+// NonceCache — replay protection for POST /auth/register
+// ---------------------------------------------------------------------------
+
+/// Single-use nonce tracker for `POST /auth/register`.
+///
+/// Backed by an LRU cache (capacity [`NONCE_CACHE_CAPACITY`], TTL
+/// [`NONCE_CACHE_TTL`]).  On every `try_claim` call the Mutex is acquired
+/// once; check and insert are performed under the same acquisition so the
+/// operation is atomic — there is no window between the check and the insert.
+///
+/// The lock is never held across an `.await` point.  `NonceCache` is `Send +
+/// Sync` by construction (`Mutex<LruCache<...>>`).
+///
+/// # Eviction
+///
+/// When the cache reaches capacity, the LRU entry is evicted before the new
+/// nonce is inserted.  Additionally, `try_claim` performs lazy TTL eviction:
+/// if an existing entry for the same nonce key is found but its recorded
+/// `Instant` is older than [`NONCE_CACHE_TTL`], the entry is treated as
+/// expired and the nonce is re-claimable (returns `true`).
+pub struct NonceCache {
+    inner: Mutex<LruCache<String, Instant>>,
+    ttl: Duration,
+}
+
+impl NonceCache {
+    /// Create a [`NonceCache`] with production defaults:
+    /// capacity [`NONCE_CACHE_CAPACITY`], TTL [`NONCE_CACHE_TTL`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_capacity_and_ttl(NONCE_CACHE_CAPACITY, NONCE_CACHE_TTL)
+    }
+
+    /// Create a [`NonceCache`] with explicit capacity and TTL.
+    ///
+    /// Intended for tests that need a small cache to exercise eviction without
+    /// inserting 10 000 entries.  Production code must use [`NonceCache::new`].
+    #[must_use]
+    pub fn with_capacity_and_ttl(capacity: usize, ttl: Duration) -> Self {
+        let cap = std::num::NonZeroUsize::new(capacity.max(1))
+            .expect("capacity is always ≥ 1 after max(1)");
+        Self {
+            inner: Mutex::new(LruCache::new(cap)),
+            ttl,
+        }
+    }
+
+    /// Atomically claim `nonce`.
+    ///
+    /// Returns `true` on the first successful claim.  Returns `false` when
+    /// `nonce` has already been claimed and its TTL has not yet expired.
+    ///
+    /// An expired nonce (older than [`Self::ttl`]) is evicted and treated as
+    /// a new nonce — returns `true`.
+    ///
+    /// # Panics
+    ///
+    /// Panics only if the internal `Mutex` is poisoned, which cannot happen
+    /// unless a previous thread panicked while holding the lock.
+    pub fn try_claim(&self, nonce: &str) -> bool {
+        let mut cache = self.inner.lock().expect("NonceCache mutex poisoned");
+        let now = Instant::now();
+
+        // peek without promoting to LRU-head so we don't disturb eviction order
+        // for a stale entry we are about to replace.
+        if let Some(&claimed_at) = cache.peek(nonce)
+            && now.duration_since(claimed_at) < self.ttl
+        {
+            // Still within TTL — this is a replay.
+            return false;
+        }
+        // Not found or expired — fall through to insert with a fresh timestamp.
+
+        // First claim (or expired re-claim): insert/update and return true.
+        cache.put(nonce.to_owned(), now);
+        true
+    }
+}
+
+impl Default for NonceCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 // ---------------------------------------------------------------------------
 // JWT claims
@@ -633,6 +740,91 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("Authorization", "Basic dXNlcjpwYXNz".parse().unwrap());
         assert!(extract_bearer(&headers).is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // NonceCache — replay protection regression tests (P0 security, issue #398)
+    // -----------------------------------------------------------------------
+
+    /// A captured registration payload replayed a second time must be rejected.
+    ///
+    /// Both calls share the same [`NonceCache`] instance (via `Arc::clone` on
+    /// the same `AppState`).  First call returns `true` (claim succeeds),
+    /// second call returns `false` (replay detected).
+    #[test]
+    fn nonce_cache_replayed_nonce_rejected() {
+        let cache = NonceCache::new();
+        let nonce = "unique-nonce-replay-test-abc123";
+
+        let first = cache.try_claim(nonce);
+        let second = cache.try_claim(nonce);
+
+        assert!(first, "first claim of a nonce must succeed");
+        assert!(!second, "replayed nonce must be rejected");
+    }
+
+    /// Two distinct nonces must both be claimable — blocking one must not
+    /// affect the other.
+    #[test]
+    fn nonce_cache_distinct_nonces_both_succeed() {
+        let cache = NonceCache::new();
+
+        let first = cache.try_claim("nonce-alpha-1");
+        let second = cache.try_claim("nonce-beta-2");
+
+        assert!(first, "first distinct nonce must be claimed");
+        assert!(second, "second distinct nonce must also be claimed");
+    }
+
+    /// LRU eviction: filling the cache to capacity and inserting one more must
+    /// evict the oldest (LRU) entry, making that nonce re-claimable as new,
+    /// while more-recently-used entries remain blocked as replays.
+    ///
+    /// Uses a small cache (capacity 4) to exercise eviction without 10 000
+    /// inserts.
+    ///
+    /// The test is structured in two stages to avoid the cascade: re-inserting
+    /// the evicted entry (A) would itself consume the last free slot and evict
+    /// the next-oldest (B).  Stage 1 verifies that B/C/D/E are all still
+    /// present (replay-rejected) after only one eviction.  Stage 2, using a
+    /// fresh cache, verifies that the evicted entry is re-claimable.
+    #[test]
+    fn nonce_cache_eviction_lru_oldest() {
+        // ---- Stage 1: middle entries stay blocked after a single eviction ----
+        let cache = NonceCache::with_capacity_and_ttl(
+            4,
+            Duration::from_secs(3600), // long TTL — eviction is capacity-driven only
+        );
+
+        // Fill to capacity: A(LRU) → B → C → D(MRU).
+        assert!(cache.try_claim("nonce-A"), "A: initial claim (slot 1/4)");
+        assert!(cache.try_claim("nonce-B"), "B: initial claim (slot 2/4)");
+        assert!(cache.try_claim("nonce-C"), "C: initial claim (slot 3/4)");
+        assert!(cache.try_claim("nonce-D"), "D: initial claim (slot 4/4)");
+
+        // Inserting E evicts A (the LRU).  Cache now: B(LRU), C, D, E(MRU).
+        assert!(cache.try_claim("nonce-E"), "E: claim triggers eviction of A");
+
+        // B, C, D, E remain in the cache — must be rejected as replays.
+        assert!(!cache.try_claim("nonce-B"), "nonce-B still cached — must be replay");
+        assert!(!cache.try_claim("nonce-C"), "nonce-C still cached — must be replay");
+        assert!(!cache.try_claim("nonce-D"), "nonce-D still cached — must be replay");
+        assert!(!cache.try_claim("nonce-E"), "nonce-E still cached — must be replay");
+
+        // ---- Stage 2: evicted entry is re-claimable (separate cache) --------
+        let cache2 = NonceCache::with_capacity_and_ttl(4, Duration::from_secs(3600));
+        cache2.try_claim("nonce-A");
+        cache2.try_claim("nonce-B");
+        cache2.try_claim("nonce-C");
+        cache2.try_claim("nonce-D");
+        // E evicts A.
+        cache2.try_claim("nonce-E");
+
+        // A is no longer in the cache — re-claiming it must succeed.
+        assert!(
+            cache2.try_claim("nonce-A"),
+            "evicted nonce-A must be re-claimable after LRU eviction"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/crates/phantom-hub/src/lib.rs
+++ b/crates/phantom-hub/src/lib.rs
@@ -39,19 +39,30 @@ use tracing::info;
 
 /// Shared hub state injected into every Axum handler.
 ///
-/// Cloning this is cheap — the expensive fields are behind [`Arc`].
+/// Cloning this is cheap — all expensive fields are behind [`Arc`].
+///
+/// The `nonce_cache` field enforces single-use semantics on registration
+/// nonces (replay protection, issue #398).  It is wrapped in `Arc` so that
+/// cloned `AppState` values — including those shared across unit-test calls —
+/// all operate on the same underlying cache.
 #[derive(Clone)]
 pub struct AppState {
     /// JWT authority — issues and verifies Phantom device tokens.
     pub jwt: Arc<auth::JwtAuthority>,
     /// API key store — validates Claude session API keys.
     pub api_keys: Arc<auth::ApiKeyStore>,
+    /// Nonce replay-protection cache.  Every nonce presented at registration
+    /// is recorded here; a second presentation of the same nonce within the
+    /// TTL window is rejected with `409 Conflict`.
+    pub nonce_cache: Arc<auth::NonceCache>,
 }
 
 impl AppState {
     /// Construct [`AppState`] from environment variables.
     ///
     /// Reads `HUB_JWT_SECRET` (required) and `HUB_API_KEYS` (optional).
+    /// The [`auth::NonceCache`] is always initialised with production defaults
+    /// (capacity [`auth::NONCE_CACHE_CAPACITY`], TTL [`auth::NONCE_CACHE_TTL`]).
     ///
     /// # Errors
     ///
@@ -63,6 +74,7 @@ impl AppState {
         Ok(Self {
             jwt: Arc::new(jwt),
             api_keys: Arc::new(api_keys),
+            nonce_cache: Arc::new(auth::NonceCache::new()),
         })
     }
 }

--- a/crates/phantom-hub/src/mcp_endpoint.rs
+++ b/crates/phantom-hub/src/mcp_endpoint.rs
@@ -124,6 +124,7 @@ mod tests {
         crate::AppState {
             jwt: Arc::new(JwtAuthority::from_secret(TEST_SECRET)),
             api_keys: Arc::new(ApiKeyStore::from_raw_keys(std::iter::once(key))),
+            nonce_cache: Arc::new(crate::auth::NonceCache::new()),
         }
     }
 
@@ -131,6 +132,7 @@ mod tests {
         crate::AppState {
             jwt: Arc::new(JwtAuthority::from_secret(TEST_SECRET)),
             api_keys: Arc::new(ApiKeyStore::default()),
+            nonce_cache: Arc::new(crate::auth::NonceCache::new()),
         }
     }
 

--- a/crates/phantom-hub/src/phantom_endpoint.rs
+++ b/crates/phantom-hub/src/phantom_endpoint.rs
@@ -10,8 +10,11 @@
 //!    may add a server-side challenge round-trip).
 //! 2. Phantom signs (nonce_bytes || peer_id_bytes) with its Ed25519 key.
 //! 3. Phantom POSTs { peer_id, public_key_hex, nonce_hex, signature_hex }.
-//! 4. Hub verifies the signature, then issues a JWT bound to peer_id.
-//! 5. Phantom stores the JWT via `phantom_net::DeviceCredentials`.
+//! 4. Hub verifies the signature.
+//! 5. Hub calls NonceCache::try_claim — returns 409 Conflict if nonce was
+//!    already used (replay protection, issue #398).
+//! 6. Hub issues a JWT bound to peer_id.
+//! 7. Phantom stores the JWT via `phantom_net::DeviceCredentials`.
 //! ```
 //!
 //! # WSS connect
@@ -45,7 +48,8 @@ pub struct RegisterRequest {
     ///
     /// v1: the client generates the nonce itself and includes it in the
     /// request.  The hub verifies the signature over (nonce || peer_id) which
-    /// proves key ownership.
+    /// proves key ownership, then records the nonce in [`auth::NonceCache`] to
+    /// prevent replay attacks.
     pub nonce_hex: String,
     /// Ed25519 signature over `(nonce_bytes || peer_id_bytes)`, hex-encoded
     /// (128 hex chars = 64 bytes).
@@ -65,7 +69,11 @@ pub struct RegisterResponse {
 
 /// Handler for `POST /auth/register`.
 ///
-/// Verifies the Ed25519 registration signature and issues a JWT device token.
+/// Verifies the Ed25519 registration signature, enforces nonce single-use via
+/// [`auth::NonceCache`], and issues a JWT device token.
+///
+/// Returns `409 Conflict` when the nonce has already been claimed — this is the
+/// replay-rejection path.
 pub async fn register(
     State(state): State<AppState>,
     Json(body): Json<RegisterRequest>,
@@ -110,7 +118,8 @@ pub async fn register(
         }
     };
 
-    // Verify the registration signature.
+    // Verify the registration signature BEFORE claiming the nonce so that an
+    // attacker cannot burn nonces without possessing a valid signing key.
     if let Err(e) = auth::verify_registration_signature(
         &body.peer_id,
         &nonce_str,
@@ -119,6 +128,18 @@ pub async fn register(
     ) {
         warn!(phantom_id = %body.peer_id, "register: {e} — auth_failure");
         return (StatusCode::UNAUTHORIZED, "signature verification failed").into_response();
+    }
+
+    // Claim the nonce.  try_claim is atomic (single Mutex acquisition —
+    // check + insert happen together with no window between them).
+    // Returns false when the nonce was already used within the TTL window.
+    if !state.nonce_cache.try_claim(&nonce_str) {
+        warn!(phantom_id = %body.peer_id, "register: nonce already used — replay_rejected");
+        return (
+            StatusCode::CONFLICT,
+            "nonce already used — registration request must not be replayed",
+        )
+            .into_response();
     }
 
     // Issue the JWT.
@@ -240,7 +261,7 @@ fn from_hex_digit(b: u8) -> Option<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::auth::{ApiKeyStore, JwtAuthority};
+    use crate::auth::{ApiKeyStore, JwtAuthority, NonceCache};
     use axum::body::Body;
     use axum::http::{Method, Request};
     use std::sync::Arc;
@@ -252,15 +273,17 @@ mod tests {
         AppState {
             jwt: Arc::new(JwtAuthority::from_secret(TEST_SECRET)),
             api_keys: Arc::new(ApiKeyStore::default()),
+            nonce_cache: Arc::new(NonceCache::new()),
         }
     }
 
-    fn make_register_body(peer_id: &str) -> RegisterRequest {
+    /// Build a valid RegisterRequest for `peer_id` using a freshly generated
+    /// Ed25519 keypair and the provided `nonce`.
+    fn make_register_body_with_nonce(peer_id: &str, nonce: &str) -> RegisterRequest {
         use ed25519_dalek::{Signer, SigningKey};
         use rand::rngs::OsRng;
 
         let signing_key = SigningKey::generate(&mut OsRng);
-        let nonce = "test-nonce-12345";
 
         let mut msg = Vec::new();
         msg.extend_from_slice(nonce.as_bytes());
@@ -282,6 +305,10 @@ mod tests {
             nonce_hex,
             signature_hex: sig_hex,
         }
+    }
+
+    fn make_register_body(peer_id: &str) -> RegisterRequest {
+        make_register_body_with_nonce(peer_id, "test-nonce-12345")
     }
 
     // -----------------------------------------------------------------------
@@ -340,6 +367,160 @@ mod tests {
             .unwrap();
 
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // -----------------------------------------------------------------------
+    // P0 regression: replayed nonce returns 409 Conflict
+    //
+    // Both requests share the same AppState (same NonceCache).  The first
+    // succeeds (200); the second is rejected (409) because the nonce was
+    // already claimed.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn register_replayed_nonce_returns_409() {
+        let state = test_state();
+        // Use separate apps but the same state so both share the NonceCache.
+        let body = make_register_body_with_nonce("replay-peer", "replay-nonce-xyz");
+
+        let first_resp = crate::build_router(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/auth/register")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Replay the identical request (same nonce, same signature).
+        let second_resp = crate::build_router(state)
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/auth/register")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            first_resp.status(),
+            StatusCode::OK,
+            "first registration must succeed"
+        );
+        assert_eq!(
+            second_resp.status(),
+            StatusCode::CONFLICT,
+            "replayed nonce must return 409 Conflict"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // P0 regression: two distinct nonces both succeed
+    //
+    // Two different valid nonces signed by two different keypairs must both
+    // receive 200 — the cache must not block legitimate concurrent registrations.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn register_distinct_nonces_both_succeed() {
+        let state = test_state();
+
+        let body_a = make_register_body_with_nonce("peer-alpha", "nonce-alpha-unique-001");
+        let body_b = make_register_body_with_nonce("peer-beta", "nonce-beta-unique-002");
+
+        let resp_a = crate::build_router(state.clone())
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/auth/register")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body_a).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let resp_b = crate::build_router(state)
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/auth/register")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body_b).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp_a.status(),
+            StatusCode::OK,
+            "first distinct nonce registration must succeed"
+        );
+        assert_eq!(
+            resp_b.status(),
+            StatusCode::OK,
+            "second distinct nonce registration must also succeed"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // P0 regression: LRU eviction — oldest entry is evicted when cache is full
+    //
+    // Uses NonceCache::with_capacity_and_ttl directly (unit-level) to verify
+    // that capacity-driven eviction makes the oldest nonce re-claimable while
+    // more-recently-used entries remain blocked.
+    //
+    // Note: This test operates on NonceCache directly (not via HTTP) because
+    // driving LRU eviction via the register handler would require
+    // NONCE_CACHE_CAPACITY (10 000) round-trips through axum.  The handler
+    // integration path is covered by register_replayed_nonce_returns_409.
+    //
+    // Two-stage design: re-inserting the evicted nonce in the same cache would
+    // cascade-evict the next-oldest entry.  Stage 1 verifies the remaining
+    // entries are blocked; Stage 2 (fresh cache) verifies the evicted entry is
+    // re-claimable.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn nonce_cache_eviction_lru_oldest() {
+        use std::time::Duration;
+        // ---- Stage 1: middle entries blocked after one eviction ----
+        let cache = NonceCache::with_capacity_and_ttl(4, Duration::from_secs(3600));
+
+        // Fill: A(LRU) → B → C → D(MRU).
+        assert!(cache.try_claim("evict-nonce-A"), "A: initial claim (1/4)");
+        assert!(cache.try_claim("evict-nonce-B"), "B: initial claim (2/4)");
+        assert!(cache.try_claim("evict-nonce-C"), "C: initial claim (3/4)");
+        assert!(cache.try_claim("evict-nonce-D"), "D: initial claim (4/4)");
+
+        // E evicts A (the LRU).  Cache: B(LRU), C, D, E(MRU).
+        assert!(cache.try_claim("evict-nonce-E"), "E: claim evicts A");
+
+        // B, C, D, E still present — must be replay-rejected.
+        assert!(!cache.try_claim("evict-nonce-B"), "B still cached — replay");
+        assert!(!cache.try_claim("evict-nonce-C"), "C still cached — replay");
+        assert!(!cache.try_claim("evict-nonce-D"), "D still cached — replay");
+        assert!(!cache.try_claim("evict-nonce-E"), "E still cached — replay");
+
+        // ---- Stage 2: evicted entry is re-claimable (fresh cache) ----
+        let cache2 = NonceCache::with_capacity_and_ttl(4, Duration::from_secs(3600));
+        cache2.try_claim("evict-nonce-A");
+        cache2.try_claim("evict-nonce-B");
+        cache2.try_claim("evict-nonce-C");
+        cache2.try_claim("evict-nonce-D");
+        cache2.try_claim("evict-nonce-E"); // evicts A
+
+        assert!(
+            cache2.try_claim("evict-nonce-A"),
+            "evicted nonce-A must be re-claimable after LRU eviction"
+        );
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## P0 Security Regression

PR #496 (closes #398) was supposed to add NonceCache for replay protection on `POST /auth/register`, but the implementation never made it to main. Any captured registration payload can be replayed indefinitely to obtain fresh 30-day JWTs — each replay receives a valid token bound to the captured `peer_id`.

**Root cause confirmed by prep agent**: merge commit `adc654f` contains zero occurrences of `NonceCache`, `nonce_cache`, or `try_claim` anywhere in `crates/phantom-hub/`. The doc comment at `auth.rs:47–52` actively concealed the gap by claiming single-use semantics were enforced.

This PR restores the missing implementation and consolidates carve-out #499 (LruCache migration) into a single PR. Closes #499.

## Changes

- `auth.rs`: Add `NonceCache` struct backed by `lru::LruCache` (capacity 10 000, TTL 10 minutes). `try_claim` is atomic — check and insert happen under a single `Mutex` acquisition with no window between them. Lock is never held across `.await`. Fix the false doc comment.
- `lib.rs`: Add `nonce_cache: Arc<NonceCache>` to `AppState`; initialize in `AppState::from_env`.
- `phantom_endpoint.rs`: Call `state.nonce_cache.try_claim(&nonce_str)` after signature verification and before JWT issuance. Return `409 Conflict` on replay.
- `mcp_endpoint.rs`: Update test helpers to include `nonce_cache` field.
- `Cargo.toml`: Add `lru = "0.12"`.

## Verification

- [x] `NonceCache::try_claim` is atomic under single `Mutex` acquisition
- [x] `lru::LruCache` evicts oldest on full insert — no full-clear fallback
- [x] `register` handler returns `409 Conflict` on replay
- [x] 3 regression tests added and passing:
  - `register_replayed_nonce_returns_409`
  - `register_distinct_nonces_both_succeed`
  - `nonce_cache_eviction_lru_oldest`
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `./scripts/pre-pr-check.sh phantom-hub` PASS (34/34 tests)

## §12 Scrutiny Notes for Reviewer

**try_claim atomicity**: `cache.peek()` (no LRU promotion) is used for the existence check, and `cache.put()` for the insert — both under the same `Mutex` guard acquired once at the top of the method. There is no release between check and insert.

**LRU eviction correctness**: The two-stage eviction test uses separate `NonceCache` instances to avoid the cascade where re-inserting the evicted nonce into the same full cache would itself evict the next-oldest. The test verifies both invariants (middle entries blocked; evicted entry re-claimable) correctly.

**No `.await` across lock**: `try_claim` is a synchronous method. The `Mutex` guard is dropped before the `register` handler returns any `impl IntoResponse`.

## Orchestration Process Gap

PR #496's fix handoff claimed the cache was added; the re-review claimed PASS on the cache being present; the merge agent's gates passed. Yet the cache is absent from main. The orchestrator should investigate whether this was a push failure, a stale-tree review, or a review process gap. Filing as a follow-up to #447.

🔒 P0 security — please fast-track with §12 review focus on `try_claim` atomicity and LRU eviction semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)