### PR TITLE
chore(phantom-skill-host): batch tech-debt — visibility, assertion, deterministic tests (#483 #485 #486)

### DIFF
--- a/crates/phantom-skill-host/src/drain_reaper.rs
+++ b/crates/phantom-skill-host/src/drain_reaper.rs
@@ -154,6 +154,15 @@ impl DrainReaper {
         });
     }
 
+    /// Drive one synchronous poll cycle — test use only.
+    ///
+    /// Equivalent to what the background thread does on each wakeup, but called
+    /// on the calling thread so tests can advance reaper state deterministically
+    /// without sleeping.
+    pub(crate) fn tick_for_test(&self) {
+        self.poll_all();
+    }
+
     /// Snapshot all live entries for telemetry.
     fn snapshot_all(&self) -> Vec<SwapState> {
         let entries = self.entries.lock().unwrap();
@@ -219,6 +228,18 @@ pub(crate) fn register<T: ?Sized + Send + Sync + 'static>(
     });
     global_reaper().register_entry(entry);
     log::debug!("skill-host/reaper: registered swap target '{name}'");
+}
+
+/// Tick the global drain-reaper once synchronously — **test use only**.
+///
+/// Exposed so integration tests in `tests/` can drive one reaper poll cycle
+/// deterministically without sleeping.  Initialises the reaper singleton if it
+/// has not yet been started (safe — identical to what `register` does).
+///
+/// Production callers should never need to call this; it is intended solely
+/// for use in integration tests to avoid wall-clock `thread::sleep` delays.
+pub fn tick_reaper_for_test() {
+    global_reaper().tick_for_test();
 }
 
 /// Return the swap state of every live `SwapManager`.

--- a/crates/phantom-skill-host/src/lib.rs
+++ b/crates/phantom-skill-host/src/lib.rs
@@ -46,7 +46,7 @@
 //! `tokio::spawn`)
 #![forbid(unsafe_op_in_unsafe_fn)]
 
-pub mod drain_reaper;
+pub(crate) mod drain_reaper;
 pub mod ffi;
 pub mod host;
 pub mod llm_ffi;
@@ -57,6 +57,7 @@ pub mod swap_manager;
 pub mod watcher;
 
 pub use drain_reaper::all_swap_states;
+pub use drain_reaper::tick_reaper_for_test;
 pub use host::{SemanticSkill, SkillHost};
 pub use llm_host::{LlmHost, LlmSkill, LlmSkillAdapter};
 pub use swap_manager::{SwapManager, SwapState, SwapStatus, pending_swaps};

--- a/crates/phantom-skill-host/src/swap_manager.rs
+++ b/crates/phantom-skill-host/src/swap_manager.rs
@@ -509,15 +509,14 @@ mod tests {
         let mgr = make_mgr(999);
         let _hold = mgr.load(); // keep refcount > 1
         mgr.swap(Arc::new(PingImpl(998)) as Arc<dyn Pinger>);
-        // Counter may have incremented (reaper may not have fired yet).
+        // Counter must have incremented by at least 1 immediately after swap.
         let after = pending_swaps();
-        // After the swap, the counter is >= before (reaper hasn't run yet).
-        // We only assert it didn't wrap (saturating_sub prevents negative).
-        assert!(after < usize::MAX);
+        // The swap installs a Draining entry; pending counter must be strictly greater than before.
+        assert!(
+            after > before,
+            "pending_swaps should be > before after swap; before={before}, after={after}"
+        );
         drop(_hold);
         drop(mgr);
-        // After dropping the holder and the manager, the reaper will eventually
-        // decrement — but we don't spin-wait here (that's the integration test).
-        let _ = before; // suppress unused warning
     }
 }

--- a/crates/phantom-skill-host/tests/refcount_drain.rs
+++ b/crates/phantom-skill-host/tests/refcount_drain.rs
@@ -15,9 +15,9 @@
 //!    unchanged.
 
 use std::sync::{Arc, Barrier};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
-use phantom_skill_host::{SwapManager, SwapStatus};
+use phantom_skill_host::{SwapManager, SwapStatus, tick_reaper_for_test};
 
 // ---------------------------------------------------------------------------
 // Dummy trait for tests — avoids any real dylib dependency
@@ -39,18 +39,29 @@ fn mgr(val: u64, name: &str) -> SwapManager<dyn Widget> {
 }
 
 // ---------------------------------------------------------------------------
-// Helper: spin-wait up to `timeout` for a condition, polling every 10 ms.
+// Helper: tick-driven wait — replaces wall-clock spin-sleep with synchronous
+// reaper ticks.
+//
+// Drives the reaper synchronously on each iteration and yields to the OS
+// scheduler (so other threads can release their clones) between checks.
+// For deadline-based tests the deadline itself is real-time; `yield_now`
+// allows enough CPU time to pass without an explicit `sleep`.  Returns
+// `true` as soon as the condition holds.
 // ---------------------------------------------------------------------------
 
 fn wait_until(timeout: Duration, mut condition: impl FnMut() -> bool) -> bool {
+    use std::time::Instant;
     let deadline = Instant::now() + timeout;
     while Instant::now() < deadline {
+        tick_reaper_for_test();
         if condition() {
             return true;
         }
-        std::thread::sleep(Duration::from_millis(10));
+        std::thread::yield_now();
     }
-    condition() // final check
+    // One final tick + check after deadline.
+    tick_reaper_for_test();
+    condition()
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three tech-debt carve-outs from PR #474 re-review, addressed in a single PR:

- **#483** — `drain_reaper` module restricted to `pub(crate)`. Confirmed zero external callers of the internal types (`DrainReaper`, `TypedEntry`, `PollResult`, `DrainEntry`). `all_swap_states` and the new `tick_reaper_for_test` remain publicly re-exported at the crate root.
- **#485** — `pending_swaps_increments_on_swap` assertion strengthened from `after < usize::MAX` (trivially true for all `usize`) to `after > before`, which directly validates the counter-increment semantics documented for `swap()`.
- **#486** — `DrainReaper::tick_for_test()` + `pub tick_reaper_for_test()` injected. The `wait_until` helper in `refcount_drain.rs` now drives the reaper synchronously via tick + `thread::yield_now()` instead of `thread::sleep(10ms)`. All 8 integration tests pass deterministically; suite wall-clock time drops from ~2s to ~0.10s.

## Files changed

- `crates/phantom-skill-host/src/lib.rs` — `pub mod` → `pub(crate) mod`; add `pub use tick_reaper_for_test`
- `crates/phantom-skill-host/src/drain_reaper.rs` — add `tick_for_test()` + `tick_reaper_for_test()`
- `crates/phantom-skill-host/src/swap_manager.rs` — strengthen unit test assertion
- `crates/phantom-skill-host/tests/refcount_drain.rs` — swap `sleep(10ms)` for tick+yield loop

## #386 coordination

`issue-386` worktree was not present at time of branch creation. No phantom-substrate files touched.

## Test plan

- [x] `cargo build --workspace` — zero warnings
- [x] `cargo test -p phantom-skill-host` — 30 passed (13 unit + 8 refcount_drain + 6 swap_smoke + 3 doctests)
- [x] `cargo test -p phantom-skill-host --test refcount_drain` — 8/8 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — zero errors

Closes #483
Closes #485
Closes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)