### PR TITLE
docs(phantom-nlp): consolidate SAFETY block at llm_export.rs:128 (closes #484)

### DIFF
--- a/crates/phantom-nlp/src/llm_export.rs
+++ b/crates/phantom-nlp/src/llm_export.rs
@@ -125,9 +125,12 @@ unsafe extern "C" fn complete_ffi(
         return;
     }
 
-    // SAFETY: pointer/length pairs are borrowed for the duration of the call;
-    // checked UTF-8 conversion — non-UTF-8 input writes a descriptive error.
-    // out_ptr / out_len / out_err are non-null (guarded above).
+    // SAFETY: `system_prompt` and `user_message` pointer/length pairs are valid
+    // for the duration of the call (enforced by the C ABI contract documented on
+    // `LlmSkillVtable::complete`).  `out_ptr`, `out_len`, and `out_err` are
+    // non-null (null-guarded above).  UTF-8 validity is checked via
+    // `std::str::from_utf8` — invalid input is converted to a descriptive error
+    // written through the out-parameters rather than causing UB.
     let sys_bytes = unsafe { std::slice::from_raw_parts(system_prompt, system_prompt_len) };
     let sys = match std::str::from_utf8(sys_bytes) {
         Ok(s) => s,


### PR DESCRIPTION
## Summary

- Replaces the previously-sparse, merged SAFETY comment above `complete_ffi`'s first `unsafe` block with a single well-formed block that names all three invariants explicitly: pointer/length validity (C ABI contract on `LlmSkillVtable::complete`), out-parameter non-null guarantee (runtime null-guard at line 124), and UTF-8 checked via `std::str::from_utf8` rather than assumed.
- Comment-only change — no unsafe semantics altered.
- Closes #484. Issue #484 was filed as FU-2 from PR #474 re-review; the duplicate removal was previously tracked as #470 and landed in batch commit `bf8b807`, but #484 remained open.

## Test plan

- [x] `cargo build --workspace` — clean, zero warnings
- [x] `cargo test -p phantom-nlp` — 81 tests pass (80 + 1 ignored live test)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero errors

Closes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)