### PR TITLE
fix(phantom-app): justify or remove unwrap at commands.rs:422 (closes #423)

### DIFF
--- a/crates/phantom-app/src/commands.rs
+++ b/crates/phantom-app/src/commands.rs
@@ -576,7 +576,13 @@ impl App {
                 self.console.scroll_offset = 0;
             }
             cmd if cmd == "offline" || cmd.starts_with("offline ") => {
-                let subcommand = cmd.strip_prefix("offline").unwrap().trim();
+                // SAFETY: the match guard above guarantees `cmd` either equals
+                // "offline" or begins with "offline ", so `strip_prefix("offline")`
+                // can never return None here.
+                let subcommand = cmd
+                    .strip_prefix("offline")
+                    .expect("match guard ensures cmd starts with \"offline\"")
+                    .trim();
                 match subcommand {
                     "on" | "enable" => {
                         self.console.system("Offline mode: ON (using local backends only)");


### PR DESCRIPTION
Closes #423.

## Rubric §5.1
Replaced unjustified `.unwrap()` with `.expect(...)` plus an inline `// SAFETY:` comment in the `offline` command handler.

## Change

The original line:
```rust
cmd if cmd == "offline" || cmd.starts_with("offline ") => {
    let subcommand = cmd.strip_prefix("offline").unwrap().trim();
```

Becomes:
```rust
cmd if cmd == "offline" || cmd.starts_with("offline ") => {
    // SAFETY: the match guard above guarantees `cmd` either equals
    // "offline" or begins with "offline ", so `strip_prefix("offline")`
    // can never return None here.
    let subcommand = cmd
        .strip_prefix("offline")
        .expect("match guard ensures cmd starts with \"offline\"")
        .trim();
```

The match guard is the invariant — `strip_prefix("offline")` cannot return None when `cmd` either equals `"offline"` or starts with `"offline "`. The `.expect` message and `// SAFETY:` comment together document this.

## Gates
- `cargo build -p phantom-app` — pass
- `cargo test -p phantom-app` — 22 passed, 0 failed
- `cargo clippy -p phantom-app --all-targets -- -D warnings` — pass
- `./scripts/pre-pr-check.sh phantom-app` — pass

## Notes
The issue cites `commands.rs:422`, but the actual unwrap (introduced in PR #353 / the offline-mode feature) had drifted to line 579 due to subsequent inserts. Confirmed by `git log -S` that this is the same `.strip_prefix("offline").unwrap()` referenced in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)