### PR TITLE
feat(phantom-relay): add PHANTOM_RELAY_REQUIRE_SIGNATURES env to deny unsigned envelopes (closes #525)

### DIFF
--- a/crates/phantom-relay/src/envelope.rs
+++ b/crates/phantom-relay/src/envelope.rs
@@ -52,6 +52,9 @@ pub enum RelayMessage {
     Ping,
     /// The sender peer lacks the required capability grant for this operation.
     CapabilityDenied { peer_id: PeerId, reason: String },
+    /// The envelope was unsigned and the relay is configured to require
+    /// signatures (see `PHANTOM_RELAY_REQUIRE_SIGNATURES`, issue #525).
+    SignatureRequired { peer_id: PeerId },
 }
 
 /// Messages a client sends to the relay after the handshake.

--- a/crates/phantom-relay/src/router.rs
+++ b/crates/phantom-relay/src/router.rs
@@ -13,6 +13,25 @@ use crate::grant::{CapabilityClass, Grant, PeerGrantRegistry};
 use crate::rate_limit::TokenBucket;
 use crate::session::SessionHandle;
 
+/// Environment variable that flips the unsigned-envelope policy from
+/// "accept with WARN" (migration window) to "deny" (issue #525).
+///
+/// Accepted truthy values: `"1"` and `"true"` (case-insensitive). Anything
+/// else — including an unset variable — preserves the migration-window
+/// behavior so existing peers continue to work during rollout.
+pub const ENV_REQUIRE_SIGNATURES: &str = "PHANTOM_RELAY_REQUIRE_SIGNATURES";
+
+/// Returns `true` when [`ENV_REQUIRE_SIGNATURES`] is set to a truthy value.
+fn deny_unsigned_from_env() -> bool {
+    match std::env::var(ENV_REQUIRE_SIGNATURES) {
+        Ok(v) => {
+            let lower = v.to_ascii_lowercase();
+            lower == "1" || lower == "true"
+        }
+        Err(_) => false,
+    }
+}
+
 /// Shared state of the relay server.
 pub struct Router {
     /// Live peer → session handle map.
@@ -25,19 +44,48 @@ pub struct Router {
     rate_limit: u32,
     /// Maximum simultaneously connected peers.
     max_peers: usize,
+    /// When `true`, envelopes lacking an Ed25519 signature are rejected with
+    /// [`RelayMessage::SignatureRequired`] instead of being accepted with a
+    /// migration-window WARN. Toggled via [`ENV_REQUIRE_SIGNATURES`] at
+    /// construction time, or explicitly via
+    /// [`Router::with_deny_unsigned`] (issue #525).
+    deny_unsigned: bool,
 }
 
 impl Router {
     /// Create a new router with the given operator limits.
+    ///
+    /// Reads [`ENV_REQUIRE_SIGNATURES`] to decide whether unsigned envelopes
+    /// are denied. When the env var is unset (the default), the relay
+    /// preserves the migration-window behavior of accepting unsigned
+    /// envelopes with a WARN log.
     #[must_use]
     pub fn new(rate_limit: u32, max_peers: usize) -> Self {
+        Self::with_deny_unsigned(rate_limit, max_peers, deny_unsigned_from_env())
+    }
+
+    /// Create a new router with an explicit `deny_unsigned` policy, bypassing
+    /// the [`ENV_REQUIRE_SIGNATURES`] env-var lookup.
+    ///
+    /// Useful for tests and for callers that load the policy from their own
+    /// configuration source rather than the process environment.
+    #[must_use]
+    pub fn with_deny_unsigned(rate_limit: u32, max_peers: usize, deny_unsigned: bool) -> Self {
         Self {
             sessions: HashMap::new(),
             rate_buckets: HashMap::new(),
             grants: PeerGrantRegistry::new(),
             rate_limit,
             max_peers,
+            deny_unsigned,
         }
+    }
+
+    /// Returns `true` when this router is configured to reject unsigned
+    /// envelopes.
+    #[must_use]
+    pub fn deny_unsigned(&self) -> bool {
+        self.deny_unsigned
     }
 
     /// Grant a capability to `peer_id`.
@@ -109,6 +157,40 @@ impl Router {
     }
 
     fn forward(&mut self, sender: &PeerId, envelope: Envelope) -> RelayMessage {
+        // --- unsigned-envelope policy (issue #525) ---
+        //
+        // During the migration window we accept envelopes with an empty `sig`
+        // field and only emit a WARN log so existing un-upgraded peers keep
+        // working. Operators can flip this to deny-all by setting the env
+        // var `PHANTOM_RELAY_REQUIRE_SIGNATURES=1` (or `true`) before the
+        // relay process starts, or by constructing the router with
+        // [`Router::with_deny_unsigned`].
+        //
+        // When `deny_unsigned` is true, the unsigned envelope is rejected
+        // with `RelayMessage::SignatureRequired` and never reaches rate-limit
+        // accounting or destination lookup.
+        //
+        // The relay only checks for *presence* of a signature here. Full
+        // cryptographic verification is the responsibility of the recipient
+        // (see `signing::verify_envelope`); the relay does not hold per-peer
+        // verifying keys.
+        if envelope.sig.is_empty() {
+            if self.deny_unsigned {
+                warn!(
+                    "router: unsigned envelope from peer {} rejected (deny_unsigned=true)",
+                    sender
+                );
+                return RelayMessage::SignatureRequired {
+                    peer_id: sender.clone(),
+                };
+            }
+            warn!(
+                "router: unsigned envelope from peer {} accepted under migration window \
+                 (set {} to deny)",
+                sender, ENV_REQUIRE_SIGNATURES
+            );
+        }
+
         // --- capability grant check (issue #415) ---
         //
         // Every peer must hold a `Relay` grant before any envelope is
@@ -427,5 +509,150 @@ mod tests {
 
         let raw = bob_session.rx.try_recv().expect("message not delivered");
         assert!(raw.contains("future-grant"));
+    }
+
+    // ── Unsigned-envelope policy tests (issue #525) ───────────────────────────
+
+    /// Process-wide lock that serializes env-var manipulation across tests.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// RAII guard that sets `ENV_REQUIRE_SIGNATURES` and restores the prior
+    /// value on drop. The `_lock` field keeps the test serial.
+    struct EnvGuard {
+        prev: Option<String>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl EnvGuard {
+        fn set(value: &str) -> Self {
+            let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let prev = std::env::var(ENV_REQUIRE_SIGNATURES).ok();
+            // SAFETY: tests are serialized by `ENV_LOCK`.
+            unsafe {
+                std::env::set_var(ENV_REQUIRE_SIGNATURES, value);
+            }
+            Self { prev, _lock: lock }
+        }
+
+        fn unset() -> Self {
+            let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let prev = std::env::var(ENV_REQUIRE_SIGNATURES).ok();
+            // SAFETY: tests are serialized by `ENV_LOCK`.
+            unsafe {
+                std::env::remove_var(ENV_REQUIRE_SIGNATURES);
+            }
+            Self { prev, _lock: lock }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: tests are serialized by `ENV_LOCK`.
+            unsafe {
+                match &self.prev {
+                    Some(v) => std::env::set_var(ENV_REQUIRE_SIGNATURES, v),
+                    None => std::env::remove_var(ENV_REQUIRE_SIGNATURES),
+                }
+            }
+        }
+    }
+
+    fn unsigned_envelope(from: &str, to: &str) -> Envelope {
+        Envelope {
+            from: PeerId(from.into()),
+            to: PeerId(to.into()),
+            payload: serde_json::json!("hello"),
+            sig: String::new(),
+            nonce: Uuid::new_v4(),
+        }
+    }
+
+    /// Default behavior (migration window): unsigned envelopes are accepted
+    /// and delivered with only a WARN log. This guards against accidental
+    /// behavior change for un-upgraded peers.
+    #[tokio::test]
+    async fn unsigned_envelope_accepted_when_deny_unsigned_false() {
+        let mut router = Router::with_deny_unsigned(100, 10, false);
+        let (mut bob_session, hb) = make_session("bob");
+        let (_, ha) = make_session("alice");
+        router.register(ha).unwrap();
+        router.register(hb).unwrap();
+        grant_relay(&mut router, "alice");
+        grant_relay(&mut router, "bob");
+
+        let envelope = unsigned_envelope("alice", "bob");
+        let nonce = envelope.nonce;
+
+        let reply = router.route(&PeerId("alice".into()), ClientMessage::Send(envelope));
+        assert!(
+            matches!(reply, RelayMessage::Delivered { nonce: n } if n == nonce),
+            "expected Delivered for unsigned envelope under migration window, got {reply:?}"
+        );
+
+        let raw = bob_session.rx.try_recv().expect("message not delivered");
+        assert!(raw.contains("hello"));
+    }
+
+    /// New deny path: when `deny_unsigned == true`, unsigned envelopes are
+    /// rejected with `SignatureRequired` before any rate-limit accounting
+    /// or destination lookup runs.
+    #[test]
+    fn unsigned_envelope_rejected_when_deny_unsigned_true() {
+        let mut router = Router::with_deny_unsigned(100, 10, true);
+        let (_, ha) = make_session("alice");
+        let (_, hb) = make_session("bob");
+        router.register(ha).unwrap();
+        router.register(hb).unwrap();
+        grant_relay(&mut router, "alice");
+        grant_relay(&mut router, "bob");
+
+        let envelope = unsigned_envelope("alice", "bob");
+        let reply = router.route(&PeerId("alice".into()), ClientMessage::Send(envelope));
+        assert!(
+            matches!(reply, RelayMessage::SignatureRequired { ref peer_id } if peer_id == &PeerId("alice".into())),
+            "expected SignatureRequired with deny_unsigned=true, got {reply:?}"
+        );
+    }
+
+    /// `Router::new` must honor `PHANTOM_RELAY_REQUIRE_SIGNATURES=1` and
+    /// flip `deny_unsigned` to true at construction time.
+    #[test]
+    fn env_var_phantom_relay_require_signatures_enables_deny() {
+        // Truthy "1": deny_unsigned must be set.
+        {
+            let _g = EnvGuard::set("1");
+            let r = Router::new(100, 10);
+            assert!(
+                r.deny_unsigned(),
+                "PHANTOM_RELAY_REQUIRE_SIGNATURES=1 must enable deny_unsigned"
+            );
+        }
+        // Truthy "true": case-insensitive accepted.
+        {
+            let _g = EnvGuard::set("TRUE");
+            let r = Router::new(100, 10);
+            assert!(
+                r.deny_unsigned(),
+                "PHANTOM_RELAY_REQUIRE_SIGNATURES=TRUE must enable deny_unsigned"
+            );
+        }
+        // Unset: migration-window default preserved.
+        {
+            let _g = EnvGuard::unset();
+            let r = Router::new(100, 10);
+            assert!(
+                !r.deny_unsigned(),
+                "unset env var must preserve migration-window default"
+            );
+        }
+        // Other values are not truthy.
+        {
+            let _g = EnvGuard::set("0");
+            let r = Router::new(100, 10);
+            assert!(
+                !r.deny_unsigned(),
+                "PHANTOM_RELAY_REQUIRE_SIGNATURES=0 must not enable deny_unsigned"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #525 (security P2). Carved out of PR #519 review.

`router::forward()` previously had no operator switch to flip the
unsigned-envelope policy from accept-with-WARN (the migration window) to
deny-all once all peers have registered Ed25519 keys. This PR adds that
switch behind an env var so the relay can be hardened without a code
change at deploy time.

- New env var `PHANTOM_RELAY_REQUIRE_SIGNATURES`. Truthy values `"1"` and
  `"true"` (case-insensitive) flip `deny_unsigned` to true at router
  construction. Anything else — including unset — preserves the
  migration-window default of accepting unsigned envelopes with a WARN log.
- New `Router::deny_unsigned: bool` field plus `Router::with_deny_unsigned`
  explicit constructor so tests and alternate config sources can bypass
  the env-var lookup.
- New `RelayMessage::SignatureRequired { peer_id }` reply variant for the
  deny path. Returned before rate-limit accounting or destination lookup.
- `forward()` migration-window comment expanded to describe the toggle and
  point operators at the env var.

## Behavior preservation

Default behavior is unchanged: with the env var unset (or set to anything
non-truthy), unsigned envelopes are still accepted with a WARN. The
unsigned-accept code path is gated, not removed.

The relay continues to do only a *presence* check on `sig`. Full
cryptographic verification remains the recipient's responsibility via
`signing::verify_envelope`.

## Test coverage

Three new tests in `crates/phantom-relay/src/router.rs::tests`:

- `unsigned_envelope_accepted_when_deny_unsigned_false` — guards the
  migration-window delivery path; an unsigned envelope with a valid Relay
  grant is delivered to the destination's channel.
- `unsigned_envelope_rejected_when_deny_unsigned_true` — covers the new
  deny path; reply is `SignatureRequired { peer_id }` before any rate-limit
  or destination work runs.
- `env_var_phantom_relay_require_signatures_enables_deny` — exercises
  `Router::new` with the env var set to `"1"`, `"TRUE"`, unset, and `"0"`.
  An `EnvGuard` + process-wide `Mutex` serialize env access so the test
  does not race other parallel tests.

## Test plan

- [x] `cargo test -p phantom-relay` — 50 unit + 2 integration tests pass
- [x] `cargo clippy -p phantom-relay --all-targets -- -D warnings` exits 0
- [x] `cargo build --workspace` produces zero errors
- [x] `cargo test --workspace --no-run` compiles cleanly
- [x] `./scripts/pre-pr-check.sh phantom-relay` passes
- [ ] Reviewer confirms env-var truthy set (`"1"`, `"true"`) is sufficient,
      or expands it to also cover `"yes"` / `"on"`
- [ ] Operator runbook updated to document the toggle (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)