### PR TITLE
fix(phantom-plugins): surface offending namespace/name in SandboxViolation (closes #490)

### DIFF
--- a/crates/phantom-plugins/src/wasm_host.rs
+++ b/crates/phantom-plugins/src/wasm_host.rs
@@ -47,6 +47,10 @@ pub enum SandboxViolation {
     ///
     /// This covers all WASI imports (`wasi_snapshot_preview1::*`) as well as
     /// any unknown host namespace.
+    ///
+    /// The wrapped string identifies the offending import in the form
+    /// `namespace='<ns>', name='<name>'` so operators can diagnose the
+    /// rejection without rebuilding with verbose logging.
     UnsupportedImport(String),
 }
 
@@ -116,29 +120,26 @@ impl WasmHost {
             .set_fuel(DEFAULT_FUEL)
             .map_err(|e| anyhow::anyhow!("failed to set store fuel: {e:#}"))?;
 
-        // No host-side imports — plugins that require imports will fail here,
-        // which is the desired sandboxing behaviour.  Surface the failure as a
-        // typed `SandboxViolation` so callers can match on it specifically.
-        let instance = Instance::new(&mut store, &module, &[]).map_err(|e| {
-            let msg = e.to_string();
-            // wasmtime reports unsatisfied imports in several ways depending on
-            // version:
-            //   - "unknown import" (older wasmtime)
-            //   - "Imports provided" (older wasmtime)
-            //   - "expected N imports, found 0" (wasmtime ≥44)
-            //
-            // Any of these indicate the module declared host imports that the
-            // sandbox does not supply.  Wrap them in the typed error so callers
-            // can match on SandboxViolation specifically.
-            let is_import_error = msg.contains("unknown import")
-                || msg.contains("Imports provided")
-                || msg.contains("expected") && msg.contains("imports") && msg.contains("found");
-            if is_import_error {
-                anyhow::Error::new(SandboxViolation::UnsupportedImport(msg))
-            } else {
-                anyhow::anyhow!("failed to instantiate WASM module: {e:#}")
-            }
-        })?;
+        // Pre-instantiation import audit: the host supplies *no* imports, so
+        // the only allowlisted import set is the empty set.  Inspecting the
+        // module up front lets us surface the first offending namespace/name
+        // in the typed `SandboxViolation` — wasmtime's own instantiation error
+        // for unsatisfied imports (e.g. `"expected 1 imports, found 0"`) does
+        // not name the offending import, which leaves operators without enough
+        // information to diagnose the rejection.
+        if let Some(import) = module.imports().next() {
+            let namespace = import.module();
+            let name = import.name();
+            return Err(anyhow::Error::new(SandboxViolation::UnsupportedImport(
+                format!("namespace='{namespace}', name='{name}'"),
+            )));
+        }
+
+        // No host-side imports declared — instantiate normally.  Any failure
+        // here is a genuine wasmtime error (not an import-resolution failure)
+        // because we already verified the module has zero imports above.
+        let instance = Instance::new(&mut store, &module, &[])
+            .map_err(|e| anyhow::anyhow!("failed to instantiate WASM module: {e:#}"))?;
 
         Ok(WasmRuntime { store, instance })
     }

--- a/crates/phantom-plugins/tests/wasm_sandbox.rs
+++ b/crates/phantom-plugins/tests/wasm_sandbox.rs
@@ -240,19 +240,13 @@ fn custom_namespace_rejected() {
 /// undefined behaviour from an unresolved import linking into arbitrary host
 /// state.
 ///
-/// # Containment gap noted (do not modify host code in this PR)
+/// # Diagnosability (closes #490)
 ///
-/// The issue spec requested that the [`SandboxViolation`] message identify
-/// both `namespace = "phantom_hots"` and `name = "do_thing"`.  In practice,
-/// wasmtime 44 uses the error format `"expected N imports, found 0"` — it does
-/// not include the import namespace or name in the string that reaches
-/// `SandboxViolation::UnsupportedImport`.  The sandbox correctly *rejects* the
-/// module (the primary security property holds), but the diagnostic message
-/// does not carry the offending namespace/name detail.
-///
-/// This is a diagnosability gap to be addressed in `wasm_host.rs` by
-/// inspecting `module.imports()` before instantiation and constructing a
-/// richer message — tracked separately; not fixed in this tests-only PR.
+/// The [`SandboxViolation::UnsupportedImport`] message must identify both the
+/// offending namespace and the offending name so operators can diagnose the
+/// rejection without rebuilding with verbose logging.  `wasm_host.rs`
+/// inspects `module.imports()` before instantiation and includes the first
+/// offending entry in the typed error.
 #[test]
 fn misspelled_namespace_rejected_with_sandbox_violation() {
     let host = WasmHost::new().expect("WasmHost::new");
@@ -271,15 +265,18 @@ fn misspelled_namespace_rejected_with_sandbox_violation() {
          SandboxViolation::UnsupportedImport, got: {err}"
     );
 
-    // The message must be non-empty so the caller receives some diagnostic.
-    // NOTE: wasmtime 44 does not include namespace/name in the error string
-    // (it reports "expected N imports, found 0").  The diagnosability gap is
-    // documented above; the containment property (Err + SandboxViolation) is
-    // what this test enforces.
+    // Diagnosability: the typed error must surface the offending namespace
+    // and name so operators can identify which import was rejected (#490).
     let msg = err.to_string();
     assert!(
-        !msg.is_empty(),
-        "SandboxViolation message must not be empty, got empty string"
+        msg.contains("phantom_hots"),
+        "SandboxViolation message must name the offending namespace \
+         'phantom_hots', got: {msg}"
+    );
+    assert!(
+        msg.contains("do_thing"),
+        "SandboxViolation message must name the offending function \
+         'do_thing', got: {msg}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Inspect `module.imports()` before `Instance::new` so `SandboxViolation::UnsupportedImport` carries the first offending namespace and function name.
- Replace the brittle wasmtime-error-string match with a deterministic pre-instantiation audit; the typed error now reads `namespace='<ns>', name='<name>'`.
- Test 4A (`misspelled_namespace_rejected_with_sandbox_violation`) updated to assert both `phantom_hots` and `do_thing` appear in the error string; doc-comment's "containment gap noted" block is removed since the gap is fixed here.

Closes #490. Resolves the diagnosability gap noted in PR #480 review.

## Test plan

- [x] `cargo build -p phantom-plugins`
- [x] `cargo test -p phantom-plugins` — 94 unit + 7 integration tests pass
- [x] `cargo clippy -p phantom-plugins --all-targets -- -D warnings`
- [x] `./scripts/pre-pr-check.sh phantom-plugins` passes

Generated with [Claude Code](https://claude.com/claude-code)