### PR TITLE
fix(phantom-brain): serialize env-mutating capability_audit tests (closes #464)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5725,6 +5725,7 @@ dependencies = [
  "phantom-semantic",
  "serde",
  "serde_json",
+ "serial_test",
  "tempfile",
  "tokio",
  "ureq",
@@ -7111,6 +7112,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7167,6 +7177,12 @@ dependencies = [
  "smithay-client-toolkit",
  "tiny-skia",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-framework"
@@ -7334,6 +7350,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
  "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/crates/phantom-brain/Cargo.toml
+++ b/crates/phantom-brain/Cargo.toml
@@ -22,6 +22,7 @@ tokio = { version = "1", features = ["fs", "sync", "rt", "macros"] }
 [dev-dependencies]
 tempfile = "3"
 tokio = { version = "1", features = ["rt", "macros", "rt-multi-thread"] }
+serial_test = "3"
 
 [lints]
 workspace = true

--- a/crates/phantom-brain/src/capability_audit.rs
+++ b/crates/phantom-brain/src/capability_audit.rs
@@ -377,6 +377,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
+    #[serial_test::serial(env)]
     fn claude_unavailable_when_key_missing() {
         // Remove key for the duration of this test.
         let prev = std::env::var("ANTHROPIC_API_KEY").ok();
@@ -392,6 +393,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(env)]
     fn claude_available_when_key_present() {
         let prev = std::env::var("ANTHROPIC_API_KEY").ok();
         unsafe { std::env::set_var("ANTHROPIC_API_KEY", "sk-test") };
@@ -411,6 +413,7 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
+    #[serial_test::serial(env)]
     fn openai_available_when_key_set() {
         let prev_key = std::env::var("OPENAI_API_KEY").ok();
         let prev_url = std::env::var("OPENAI_BASE_URL").ok();
@@ -432,6 +435,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(env)]
     fn openai_available_when_base_url_set() {
         let prev_key = std::env::var("OPENAI_API_KEY").ok();
         let prev_url = std::env::var("OPENAI_BASE_URL").ok();
@@ -453,6 +457,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(env)]
     fn openai_unavailable_when_neither_set() {
         let prev_key = std::env::var("OPENAI_API_KEY").ok();
         let prev_url = std::env::var("OPENAI_BASE_URL").ok();


### PR DESCRIPTION
## What
Tag env-mutating tests in `capability_audit` with `#[serial_test::serial(env)]` so parallel test execution does not race on shared process env (`OPENAI_BASE_URL`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`).

Adds `serial_test = "3"` to `phantom-brain` `[dev-dependencies]`.

Tests now serialized under the named `env` lock (lets non-env tests still run in parallel):
- `claude_unavailable_when_key_missing`
- `claude_available_when_key_present`
- `openai_available_when_key_set`
- `openai_available_when_base_url_set`  *(the test from #464)*
- `openai_unavailable_when_neither_set`

## Root cause
Each test snapshots, mutates, then restores the env vars. With `cargo test`'s default multi-threaded runner, two tests could interleave their `remove_var` / `set_var` / `var()` calls and observe each other's state, producing nondeterministic failures.

## Verification
- 5x consecutive `cargo test -p phantom-brain capability_audit -- --test-threads=4` runs all green (16 passed each iteration)
- `cargo test -p phantom-brain` full suite green
- `cargo clippy -p phantom-brain --all-targets -- -D warnings` clean
- `./scripts/pre-pr-check.sh phantom-brain` PASS

Closes #464