### PR TITLE
fix(phantom-stt): replace feature-gated MockBackend in SttStream doctest (#493)

### DIFF
--- a/crates/phantom-stt/src/stream.rs
+++ b/crates/phantom-stt/src/stream.rs
@@ -154,12 +154,42 @@ impl SttStreamConfig {
 /// # async fn example() {
 /// use std::sync::Arc;
 /// use tokio::sync::mpsc;
-/// use phantom_stt::{AudioChunk, MockBackend};
+/// use phantom_stt::{
+///     AudioChunk, BoxedTranscriptStream, SttError, TranscriptBackend, TranscriptStreamItem,
+/// };
 /// use phantom_stt::stream::{SttStream, SttStreamConfig};
+///
+/// /// Minimal backend for the doctest: drains audio, emits no events.
+/// struct NullBackend;
+///
+/// /// A [`futures_core::Stream`] that immediately returns `None`.
+/// struct EmptyStream;
+///
+/// impl futures_core::Stream for EmptyStream {
+///     type Item = TranscriptStreamItem;
+///     fn poll_next(
+///         self: std::pin::Pin<&mut Self>,
+///         _cx: &mut std::task::Context<'_>,
+///     ) -> std::task::Poll<Option<Self::Item>> {
+///         std::task::Poll::Ready(None)
+///     }
+/// }
+///
+/// #[async_trait::async_trait]
+/// impl TranscriptBackend for NullBackend {
+///     fn name(&self) -> &'static str { "null" }
+///     async fn transcribe(
+///         &self,
+///         mut audio_rx: mpsc::Receiver<AudioChunk>,
+///     ) -> Result<BoxedTranscriptStream, SttError> {
+///         while audio_rx.recv().await.is_some() {}
+///         Ok(Box::pin(EmptyStream))
+///     }
+/// }
 ///
 /// let (audio_tx, audio_rx) = mpsc::channel::<AudioChunk>(64);
 /// let (partial_tx, mut partial_rx) = mpsc::channel(64);
-/// let backend = Arc::new(MockBackend::new());
+/// let backend = Arc::new(NullBackend);
 /// let stream = SttStream::new(backend, SttStreamConfig::default());
 ///
 /// // Drive in a background task.


### PR DESCRIPTION
## Summary

- `SttStream`'s doctest imported `phantom_stt::MockBackend`, which is compiled only under `#[cfg(any(test, feature = "test-utils"))]`
- Running `cargo test --doc -p phantom-stt` without `--features test-utils` failed with E0432 (`no MockBackend in the root`)
- Fix: replace the `MockBackend` import with a self-contained `NullBackend` + `EmptyStream` defined inline in the doctest, requiring no changes to feature flags, `lib.rs`, or `Cargo.toml`

**Fix choice rationale:** Inline mock is the most idiomatic approach — doctests should be self-contained and not rely on test-only symbols leaking into the public API surface. A `#[cfg(doctest)]` re-export would permanently widen the public API for a narrow tooling reason; `required-features` would silently skip the doctest in default CI runs.

## Test plan

- [x] `cargo test --doc -p phantom-stt` exits 0 (was: FAILED with E0432)
- [x] `cargo test -p phantom-stt` passes all 28 unit tests + 1 doctest
- [x] `cargo build --workspace` exits 0
- [x] Pre-existing `Cargo.toml:39` clippy noise confirmed present on `origin/main` before this change; not introduced here

Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)