### PR TITLE
fix(phantom-context): make git_info test robust to detached HEAD (closes #439)

### DIFF
--- a/crates/phantom-context/src/context.rs
+++ b/crates/phantom-context/src/context.rs
@@ -505,14 +505,104 @@ mod tests {
 
     #[test]
     fn git_info_in_real_repo() {
-        // Run inside the workspace root which is a git repo.
-        let workspace = Path::new("/Users/jermiranda/Documents/GitHub/badass-cli");
-        if !workspace.join(".git").exists() {
-            return; // skip if not available
+        // Build a fresh repo in a tempdir so the test is hermetic and works in
+        // CI / agent worktrees where the host repo may have a detached HEAD.
+        let dir = tmp();
+        let path = dir.path();
+
+        // Skip cleanly if `git` isn't on PATH (e.g. minimal sandbox).
+        let Ok(init) = Command::new("git")
+            .args(["init", "-q", "-b", "phantom-test"])
+            .current_dir(path)
+            .status()
+        else {
+            return;
+        };
+        if !init.success() {
+            return;
         }
-        let info = collect_git_info(workspace);
-        assert!(info.is_some());
-        let info = info.unwrap();
-        assert!(!info.branch.is_empty());
+
+        // Configure a local identity so `git commit` works without global config.
+        for args in [
+            ["config", "user.email", "test@phantom.local"].as_slice(),
+            ["config", "user.name", "Phantom Test"].as_slice(),
+        ] {
+            Command::new("git")
+                .args(args)
+                .current_dir(path)
+                .status()
+                .expect("git config");
+        }
+
+        std::fs::write(path.join("README.md"), "hello").unwrap();
+        Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(path)
+            .status()
+            .expect("git add");
+        Command::new("git")
+            .args(["commit", "-q", "-m", "init"])
+            .current_dir(path)
+            .status()
+            .expect("git commit");
+
+        let info = collect_git_info(path).expect("collect_git_info on fresh repo");
+        assert_eq!(info.branch, "phantom-test");
+        assert!(!info.is_dirty);
+        assert_eq!(info.ahead, 0);
+        assert_eq!(info.behind, 0);
+    }
+
+    #[test]
+    fn git_info_returns_none_on_detached_head() {
+        // Detached HEAD has no current branch — `collect_git_info` should bail
+        // out cleanly rather than panicking or returning a bogus branch name.
+        let dir = tmp();
+        let path = dir.path();
+
+        let Ok(init) = Command::new("git")
+            .args(["init", "-q", "-b", "phantom-test"])
+            .current_dir(path)
+            .status()
+        else {
+            return;
+        };
+        if !init.success() {
+            return;
+        }
+
+        for args in [
+            ["config", "user.email", "test@phantom.local"].as_slice(),
+            ["config", "user.name", "Phantom Test"].as_slice(),
+        ] {
+            Command::new("git")
+                .args(args)
+                .current_dir(path)
+                .status()
+                .expect("git config");
+        }
+
+        std::fs::write(path.join("README.md"), "hello").unwrap();
+        Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(path)
+            .status()
+            .expect("git add");
+        Command::new("git")
+            .args(["commit", "-q", "-m", "init"])
+            .current_dir(path)
+            .status()
+            .expect("git commit");
+
+        // Detach HEAD at the current commit.
+        Command::new("git")
+            .args(["checkout", "-q", "--detach", "HEAD"])
+            .current_dir(path)
+            .status()
+            .expect("git checkout --detach");
+
+        // `git branch --show-current` is empty on detached HEAD, so we currently
+        // return None. The contract: don't panic, don't fabricate a branch.
+        assert!(collect_git_info(path).is_none());
     }
 }


### PR DESCRIPTION
Closes #439.

## Summary
- The `git_info_in_real_repo` test previously asserted on a hardcoded host workspace path and required `git branch --show-current` to be non-empty. In CI agent worktrees with detached HEAD, `--show-current` returns empty, `collect_git_info` returns `None`, and the test panics.
- Replaced with a hermetic tempdir fixture: `git init -b phantom-test`, local identity config, one commit, then assert `info.branch == "phantom-test"` and clean state.
- Added companion test `git_info_returns_none_on_detached_head` that fresh-inits a repo, detaches HEAD, and asserts `collect_git_info` returns `None` — pinning the documented contract (no panic, no fabricated branch).

## Test plan
- [x] `cargo test -p phantom-context` — 37 pass, including both git tests
- [x] `cargo build -p phantom-context`
- [x] `cargo clippy -p phantom-context --all-targets -- -D warnings`
- [x] `./scripts/pre-pr-check.sh phantom-context`
- [x] Test passes whether the host repo is on a branch or detached (test no longer reads host repo state)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)