### PR TITLE
fix(phantom-relay): justify or replace unwrap_or at agent_route.rs:201 (closes #468)

### DIFF
--- a/crates/phantom-relay/src/agent_route.rs
+++ b/crates/phantom-relay/src/agent_route.rs
@@ -190,7 +190,9 @@ pub fn route_agent_envelope(
                 return Err(AgentRouteError::GrantDenied(from_peer.clone()));
             }
 
-            let payload = serde_json::to_value(&env).unwrap_or(serde_json::Value::Null);
+            let payload = serde_json::to_value(&env).map_err(|e| {
+                AgentRouteError::RelayError(format!("failed to serialize agent envelope: {e}"))
+            })?;
             let mut wire = Envelope {
                 from: from_peer.clone(),
                 to: to_peer.clone(),


### PR DESCRIPTION
## Summary
- Replaced silent `serde_json::to_value(&env).unwrap_or(serde_json::Value::Null)` at `crates/phantom-relay/src/agent_route.rs:193` (the line cited as 201 in the issue) with proper error propagation via `?`.
- The enclosing `route_agent_envelope` fn already returns `Result<(), AgentRouteError>`, so a serialization failure now surfaces as `AgentRouteError::RelayError` instead of silently routing a `Null` payload to the remote peer.
- Closes #468.

## Test plan
- [x] `cargo build -p phantom-relay`
- [x] `cargo test -p phantom-relay` (47 unit + 2 integration tests pass)
- [x] `cargo clippy -p phantom-relay -- -D warnings`
- [x] `./scripts/pre-pr-check.sh phantom-relay`

Generated with Claude Code