### PR TITLE
feat(phantom-app): drive StatusBar offline indicator from set_offline_mode (closes #424)

### DIFF
--- a/crates/phantom-app/src/action_context.rs
+++ b/crates/phantom-app/src/action_context.rs
@@ -14,6 +14,7 @@ use phantom_agents::agent::PauseReason;
 use phantom_agents::dispatch::Disposition;
 use phantom_brain::dispatch::ActionHandler;
 use phantom_brain::events::{ConnectionState, SuggestionOption};
+use phantom_ui::widgets::StatusBar;
 
 use crate::app::SuggestionOverlay;
 use crate::console::Console;
@@ -46,6 +47,9 @@ pub(crate) struct AppActionHandler<'a> {
     /// Accumulates `SpawnAgent` requests deferred to after the action loop
     /// (avoids borrow conflicts on `App`).
     pub tasks_to_spawn: &'a mut Vec<AgentSpawnOpts>,
+    /// Status bar widget; updated when offline-mode toggles so the
+    /// `[OFFLINE]` chip appears in the bottom-right of the chrome.
+    pub status_bar: &'a mut StatusBar,
 }
 
 impl ActionHandler for AppActionHandler<'_> {
@@ -150,6 +154,75 @@ impl ActionHandler for AppActionHandler<'_> {
     fn set_offline_mode(&mut self, enabled: bool) {
         info!("[PHANTOM]: Offline mode {}", if enabled { "ON" } else { "OFF" });
         // The actual router state is managed by the brain thread; this hook
-        // is the GUI-side notification surface (e.g. for status-bar updates).
+        // mirrors the flag onto the status bar so the `[OFFLINE]` chip
+        // renders in the bottom-right chrome (#424).
+        self.status_bar.set_offline_mode(enabled);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use phantom_adapter::EventBus;
+    use phantom_brain::events::AiAction;
+    use phantom_ui::layout::{LayoutEngine, Rect};
+    use phantom_ui::widgets::Widget;
+
+    fn status_rect() -> Rect {
+        Rect { x: 0.0, y: 0.0, width: 1920.0, height: 28.0 }
+    }
+
+    fn has_offline_chip(bar: &StatusBar) -> bool {
+        bar.render_text(&status_rect())
+            .iter()
+            .any(|s| s.text.contains("[OFFLINE]"))
+    }
+
+    /// `AppActionHandler::set_offline_mode` must mirror the flag onto the
+    /// `StatusBar` so the `[OFFLINE]` chip appears/clears in the chrome (#424).
+    #[test]
+    fn set_offline_mode_drives_status_bar_indicator() {
+        let mut suggestion: Option<SuggestionOverlay> = None;
+        let mut memory: Option<phantom_memory::MemoryStore> = None;
+        let mut notification_store: Option<
+            phantom_memory::notifications::NotificationStore,
+        > = None;
+        let mut console = Console::new();
+        let mut coordinator = AppCoordinator::new(EventBus::new());
+        let mut layout = LayoutEngine::new().expect("layout");
+        let mut scene = phantom_scene::tree::SceneTree::new();
+        let mut tasks_to_spawn = Vec::new();
+        let mut status_bar = StatusBar::new();
+
+        assert!(!has_offline_chip(&status_bar), "default: no chip");
+
+        AiAction::SetOfflineMode { enabled: true }.execute(&mut AppActionHandler {
+            now: Instant::now(),
+            suggestion: &mut suggestion,
+            memory: &mut memory,
+            notification_store: &mut notification_store,
+            console: &mut console,
+            coordinator: &mut coordinator,
+            layout: &mut layout,
+            scene: &mut scene,
+            tasks_to_spawn: &mut tasks_to_spawn,
+            status_bar: &mut status_bar,
+        });
+        assert!(has_offline_chip(&status_bar), "chip must appear when enabled");
+
+        AiAction::SetOfflineMode { enabled: false }.execute(&mut AppActionHandler {
+            now: Instant::now(),
+            suggestion: &mut suggestion,
+            memory: &mut memory,
+            notification_store: &mut notification_store,
+            console: &mut console,
+            coordinator: &mut coordinator,
+            layout: &mut layout,
+            scene: &mut scene,
+            tasks_to_spawn: &mut tasks_to_spawn,
+            status_bar: &mut status_bar,
+        });
+        assert!(!has_offline_chip(&status_bar), "chip must clear when disabled");
     }
 }

--- a/crates/phantom-app/src/update.rs
+++ b/crates/phantom-app/src/update.rs
@@ -137,6 +137,7 @@ impl App {
                     layout: &mut self.layout,
                     scene: &mut self.scene,
                     tasks_to_spawn: &mut tasks_to_spawn,
+                    status_bar: &mut self.status_bar,
                 });
             }
         }
@@ -164,6 +165,7 @@ impl App {
                     layout: &mut self.layout,
                     scene: &mut self.scene,
                     tasks_to_spawn: &mut tasks_to_spawn,
+                    status_bar: &mut self.status_bar,
                 });
             }
         }
@@ -181,6 +183,7 @@ impl App {
                 layout: &mut self.layout,
                 scene: &mut self.scene,
                 tasks_to_spawn: &mut tasks_to_spawn,
+                status_bar: &mut self.status_bar,
             });
         }
 
@@ -203,6 +206,7 @@ impl App {
                             layout: &mut self.layout,
                             scene: &mut self.scene,
                             tasks_to_spawn: &mut tasks_to_spawn,
+                            status_bar: &mut self.status_bar,
                         });
                     }
                 }


### PR DESCRIPTION
Closes #424. Carve-out from #353.

## Summary
- `AppActionHandler::set_offline_mode` previously only logged the toggle — the existing `StatusBar::set_offline_mode` flag (which already renders an `[OFFLINE]` chip in the chrome) was never written.
- Adds a `status_bar: &mut StatusBar` field to `AppActionHandler` and forwards the flag inside `set_offline_mode`. All four construction sites in `update.rs` pass `&mut self.status_bar`.
- New unit test dispatches `AiAction::SetOfflineMode { enabled }` through the real handler and asserts the `[OFFLINE]` chip appears in the rendered text when enabled and clears when disabled.

## Footprint
- `crates/phantom-app/src/action_context.rs` (+74 / -1) — handler field, wiring, and unit test
- `crates/phantom-app/src/update.rs` (+4 / -0) — pass `status_bar` at the four `AppActionHandler` construction sites

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test -p phantom-app` (474 lib tests pass, including the new `set_offline_mode_drives_status_bar_indicator`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `./scripts/pre-pr-check.sh phantom-app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)