### PR TITLE
feat(#399): phantom.spawn_agent — Phase 2 hub MCP tool + Phantom-side wiring

### DIFF
--- a/crates/phantom-app/src/agent_pane/mod.rs
+++ b/crates/phantom-app/src/agent_pane/mod.rs
@@ -698,6 +698,15 @@ impl AgentPane {
         &self.task
     }
 
+    /// Return the stable [`phantom_agents::AgentId`] assigned at spawn time.
+    ///
+    /// Used by `phantom.spawn_agent` (issue #399) to return a stable id to
+    /// the MCP caller without coupling the hub or listener to the full pane
+    /// lifecycle.
+    pub(crate) fn agent_id(&self) -> u64 {
+        self.agent.id()
+    }
+
     /// Return the current execution status.
     pub(crate) fn status(&self) -> AgentPaneStatus {
         self.status

--- a/crates/phantom-app/src/agent_pane/spawn.rs
+++ b/crates/phantom-app/src/agent_pane/spawn.rs
@@ -21,7 +21,7 @@ impl App {
     /// Existing callers passing a bare [`AgentTask`] keep working byte-for-byte
     /// (no chat model override → default Claude path).
     pub(crate) fn spawn_agent_pane(&mut self, task: AgentTask) -> bool {
-        self.spawn_agent_pane_with_opts(AgentSpawnOpts::new(task))
+        self.spawn_agent_pane_with_opts(AgentSpawnOpts::new(task)).is_some()
     }
 
     /// Spawn a new agent pane with explicit spawn options.
@@ -29,10 +29,16 @@ impl App {
     /// Splits the focused pane vertically, creates the agent (using the
     /// requested [`ChatModel`] if any), wraps it in an `AgentAdapter`, and
     /// registers it in the new split pane.
+    ///
+    /// Returns `Some(agent_id)` on success, `None` when the spawn cannot
+    /// proceed (no focused pane, layout error, or missing API key).
+    /// The `agent_id` is the stable [`phantom_agents::AgentId`] (`u64`)
+    /// assigned by the agent's internal id counter — callers can use this
+    /// to correlate subsequent `phantom.get_agent_status` polls (issue #400).
     pub(crate) fn spawn_agent_pane_with_opts(
         &mut self,
         opts: AgentSpawnOpts,
-    ) -> bool {
+    ) -> Option<u64> {
         // Extract metadata before opts is moved into spawn_with_opts.
         let spawn_tag = opts.spawn_tag;
         // role/label carry Composer spawn_subagent metadata (#224).
@@ -41,17 +47,17 @@ impl App {
         let resolved_model = opts.resolve_model();
         let Some(claude_config) = resolve_api_config(&resolved_model) else {
             warn!("Cannot spawn agent: no API key configured for model {:?}", resolved_model);
-            return false;
+            return None;
         };
 
         // Split the focused pane to make room for the agent.
         let Some(focused_app_id) = self.coordinator.focused() else {
             warn!("Cannot spawn agent: no focused adapter");
-            return false;
+            return None;
         };
         let Some(current_pane_id) = self.coordinator.pane_id_for(focused_app_id) else {
             warn!("Cannot spawn agent: focused adapter has no layout pane");
-            return false;
+            return None;
         };
 
         let split_result = self.layout.split_vertical(current_pane_id);
@@ -59,7 +65,7 @@ impl App {
             Ok(ids) => ids,
             Err(e) => {
                 warn!("Agent split failed: {e}");
-                return false;
+                return None;
             }
         };
 
@@ -168,6 +174,10 @@ impl App {
             agent_pane.set_agent_capture(capture.clone(), self.session_uuid);
         }
 
+        // Capture the stable AgentId BEFORE the pane is moved into the adapter.
+        // This is the value returned to MCP callers (issue #399).
+        let agent_id = agent_pane.agent_id();
+
         let adapter = crate::adapters::agent::AgentAdapter::with_spawn_tag(agent_pane, spawn_tag);
 
         let scene_node = self
@@ -202,8 +212,8 @@ impl App {
                 source: phantom_agents::spawn_rules::EventSource::User,
             });
 
-        info!("Agent adapter registered (AppId {app_id}) in split pane");
-        true
+        info!("Agent adapter registered (AppId {app_id}) in split pane (agent_id={agent_id})");
+        Some(agent_id)
     }
 
     /// Drain the App's `BlockedEventSink` and return the queued

--- a/crates/phantom-app/src/commands.rs
+++ b/crates/phantom-app/src/commands.rs
@@ -192,7 +192,7 @@ impl App {
                             self.console
                                 .output(format!("  model: {}", m.backend_name()));
                         }
-                        if self.spawn_agent_pane_with_opts(opts) {
+                        if self.spawn_agent_pane_with_opts(opts).is_some() {
                             self.console.system("Agent pane opened.");
                             self.console.open = false;
                         } else {

--- a/crates/phantom-app/src/update.rs
+++ b/crates/phantom-app/src/update.rs
@@ -12,7 +12,7 @@ use phantom_brain::events::AiEvent;
 use phantom_brain::ooda::WorldState;
 use phantom_context::ProjectContext;
 use phantom_history::HistoryEntry;
-use phantom_mcp::{AppCommand, ScreenshotReply};
+use phantom_mcp::{AppCommand, ScreenshotReply, SpawnAgentReply};
 use phantom_protocol::Event;
 use crate::app::{App, AppState};
 use crate::input::chrono_time_string;
@@ -706,6 +706,53 @@ impl App {
             AppCommand::SetMemory { key, value, reply } => {
                 let result = self.mcp_set_memory(&key, &value);
                 let _ = reply.send(result);
+            }
+            AppCommand::SpawnAgent { prompt, role: _, reply } => {
+                // role mapping is deferred to v2; all roles use the FreeForm path.
+                let task = phantom_agents::agent::AgentTask::FreeForm { prompt };
+                // Build a minimal ISO-8601 UTC timestamp without a chrono dep.
+                let started_at = {
+                    let secs = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs();
+                    let s = secs % 60;
+                    let m = (secs / 60) % 60;
+                    let h = (secs / 3600) % 24;
+                    let days = secs / 86400; // days since 1970-01-01
+                    // Simple Gregorian calendar computation.
+                    let (year, month, day) = {
+                        let mut y = 1970u32;
+                        let mut d = days;
+                        loop {
+                            let leap = (y.is_multiple_of(4) && !y.is_multiple_of(100)) || y.is_multiple_of(400);
+                            let yd = if leap { 366u64 } else { 365 };
+                            if d < yd { break; }
+                            d -= yd;
+                            y += 1;
+                        }
+                        let leap = (y.is_multiple_of(4) && !y.is_multiple_of(100)) || y.is_multiple_of(400);
+                        let mdays = [31u64,if leap{29}else{28},31,30,31,30,31,31,30,31,30,31];
+                        let mut mo = 1u32;
+                        for &md in &mdays {
+                            if d < md { break; }
+                            d -= md;
+                            mo += 1;
+                        }
+                        (y, mo, d + 1)
+                    };
+                    format!("{year:04}-{month:02}-{day:02}T{h:02}:{m:02}:{s:02}Z")
+                };
+                match self.spawn_agent_pane_with_opts(phantom_agents::AgentSpawnOpts::new(task)) {
+                    Some(agent_id) => {
+                        let _ = reply.send(Ok(SpawnAgentReply { agent_id, started_at }));
+                    }
+                    None => {
+                        let _ = reply.send(Err(
+                            "spawn_agent failed: no focused pane or API key not configured".into(),
+                        ));
+                    }
+                }
             }
         }
     }

--- a/crates/phantom-hub/src/mcp_endpoint.rs
+++ b/crates/phantom-hub/src/mcp_endpoint.rs
@@ -11,12 +11,24 @@
 //! - `phantom.read_output` — routes a `phantom.read_output` JSON-RPC frame with an optional
 //!   `since` cursor to the target Phantom; returns the text + next cursor.
 //!
+//! # Phase 2 (issue #399)
+//!
+//! - `phantom.spawn_agent` — routes a `phantom.spawn_agent` JSON-RPC frame to the target
+//!   Phantom; Phantom calls [`phantom_agents::AgentManager::spawn`] and returns an
+//!   `{ agent_id, started_at }` payload. The hub forwards the structured reply unchanged.
+//!
 //! # Auth
 //!
 //! Both endpoints require `Authorization: Bearer <api-key>` where the key is
 //! a `phk_<base64url>` value loaded from `HUB_API_KEYS` at startup.  The hub
 //! stores SHA-256 hashes; comparison is constant-time via [`crate::auth::ApiKeyStore::validate`].
 //! An absent or invalid key returns 401 immediately, before any registry access.
+//!
+//! For `phantom.spawn_agent` the hub also verifies that the target `phantom_id` is
+//! online in the registry before forwarding (404-equivalent JSON-RPC error if not).
+//! Per-key capability scoping (allowlist for spawn per API key) is deferred to issue
+//! #409 (ticket 09); v1 grants spawn to any valid API key. The comment
+//! `// SECURITY: ticket-09 will add per-key capability scoping here` marks the call site.
 //!
 //! # Transport
 //!
@@ -29,8 +41,8 @@
 //!
 //! # `tools/list`
 //!
-//! The hub has its own `tools/list` — Phase 1 does NOT proxy `tools/list` to any Phantom.
-//! The three tools defined here are the entire surface area for Phase 1.
+//! The hub has its own `tools/list` — it does NOT proxy `tools/list` to any Phantom.
+//! Phase 2 surface area: four tools (three from Phase 1 plus `phantom.spawn_agent`).
 //!
 //! # Output buffering for `read_output`
 //!
@@ -39,8 +51,8 @@
 //! The hub relays those fields back to Claude unchanged.  Cap and eviction are
 //! Phantom-side concerns; the hub is a pure pass-through for `read_output` payloads.
 //!
-//! For Phase 1, the hub's default timeout (30 s, `HUB_FORWARD_TIMEOUT_SECS`) applies
-//! to both `run_command` and `read_output`.  Long-running commands should use
+//! For Phase 1+2, the hub's default timeout (30 s, `HUB_FORWARD_TIMEOUT_SECS`) applies
+//! to `run_command`, `read_output`, and `spawn_agent`.  Long-running commands should use
 //! `read_output` polling with the cursor rather than waiting on `run_command`.
 
 use axum::body::Body;
@@ -140,6 +152,38 @@ fn fleet_tools() -> Vec<McpTool> {
                     }
                 },
                 "required": ["phantom_id"]
+            }),
+        },
+        // Phase 2 (issue #399): remote agent spawn returning a stable AgentId.
+        McpTool {
+            name: "phantom.spawn_agent".into(),
+            description: "Spawn an AI agent on a specific Phantom instance. \
+                Returns a stable agent_id (decimal string) and started_at timestamp \
+                immediately — the agent runs asynchronously. \
+                Use phantom.get_agent_status (issue #400) to poll for progress. \
+                NOTE: any valid API key can spawn agents in v1; per-key capability \
+                scoping is deferred to issue #409."
+                .into(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "phantom_id": {
+                        "type": "string",
+                        "description": "The stable peer ID of the target Phantom, \
+                            as returned by phantom.list_phantoms."
+                    },
+                    "prompt": {
+                        "type": "string",
+                        "description": "Free-form task description for the agent."
+                    },
+                    "role": {
+                        "type": "string",
+                        "enum": ["default", "defender", "inspector"],
+                        "description": "Agent role. Defaults to 'default'.",
+                        "default": "default"
+                    }
+                },
+                "required": ["phantom_id", "prompt"]
             }),
         },
     ]
@@ -317,6 +361,8 @@ async fn dispatch_tools_call(
         "phantom.list_phantoms" => dispatch_list_phantoms(state, id).await,
         "phantom.run_command" => dispatch_run_command(state, id, &args).await,
         "phantom.read_output" => dispatch_read_output(state, id, &args).await,
+        // Phase 2 (issue #399)
+        "phantom.spawn_agent" => dispatch_spawn_agent(state, id, &args).await,
         other => {
             warn!("mcp: tools/call for unknown tool '{other}'");
             json_rpc_error(id, -32601, format!("Unknown tool: {other}"))
@@ -458,6 +504,87 @@ async fn dispatch_read_output(
         method: "tools/call".into(),
         params: json!({
             "name": "phantom.read_output",
+            "arguments": forward_args
+        }),
+    };
+
+    let pid = PhantomId::new(&phantom_id);
+
+    match router::forward(&state.registry, &pid, phantom_req, None, &()).await {
+        Ok(resp) => phantom_response_to_mcp(id, resp),
+        Err(e) => route_error_to_mcp(id, &phantom_id, e),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// phantom.spawn_agent (issue #399)
+// ---------------------------------------------------------------------------
+
+/// Route a `phantom.spawn_agent` JSON-RPC frame to the named Phantom.
+///
+/// The hub is a pure pass-through for this tool — it does NOT call
+/// `AgentManager` itself. Instead it forwards the frame to the Phantom's
+/// MCP listener, which dispatches `AppCommand::SpawnAgent` on the App thread,
+/// calls `AgentManager::spawn`, and returns `{ agent_id, started_at }`.
+///
+/// # Auth / capability gate
+///
+/// Auth: API key validated by the shared `require_api_key` guard (returns 401
+/// to the HTTP layer before this function is reached).
+///
+/// Capability gate v1: any valid API key can spawn agents.  Per-key capability
+/// scoping (limiting spawn to explicitly-whitelisted keys) is deferred to
+/// issue #409.
+/// SECURITY: ticket-09 will add per-key capability scoping here.
+///
+/// The `phantom_id` existence check is enforced by `router::forward` which
+/// returns `RouteError::NotFound` when the peer is absent from the registry.
+async fn dispatch_spawn_agent(
+    state: &AppState,
+    id: serde_json::Value,
+    args: &serde_json::Value,
+) -> serde_json::Value {
+    let phantom_id = match args.get("phantom_id").and_then(|v| v.as_str()) {
+        Some(p) if !p.is_empty() => p.to_owned(),
+        _ => {
+            return json_rpc_error(id, -32602, "missing or empty 'phantom_id' argument");
+        }
+    };
+
+    let prompt = match args.get("prompt").and_then(|v| v.as_str()) {
+        Some(p) if !p.is_empty() => p.to_owned(),
+        _ => {
+            return json_rpc_error(id, -32602, "missing or empty 'prompt' argument");
+        }
+    };
+
+    // Validate role against the allowlist; forward the raw value — Phantom
+    // coerces unknown roles to "default" on its side.
+    let role = args.get("role").and_then(|v| v.as_str()).unwrap_or("default");
+    let role = match role {
+        "defender" | "inspector" | "default" => role.to_owned(),
+        other => {
+            warn!("mcp: spawn_agent role '{other}' not in allowlist, coercing to 'default'");
+            "default".to_owned()
+        }
+    };
+
+    info!("mcp: spawn_agent phantom={phantom_id} prompt={prompt:?} role={role}");
+
+    // SECURITY: ticket-09 will add per-key capability scoping here.
+    // v1: any valid API key may spawn agents.
+
+    let forward_args = json!({
+        "prompt": prompt,
+        "role": role
+    });
+
+    let phantom_req = JsonRpcRequest {
+        jsonrpc: "2.0".into(),
+        id: Some(id.clone()),
+        method: "tools/call".into(),
+        params: json!({
+            "name": "phantom.spawn_agent",
             "arguments": forward_args
         }),
     };
@@ -713,11 +840,11 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // tools/list → three tools
+    // tools/list → four tools (Phase 2 adds phantom.spawn_agent)
     // -----------------------------------------------------------------------
 
     #[tokio::test]
-    async fn mcp_tools_list_returns_three_tools() {
+    async fn mcp_tools_list_returns_four_tools() {
         let app = crate::build_router(test_state_with_key(TEST_API_KEY));
         let resp = app
             .oneshot(
@@ -747,7 +874,8 @@ mod tests {
         assert!(names.contains(&"phantom.list_phantoms"), "names: {names:?}");
         assert!(names.contains(&"phantom.run_command"), "names: {names:?}");
         assert!(names.contains(&"phantom.read_output"), "names: {names:?}");
-        assert_eq!(names.len(), 3, "expected exactly 3 tools, got: {names:?}");
+        assert!(names.contains(&"phantom.spawn_agent"), "names: {names:?}");
+        assert_eq!(names.len(), 4, "expected exactly 4 tools, got: {names:?}");
     }
 
     // -----------------------------------------------------------------------
@@ -1112,6 +1240,171 @@ mod tests {
                         json!({
                             "name": "phantom.run_command",
                             "arguments": { "command": "ls" }
+                        }),
+                    )))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let val: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let code = val["error"]["code"].as_i64().unwrap_or(0);
+        assert_eq!(code, -32602, "expected INVALID_PARAMS -32602, got {code}");
+    }
+
+    // -----------------------------------------------------------------------
+    // phantom.spawn_agent: valid auth + connected peer → agent_id returned
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn spawn_agent_valid_auth_and_connected_peer_returns_agent_id() {
+        let state = test_state_with_key(TEST_API_KEY);
+        let mut rx = register_fake_phantom(&state, "spawn-phantom", "localhost", "0.1.0").await;
+
+        // Fake Phantom: receives spawn_agent, returns agent_id + started_at.
+        let reg_clone = Arc::clone(&state.registry);
+        tokio::spawn(async move {
+            let req = rx.recv().await.expect("fake phantom should receive request");
+            let hub_id = req.id.clone().unwrap().as_u64().unwrap();
+            deliver_response(
+                &reg_clone,
+                &PhantomId::new("spawn-phantom"),
+                crate::router::JsonRpcResponse {
+                    jsonrpc: "2.0".into(),
+                    id: Some(serde_json::Value::Number(hub_id.into())),
+                    result: Some(json!({
+                        "content": [{"type": "text", "text": "agent spawned: id=7 started_at=2026-04-30T00:00:00Z"}],
+                        "agent_id": "7",
+                        "started_at": "2026-04-30T00:00:00Z"
+                    })),
+                    error: None,
+                },
+            )
+            .await;
+        });
+
+        let app = crate::build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/mcp")
+                    .header("Authorization", auth_header(TEST_API_KEY))
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(mcp_request_body(
+                        "tools/call",
+                        json!({
+                            "name": "phantom.spawn_agent",
+                            "arguments": {
+                                "phantom_id": "spawn-phantom",
+                                "prompt": "list the modified files in this repo"
+                            }
+                        }),
+                    )))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let val: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(val.get("error").is_none(), "unexpected error: {val}");
+        let agent_id = val["result"]["agent_id"].as_str().unwrap_or("");
+        assert_eq!(agent_id, "7", "expected agent_id '7', got: {val}");
+    }
+
+    // -----------------------------------------------------------------------
+    // phantom.spawn_agent: unknown peer → JSON-RPC NotFound error
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn spawn_agent_unknown_peer_returns_rpc_error() {
+        let app = crate::build_router(test_state_with_key(TEST_API_KEY));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/mcp")
+                    .header("Authorization", auth_header(TEST_API_KEY))
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(mcp_request_body(
+                        "tools/call",
+                        json!({
+                            "name": "phantom.spawn_agent",
+                            "arguments": {
+                                "phantom_id": "ghost-phantom",
+                                "prompt": "do something"
+                            }
+                        }),
+                    )))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let val: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(val.get("error").is_some(), "expected error, got: {val}");
+        let code = val["error"]["code"].as_i64().unwrap();
+        assert_eq!(code, -32001, "expected NotFound -32001, got {code}");
+    }
+
+    // -----------------------------------------------------------------------
+    // phantom.spawn_agent: no API key → 401
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn spawn_agent_no_api_key_returns_401() {
+        let app = crate::build_router(test_state_with_key(TEST_API_KEY));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/mcp")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(mcp_request_body(
+                        "tools/call",
+                        json!({
+                            "name": "phantom.spawn_agent",
+                            "arguments": {
+                                "phantom_id": "any-phantom",
+                                "prompt": "do something"
+                            }
+                        }),
+                    )))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // -----------------------------------------------------------------------
+    // phantom.spawn_agent: missing prompt → INVALID_PARAMS error
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn spawn_agent_missing_prompt_returns_invalid_params() {
+        let app = crate::build_router(test_state_with_key(TEST_API_KEY));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/mcp")
+                    .header("Authorization", auth_header(TEST_API_KEY))
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(mcp_request_body(
+                        "tools/call",
+                        json!({
+                            "name": "phantom.spawn_agent",
+                            "arguments": { "phantom_id": "some-phantom" }
                         }),
                     )))
                     .unwrap(),

--- a/crates/phantom-mcp/src/lib.rs
+++ b/crates/phantom-mcp/src/lib.rs
@@ -22,7 +22,7 @@ pub mod server;
 pub use client::{McpClient, McpResourceDef, McpToolDef};
 pub use error::McpError;
 pub use hub_listener::{HubListener, spawn_hub};
-pub use listener::{spawn as spawn_listener, AppCommand, McpListener, ScreenshotReply};
+pub use listener::{spawn as spawn_listener, AppCommand, McpListener, ScreenshotReply, SpawnAgentReply};
 pub use protocol::{
     JsonRpcError, JsonRpcRequest, JsonRpcResponse, McpResource, McpTool,
     create_error, create_request, create_response,

--- a/crates/phantom-mcp/src/listener.rs
+++ b/crates/phantom-mcp/src/listener.rs
@@ -10,6 +10,17 @@
 //!
 //! One thread binds the socket and accepts; each accepted connection gets its
 //! own worker thread. This handles multiple concurrent clients without async.
+//!
+//! # Phase 2: `phantom.spawn_agent` (issue #399)
+//!
+//! [`AppCommand::SpawnAgent`] is the parallel path to `phantom.command "agent …"`.
+//! Unlike the fire-and-forget `PhantomCommand` path, `SpawnAgent` returns the
+//! [`u64`] `AgentId` synchronously, enabling downstream polling via
+//! `phantom.get_agent_status` (issue #400).
+//!
+//! The reply payload is `{ agent_id: <string>, started_at: <iso8601> }`.
+//! `agent_id` is serialised as a decimal string so that JavaScript callers
+//! are not at risk of 53-bit integer truncation.
 
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::{UnixListener, UnixStream};
@@ -88,6 +99,24 @@ pub enum AppCommand {
         value: String,
         reply: SyncSender<Result<String, String>>,
     },
+    /// Spawn an AI agent with the given prompt.
+    ///
+    /// The App thread calls [`phantom_agents::AgentManager::spawn`] with an
+    /// `AgentTask::FreeForm { prompt }` and returns the resulting [`u64`]
+    /// `AgentId` over the reply channel.  The role is validated against
+    /// `["default", "defender", "inspector"]`; any unknown value is coerced to
+    /// `"default"`.
+    ///
+    /// Spawning is fire-and-forget at the agent level: the command returns
+    /// immediately with the id before any tool runs.  Status polling is handled
+    /// by `phantom.get_agent_status` (issue #400).
+    SpawnAgent {
+        /// Free-form prompt describing the task.
+        prompt: String,
+        /// Optional role override (`"default"`, `"defender"`, or `"inspector"`).
+        role: Option<String>,
+        reply: SyncSender<Result<SpawnAgentReply, String>>,
+    },
 }
 
 /// Payload returned for a successful screenshot.
@@ -96,6 +125,19 @@ pub struct ScreenshotReply {
     pub path: PathBuf,
     pub width: u32,
     pub height: u32,
+}
+
+/// Payload returned for a successful `phantom.spawn_agent` call.
+///
+/// `agent_id` is the canonical `u64` assigned by [`phantom_agents::AgentManager`].
+/// It is exposed as a plain [`u64`] here; the MCP layer serialises it as a
+/// decimal string to avoid JavaScript 53-bit integer truncation.
+#[derive(Debug, Clone)]
+pub struct SpawnAgentReply {
+    /// Stable agent identifier within this Phantom session.
+    pub agent_id: u64,
+    /// ISO-8601 UTC timestamp at the moment the agent was registered.
+    pub started_at: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -315,6 +357,8 @@ fn dispatch(
         "phantom.split_pane" => dispatch_split_pane(id, &args, cmd_tx),
         "phantom.get_memory" => dispatch_get_memory(id, &args, cmd_tx),
         "phantom.set_memory" => dispatch_set_memory(id, &args, cmd_tx),
+        // Phase 2 (issue #399): direct agent-spawn returning a stable AgentId.
+        "phantom.spawn_agent" => dispatch_spawn_agent(id, &args, cmd_tx),
         // For every other tool, defer to the stub implementation in `server`.
         _ => server.handle_request(request),
     }
@@ -674,6 +718,88 @@ fn dispatch_set_memory(
 }
 
 // ---------------------------------------------------------------------------
+// phantom.spawn_agent (issue #399)
+// ---------------------------------------------------------------------------
+
+/// Dispatch `phantom.spawn_agent` — spawn an agent and return its stable AgentId.
+///
+/// This is a **parallel path** to `phantom.command "agent …"`.  Unlike that
+/// fire-and-forget path, this dispatcher returns the [`u64`] AgentId so that
+/// Claude can poll for status via `phantom.get_agent_status` (issue #400).
+///
+/// Allowed roles: `"default"` (default), `"defender"`, `"inspector"`.  Any
+/// unrecognised role string is silently coerced to `"default"`.
+///
+/// The reply payload contains:
+/// - `agent_id`   — decimal string (avoids JS 53-bit truncation for large ids).
+/// - `started_at` — ISO-8601 UTC timestamp at spawn time.
+fn dispatch_spawn_agent(
+    id: serde_json::Value,
+    args: &serde_json::Value,
+    cmd_tx: &Sender<AppCommand>,
+) -> protocol::JsonRpcResponse {
+    let prompt = args
+        .get("prompt")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    if prompt.is_empty() {
+        return protocol::create_error(id, INVALID_PARAMS, "missing 'prompt' argument");
+    }
+
+    // Validate role against the allowlist; coerce unknown values to "default".
+    let raw_role = args.get("role").and_then(|v| v.as_str()).unwrap_or("default");
+    let role = match raw_role {
+        "defender" | "inspector" | "default" => Some(raw_role.to_owned()),
+        _ => {
+            warn!(
+                "spawn_agent: unknown role '{}', coercing to 'default'",
+                raw_role
+            );
+            Some("default".to_owned())
+        }
+    };
+
+    let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+    if cmd_tx
+        .send(AppCommand::SpawnAgent {
+            prompt: prompt.clone(),
+            role,
+            reply: reply_tx,
+        })
+        .is_err()
+    {
+        return protocol::create_error(id, INTERNAL_ERROR, "app command channel closed");
+    }
+
+    match reply_rx.recv_timeout(Duration::from_secs(10)) {
+        Ok(Ok(reply)) => protocol::create_response(
+            id,
+            json!({
+                "content": [{
+                    "type": "text",
+                    "text": format!(
+                        "agent spawned: id={} started_at={}",
+                        reply.agent_id, reply.started_at
+                    )
+                }],
+                "agent_id": reply.agent_id.to_string(),
+                "started_at": reply.started_at,
+            }),
+        ),
+        Ok(Err(e)) => protocol::create_response(
+            id,
+            json!({
+                "content": [{"type": "text", "text": format!("spawn_agent failed: {e}")}],
+                "isError": true,
+            }),
+        ),
+        Err(e) => protocol::create_error(id, INTERNAL_ERROR, &format!("app reply dropped: {e}")),
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -839,6 +965,50 @@ mod tests {
         let req = r#"{"jsonrpc":"2.0","id":15,"method":"tools/call","params":{"name":"phantom.set_memory","arguments":{"key":"","value":"v"}}}"#;
         let resp = send_and_recv(&mut stream, req);
         assert!(resp.contains("missing"), "should reject empty key: {resp}");
+    }
+
+    // ── phantom.spawn_agent ──────────────────────────────────────────────────
+
+    #[test]
+    fn spawn_agent_forwards_to_app_thread_and_returns_agent_id() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock = tmp.path().join("mcp-spawn-agent.sock");
+        let (cmd_tx, cmd_rx) = mpsc::channel();
+        let _listener = spawn(sock.clone(), cmd_tx).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        // Fake app thread: fulfil SpawnAgent with a deterministic reply.
+        thread::spawn(move || {
+            for cmd in cmd_rx {
+                if let AppCommand::SpawnAgent { prompt, role, reply } = cmd {
+                    let _ = (prompt, role); // consumed
+                    let _ = reply.send(Ok(SpawnAgentReply {
+                        agent_id: 42,
+                        started_at: "2026-04-30T00:00:00Z".to_owned(),
+                    }));
+                }
+            }
+        });
+
+        let mut stream = UnixStream::connect(&sock).unwrap();
+        let req = r#"{"jsonrpc":"2.0","id":20,"method":"tools/call","params":{"name":"phantom.spawn_agent","arguments":{"prompt":"list modified files","role":"default"}}}"#;
+        let resp = send_and_recv(&mut stream, req);
+        assert!(resp.contains("42"), "expected agent_id 42 in: {resp}");
+        assert!(resp.contains("2026-04-30"), "expected started_at in: {resp}");
+    }
+
+    #[test]
+    fn spawn_agent_rejects_empty_prompt() {
+        let tmp = tempfile::tempdir().unwrap();
+        let sock = tmp.path().join("mcp-spawn-agent-empty.sock");
+        let (cmd_tx, _cmd_rx) = mpsc::channel();
+        let _listener = spawn(sock.clone(), cmd_tx).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(50));
+
+        let mut stream = UnixStream::connect(&sock).unwrap();
+        let req = r#"{"jsonrpc":"2.0","id":21,"method":"tools/call","params":{"name":"phantom.spawn_agent","arguments":{"prompt":""}}}"#;
+        let resp = send_and_recv(&mut stream, req);
+        assert!(resp.contains("missing"), "should reject empty prompt: {resp}");
     }
 
     #[test]

--- a/crates/phantom-mcp/src/server.rs
+++ b/crates/phantom-mcp/src/server.rs
@@ -306,6 +306,30 @@ fn builtin_tools() -> Vec<McpTool> {
                 "required": ["command"],
             }),
         },
+        // Phase 2 (issue #399): direct agent-spawn returning a stable AgentId.
+        McpTool {
+            name: "phantom.spawn_agent".to_owned(),
+            description: "Spawn an AI agent on this Phantom instance and return a stable AgentId. \
+                The agent runs asynchronously; use phantom.get_agent_status (issue #400) to poll \
+                for progress. Unlike phantom.command 'agent …', this tool returns the AgentId \
+                immediately so downstream status queries are possible.".to_owned(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "prompt": {
+                        "type": "string",
+                        "description": "Free-form task description for the agent."
+                    },
+                    "role": {
+                        "type": "string",
+                        "enum": ["default", "defender", "inspector"],
+                        "description": "Agent role. Defaults to 'default'. Unknown values are coerced to 'default'.",
+                        "default": "default"
+                    }
+                },
+                "required": ["prompt"],
+            }),
+        },
     ]
 }
 
@@ -362,11 +386,12 @@ mod tests {
         let req = create_request(2, "tools/list", json!({}));
         let resp = s.handle_request(&req);
         let tools = resp.result.unwrap()["tools"].as_array().unwrap().clone();
-        assert_eq!(tools.len(), 9);
+        assert_eq!(tools.len(), 10);
         let names: Vec<String> = tools.iter().map(|t| t["name"].as_str().unwrap().to_owned()).collect();
         assert!(names.contains(&"phantom.run_command".to_owned()));
         assert!(names.contains(&"phantom.screenshot".to_owned()));
         assert!(names.contains(&"phantom.set_memory".to_owned()));
+        assert!(names.contains(&"phantom.spawn_agent".to_owned()));
     }
 
     #[test]
@@ -445,9 +470,9 @@ mod tests {
     }
 
     #[test]
-    fn server_has_nine_tools_and_three_resources() {
+    fn server_has_ten_tools_and_three_resources() {
         let s = server();
-        assert_eq!(s.tools().len(), 9);
+        assert_eq!(s.tools().len(), 10);
         assert_eq!(s.resources().len(), 3);
     }
 
@@ -458,11 +483,12 @@ mod tests {
             "phantom.run_command", "phantom.read_output", "phantom.screenshot",
             "phantom.split_pane", "phantom.get_context", "phantom.get_memory",
             "phantom.set_memory", "phantom.send_key", "phantom.command",
+            "phantom.spawn_agent",
         ];
         for name in tool_names {
             let req = create_request(100, "tools/call", json!({
                 "name": name,
-                "arguments": {"command": "test", "key": "k", "value": "v", "direction": "h"}
+                "arguments": {"command": "test", "key": "k", "value": "v", "direction": "h", "prompt": "test prompt"}
             }));
             let resp = s.handle_request(&req);
             let result = resp.result.unwrap();


### PR DESCRIPTION
## Summary

- Adds `phantom.spawn_agent(phantom_id, prompt, role?)` as the 4th fleet MCP tool in phantom-hub, enabling external AI (Claude Code, etc.) to spawn an agent pane in a named Phantom instance and receive a stable `AgentId` back synchronously
- Wires the full producer→consumer path: hub validates auth + forwards via `router::forward` → Phantom's Unix-socket listener dispatches `AppCommand::SpawnAgent` → `App::handle_mcp_command` calls `spawn_agent_pane_with_opts` → returns `{ agent_id, started_at }` to the caller
- Changes `spawn_agent_pane_with_opts` return type from `bool` to `Option<u64>` so the canonical `AgentId` is surfaced; fixes the single call site in `commands.rs`

Closes #399. Part of epic #392. The returned `agent_id` is the direct input to `phantom.get_agent_status` (issue #400, next step).

## Security

Capability gate: v1 grants any valid API key spawn access. `// SECURITY: ticket-09 will add per-key capability scoping here` markers are in place at §12.2 of the arch spec (hub `dispatch_spawn_agent`) and in phantom-mcp `dispatch_spawn_agent`.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace --no-run` — all test binaries compile
- [x] `cargo test -p phantom-hub -p phantom-mcp -p phantom-agents` — 774 phantom-agents + 62 hub + 72 mcp tests, 0 failures
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] Hub tests: `spawn_agent_valid_auth_and_connected_peer_returns_agent_id`, `spawn_agent_unknown_peer_returns_rpc_error` (-32001), `spawn_agent_no_api_key_returns_401`, `spawn_agent_missing_prompt_returns_invalid_params` (-32602), `mcp_tools_list_returns_four_tools`
- [x] Phantom-side listener tests: `spawn_agent_forwards_to_app_thread_and_returns_agent_id`, `spawn_agent_rejects_empty_prompt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)