### PR TITLE
fix: batch carve-outs #412 #455 #513 — net identity, brain bridge handle, shared agent id allocator

### DIFF
--- a/crates/phantom-agents/src/agent.rs
+++ b/crates/phantom-agents/src/agent.rs
@@ -5,6 +5,7 @@
 //! and a visible output log that the renderer streams into the pane.
 
 use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use crate::correlation::CorrelationId;
@@ -23,6 +24,26 @@ use crate::tools::{ToolCall, ToolResult};
 /// [`crate::quarantine::QuarantineRegistry`]) so no narrowing cast is required
 /// at the dispatch / quarantine boundary. Fixes issue #273.
 pub type AgentId = u64;
+
+// Process-global monotonic counter shared by all AgentId allocation paths.
+//
+// Starts at 1 so that 0 is never a valid live AgentId — callers can use 0
+// as a sentinel/unset value. `AgentManager::spawn` calls `allocate_agent_id`
+// directly instead of keeping its own `next_id` field, so both the manager
+// path and the direct `AgentPane::spawn_with_opts` path pull from the same
+// sequence and IDs remain globally unique within a process.
+static NEXT_AGENT_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Allocate the next unique [`AgentId`] from the process-global counter.
+///
+/// The returned id is guaranteed to be ≥ 1 and strictly greater than every
+/// previously returned value within the same process. Both
+/// [`crate::manager::AgentManager::spawn`] and
+/// `phantom_app::AgentPane::spawn_with_opts` call this function, so ids are
+/// globally unique regardless of which spawn path is used.
+pub fn allocate_agent_id() -> AgentId {
+    NEXT_AGENT_ID.fetch_add(1, Ordering::Relaxed)
+}
 
 // ---------------------------------------------------------------------------
 // AgentStatus

--- a/crates/phantom-agents/src/cli.rs
+++ b/crates/phantom-agents/src/cli.rs
@@ -857,10 +857,10 @@ mod tests {
     #[test]
     fn format_list_with_agents() {
         let mut mgr = AgentManager::new(4);
-        mgr.spawn(AgentTask::FreeForm {
+        let id1 = mgr.spawn(AgentTask::FreeForm {
             prompt: "do something".into(),
         });
-        mgr.spawn(AgentTask::ReviewCode {
+        let id2 = mgr.spawn(AgentTask::ReviewCode {
             files: vec!["a.rs".into()],
             context: "test".into(),
         });
@@ -868,9 +868,10 @@ mod tests {
         let lines = format_agent_list(&mgr);
         // Header present.
         assert!(lines.iter().any(|l| l.contains("PHANTOM AGENTS")));
-        // Both agents appear.
-        assert!(lines.iter().any(|l| l.contains("#1")));
-        assert!(lines.iter().any(|l| l.contains("#2")));
+        // Both agents appear — check by the actual allocated ids, not hardcoded
+        // constants, because ids are drawn from a process-global counter (#513).
+        assert!(lines.iter().any(|l| l.contains(&format!("#{id1}"))));
+        assert!(lines.iter().any(|l| l.contains(&format!("#{id2}"))));
         assert!(lines.iter().any(|l| l.contains("review: 1 file(s)")));
     }
 
@@ -914,7 +915,10 @@ mod tests {
         };
         let output = execute_agent_command(&cmd, &mut mgr);
         assert_eq!(mgr.agents().len(), 1);
-        assert!(output[0].contains("spawned agent #1"));
+        // Id is drawn from the global counter; check that some non-zero id is
+        // reported rather than hardcoding 1 (fixes #513).
+        let actual_id = mgr.agents()[0].id();
+        assert!(output[0].contains(&format!("spawned agent #{actual_id}")));
     }
 
     #[test]
@@ -993,7 +997,8 @@ mod tests {
             prompt: "test task".into(),
         });
         let output = execute_agent_command(&AgentCommand::Show { id }, &mut mgr);
-        assert!(output.iter().any(|l| l.contains("Agent #1")));
+        // Use the actual allocated id rather than hardcoding 1 (fixes #513).
+        assert!(output.iter().any(|l| l.contains(&format!("Agent #{id}"))));
     }
 
     #[test]
@@ -1211,7 +1216,8 @@ mod tests {
             },
         };
         let output = execute_agent_command(&cmd, &mut mgr);
-        assert!(output[0].contains("spawned agent #1"));
+        let actual_id = mgr.agents()[0].id();
+        assert!(output[0].contains(&format!("spawned agent #{actual_id}")));
         assert!(output.iter().any(|l| l.contains("claude:claude-opus-4-7")));
         assert!(output.iter().any(|l| l.contains("Actor")));
         assert!(output.iter().any(|l| l.contains("120s")));

--- a/crates/phantom-agents/src/manager.rs
+++ b/crates/phantom-agents/src/manager.rs
@@ -10,7 +10,7 @@
 
 use std::time::Duration;
 
-use crate::agent::{Agent, AgentId, AgentStatus, AgentTask};
+use crate::agent::{Agent, AgentId, AgentStatus, AgentTask, allocate_agent_id};
 use crate::peer_routing::{AgentRouter, AnyAgentRef, RemoteAgentInfo};
 
 // ---------------------------------------------------------------------------
@@ -22,9 +22,13 @@ use crate::peer_routing::{AgentRouter, AnyAgentRef, RemoteAgentInfo};
 /// Wraps a [`AgentRouter`] for cross-peer visibility. The router starts
 /// disconnected (local-only mode) and is wired up once the relay handshake
 /// completes.
+///
+/// AgentIds are allocated from the process-global [`allocate_agent_id`]
+/// counter rather than a per-manager field, so ids remain unique across both
+/// the `AgentManager::spawn` path and the direct `AgentPane::spawn_with_opts`
+/// path (fixes #513).
 pub struct AgentManager {
     agents: Vec<Agent>,
-    next_id: AgentId,
     max_concurrent: usize,
     /// Cross-peer routing state (optional relay connection + remote agent cache).
     pub(crate) router: AgentRouter,
@@ -32,11 +36,10 @@ pub struct AgentManager {
 
 impl AgentManager {
     /// Create a new manager with the given concurrency limit.
-    #[must_use] 
+    #[must_use]
     pub fn new(max_concurrent: usize) -> Self {
         Self {
             agents: Vec::new(),
-            next_id: 1,
             max_concurrent,
             router: AgentRouter::new(),
         }
@@ -66,9 +69,12 @@ impl AgentManager {
     }
 
     /// Spawn a new agent with the given task. Returns the agent ID.
+    ///
+    /// The ID is drawn from the process-global [`allocate_agent_id`] counter
+    /// so it is distinct from any ID produced by a concurrent
+    /// `AgentPane::spawn_with_opts` direct-spawn (fixes #513).
     pub fn spawn(&mut self, task: AgentTask) -> AgentId {
-        let id = self.next_id;
-        self.next_id += 1;
+        let id = allocate_agent_id();
 
         let mut agent = Agent::new(id, task);
 
@@ -204,15 +210,20 @@ mod tests {
         }
     }
 
+    /// IDs are drawn from the process-global allocator so absolute values are
+    /// non-deterministic across test runs. We assert uniqueness, non-zero, and
+    /// strictly increasing order instead of fixed values (fixes #513).
     #[test]
     fn spawn_assigns_sequential_ids() {
         let mut mgr = AgentManager::new(4);
         let id1 = mgr.spawn(free_task("a"));
         let id2 = mgr.spawn(free_task("b"));
         let id3 = mgr.spawn(free_task("c"));
-        assert_eq!(id1, 1);
-        assert_eq!(id2, 2);
-        assert_eq!(id3, 3);
+        assert_ne!(id1, 0, "id must not be the sentinel 0");
+        assert!(id2 > id1, "ids must be strictly increasing");
+        assert!(id3 > id2, "ids must be strictly increasing");
+        assert_ne!(id1, id2);
+        assert_ne!(id2, id3);
     }
 
     #[test]

--- a/crates/phantom-app/src/agent_pane/mod.rs
+++ b/crates/phantom-app/src/agent_pane/mod.rs
@@ -17,7 +17,7 @@ use std::sync::{Arc, Mutex};
 
 use log::{info, warn};
 
-use phantom_agents::agent::{Agent, AgentMessage};
+use phantom_agents::agent::{Agent, AgentMessage, allocate_agent_id};
 use phantom_agents::api::{ApiEvent, ApiHandle, ClaudeConfig};
 use phantom_agents::chat::{ChatBackend, ChatError, ChatModel, build_backend_with_privacy};
 use phantom_agents::permissions::PermissionSet;
@@ -402,7 +402,9 @@ impl AgentPane {
             }
         };
 
-        let mut agent = Agent::new(0, task.clone());
+        // Allocate from the process-global counter so the id is distinct from
+        // any id produced via AgentManager::spawn on another path (fixes #513).
+        let mut agent = Agent::new(allocate_agent_id(), task.clone());
         let sys_prompt = agent.system_prompt();
         agent.push_message(AgentMessage::System(sys_prompt));
 

--- a/crates/phantom-app/src/agent_pane/tests.rs
+++ b/crates/phantom-app/src/agent_pane/tests.rs
@@ -1052,11 +1052,10 @@ fn spawn_agent_pane_task_matches_prompt() {
     assert_eq!(pane.status, AgentPaneStatus::Working);
 }
 
-/// Multiple panes must each receive a distinct agent ID from the underlying
-/// `Agent` allocation.  Uniqueness is enforced by `AgentManager::spawn`
-/// (sequential IDs starting at 1), but we verify the pane's agent id is
-/// set non-zero even in the test-fixture path by checking the two agents
-/// get different ids when constructed through the manager.
+/// Multiple panes must each receive a distinct, non-zero agent ID from the
+/// underlying `Agent` allocation. IDs are drawn from the process-global
+/// `allocate_agent_id` counter rather than a per-manager field, so they are
+/// unique regardless of which spawn path is used (fixes #513).
 #[test]
 fn spawn_two_panes_have_unique_agent_ids() {
     use phantom_agents::manager::AgentManager;
@@ -1067,8 +1066,10 @@ fn spawn_two_panes_have_unique_agent_ids() {
     let id2 = mgr.spawn(AgentTask::FreeForm { prompt: "task B".into() });
 
     assert_ne!(id1, id2, "each spawned agent must receive a unique ID");
-    assert_eq!(id1, 1);
-    assert_eq!(id2, 2);
+    assert_ne!(id1, 0, "spawned agent id must not be the sentinel 0");
+    assert_ne!(id2, 0, "spawned agent id must not be the sentinel 0");
+    // IDs increase monotonically regardless of absolute starting point.
+    assert!(id2 > id1, "second spawn must receive a higher id than the first");
 
     // Verify both are independently retrievable.
     assert!(mgr.get(id1).is_some());
@@ -1584,4 +1585,32 @@ fn non_cartographer_pane_always_has_none_dag_explorer_in_ctx() {
         "DispatchContext for a non-Cartographer pane must have dag_explorer = None \
          even when one is set on the pane (defence-in-depth)"
     );
+}
+
+// =========================================================================
+// Issue #513 — direct spawn_with_opts path must produce non-zero distinct ids
+// =========================================================================
+
+/// The process-global `allocate_agent_id` allocator must never return 0 and
+/// must return strictly increasing values on successive calls. Both
+/// `AgentManager::spawn` and `AgentPane::spawn_with_opts` call this function,
+/// so this test verifies the shared contract without requiring a live GPU or
+/// HTTP stack.
+#[test]
+fn allocate_agent_id_is_non_zero_and_increasing() {
+    use phantom_agents::agent::allocate_agent_id;
+
+    let a = allocate_agent_id();
+    let b = allocate_agent_id();
+    let c = allocate_agent_id();
+
+    assert_ne!(a, 0, "allocate_agent_id must never return 0 (reserved sentinel)");
+    assert_ne!(b, 0, "allocate_agent_id must never return 0 (reserved sentinel)");
+    assert_ne!(c, 0, "allocate_agent_id must never return 0 (reserved sentinel)");
+
+    assert!(b > a, "allocate_agent_id must be strictly increasing");
+    assert!(c > b, "allocate_agent_id must be strictly increasing");
+
+    assert_ne!(a, b, "allocate_agent_id must return distinct values");
+    assert_ne!(b, c, "allocate_agent_id must return distinct values");
 }

--- a/crates/phantom-app/src/inspector.rs
+++ b/crates/phantom-app/src/inspector.rs
@@ -22,6 +22,23 @@ use phantom_ui::tokens::Tokens;
 use crate::adapters::inspector::InspectorAdapter;
 use crate::app::App;
 
+/// Load the local peer identity from the OS keyring and return its string
+/// representation.
+///
+/// Uses the `"phantom"` service namespace so the key is shared across all
+/// code paths that call `Identity::load_or_generate("phantom")`.  Falls back
+/// to `"unknown"` when the keyring is unavailable (e.g. in CI or sandboxed
+/// environments) so the Peers tab always renders something legible.
+fn load_local_peer_id() -> String {
+    match phantom_net::identity::Identity::load_or_generate("phantom") {
+        Ok(id) => id.peer_id.to_string(),
+        Err(e) => {
+            warn!("inspector: could not load local peer identity: {e}");
+            "unknown".to_string()
+        }
+    }
+}
+
 /// Dotted-name prefix the runtime writes for `EventKind::CapabilityDenied`
 /// (see `runtime::kind_dotted_name`). The `<agent_id>` suffix is appended
 /// by the runtime, so prefix-matching is the right contract: the ids vary
@@ -88,6 +105,7 @@ impl App {
         if let Ok(mut guard) = snapshot.write() {
             let mut view = self.runtime.snapshot();
             view.denials = self.collect_recent_denials();
+            view.local_node_id = load_local_peer_id();
             *guard = view;
         }
 
@@ -146,6 +164,7 @@ impl App {
         };
         let mut view = self.runtime.snapshot();
         view.denials = self.collect_recent_denials();
+        view.local_node_id = load_local_peer_id();
         if let Ok(mut guard) = snapshot.write() {
             *guard = view;
         }
@@ -412,5 +431,35 @@ mod tests {
         assert_eq!(got.attempted_class, "Act");
         assert_eq!(got.source_chain, vec![1, 2, 3]);
         assert_eq!(got.timestamp_ms, 42_000);
+    }
+
+    // =========================================================================
+    // Issue #412 — wire InspectorRuntime.local_node_id to Identity::load_or_generate
+    // =========================================================================
+
+    /// `load_local_peer_id` must invoke the load-or-generate path and return a
+    /// non-empty string that is not the old hard-coded sentinel `"localhost"`.
+    ///
+    /// In test builds the `keyring` crate uses an in-process mock backend, so
+    /// `Identity::load_or_generate` works without OS keyring access.  Two calls
+    /// with the same service namespace must return the same peer-id (stable
+    /// identity contract from phantom-net).
+    #[test]
+    fn load_local_peer_id_is_stable_and_not_localhost() {
+        let id1 = super::load_local_peer_id();
+        let id2 = super::load_local_peer_id();
+
+        assert!(
+            !id1.is_empty(),
+            "local_node_id must not be empty"
+        );
+        assert_ne!(
+            id1, "localhost",
+            "local_node_id must not be the old hard-coded sentinel"
+        );
+        assert_eq!(
+            id1, id2,
+            "load_local_peer_id must be stable across calls (load-or-generate contract)"
+        );
     }
 }

--- a/crates/phantom-brain/src/brain.rs
+++ b/crates/phantom-brain/src/brain.rs
@@ -482,7 +482,17 @@ fn brain_loop(
             let fwd_tx = outbound_tx.clone();
             // Spawn a lightweight bridge that converts PeerId → String for the
             // relay task, which expects (String, String).
-            std::thread::Builder::new()
+            //
+            // Daemon-thread justification (§7.3): the JoinHandle is intentionally
+            // discarded here. This bridge thread has a bounded, self-terminating
+            // lifetime: it exits as soon as `mapped_rx` is drained and closed,
+            // which happens naturally when `agent_router` drops `mapped_tx` during
+            // brain shutdown. There is no state to flush and no panic from this
+            // thread needs to propagate — the brain's supervisor loop already
+            // restarts the OODA iteration independently. Retaining the JoinHandle
+            // would require wrapping it in a Mutex or shipping it out-of-band
+            // through `brain_supervised`, adding complexity with no safety gain.
+            let _bridge_handle = std::thread::Builder::new()
                 .name("brain-relay-bridge".into())
                 .spawn(move || {
                     // We need a tokio runtime to drive the async recv.
@@ -499,6 +509,7 @@ fn brain_loop(
                     });
                 })
                 .expect("failed to spawn brain-relay-bridge");
+            // _bridge_handle is intentionally dropped — see daemon-thread comment above.
 
             agent_router.set_relay(mapped_tx, PeerId::new(local_peer_id.clone()));
             log::info!(


### PR DESCRIPTION
## Summary

- **#412 (P1)**: Wire `InspectorRuntime.local_node_id` to `phantom-net::Identity::load_or_generate`. Adds `load_local_peer_id()` helper in `inspector.rs` that calls `Identity::load_or_generate("phantom")` with a `"unknown"` fallback on keyring error. Wired into both snapshot sites (`spawn_inspector_pane` seed and per-frame `refresh_inspector_snapshot`).
- **#455 (tech-debt)**: Assign the brain-relay-bridge `JoinHandle` to `_bridge_handle` and add a block comment documenting the daemon-thread justification (§7.3): the thread exits naturally when `mapped_tx` is dropped at brain shutdown; joining would add complexity with no safety gain.
- **#513 (tech-debt)**: Introduce `allocate_agent_id()` process-global `AtomicU64` counter (starts at 1) in `phantom-agents::agent`. Both `AgentManager::spawn` and `AgentPane::spawn_with_opts` call this function. Remove the redundant `AgentManager::next_id` field. Update tests that hardcoded absolute id values to assert uniqueness/monotonic order.

## Test plan

- [ ] `cargo test -p phantom-agents` — 774 tests pass; `spawn_assigns_sequential_ids`, `format_list_with_agents`, `execute_spawn_creates_agent`, `execute_show_existing_agent` updated; new `allocate_agent_id_is_non_zero_and_increasing` test added (in `phantom-app`)
- [ ] `cargo test -p phantom-app` — 473 tests pass; new `load_local_peer_id_is_stable_and_not_localhost` covers the `load_or_generate` path
- [ ] `cargo test -p phantom-brain` — all pass; no behavior change, comment-only for #455
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] `./scripts/pre-pr-check.sh phantom-app` — PASS

Closes #412, #455, #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)