### PR TITLE
fix(phantom-brain): replace Agent::new(0) wart in claude::investigate (closes #523)

### DIFF
--- a/crates/phantom-brain/src/claude.rs
+++ b/crates/phantom-brain/src/claude.rs
@@ -144,7 +144,7 @@ pub fn build_error_analysis_prompt(
 /// Blocks until done — the brain thread is dedicated and doesn't share
 /// work with the render loop.
 pub fn investigate(prompt: &str, working_dir: &str, max_rounds: u32) -> Result<String, String> {
-    use phantom_agents::agent::{Agent, AgentMessage, AgentTask};
+    use phantom_agents::agent::{Agent, AgentMessage, AgentTask, allocate_agent_id};
     use phantom_agents::api::{ApiEvent, ClaudeConfig, send_message};
     use phantom_agents::role::AgentRole;
     use phantom_agents::tools::{available_tools, execute_tool};
@@ -154,7 +154,12 @@ pub fn investigate(prompt: &str, working_dir: &str, max_rounds: u32) -> Result<S
     let task = AgentTask::FreeForm {
         prompt: prompt.to_string(),
     };
-    let mut agent = Agent::new(0, task);
+    // Pull a fresh id from the process-global counter rather than the old
+    // sentinel `0`. The agent is transient (never registered with
+    // `AgentManager`), but allocating a real id keeps the invariant that no
+    // production path constructs an `Agent` with id 0 (issue #523, follow-up
+    // to PR #520's unification of `allocate_agent_id`).
+    let mut agent = Agent::new(allocate_agent_id(), task);
     let sys = agent.system_prompt();
     agent.push_message(AgentMessage::System(sys));
     agent.push_message(AgentMessage::User(prompt.to_string()));


### PR DESCRIPTION
## Summary
- Replaces the `Agent::new(0, task)` sentinel callsite in `phantom-brain::claude::investigate` with `Agent::new(allocate_agent_id(), task)`, completing the AgentId allocation unification started in PR #520.
- Adds an inline comment explaining that the agent is still transient (never registered with `AgentManager`) but now pulls from the same process-global counter used by the manager and `AgentPane::spawn_with_opts`, so no production path constructs an `Agent` with id 0.

## Acceptance (from #523)
- [x] `claude::investigate` calls `phantom_agents::agent::allocate_agent_id()` instead of `Agent::new(0, ...)`
- [x] No production code path constructs an agent with sentinel id 0 (the remaining `Agent::new(0, ...)` callsites are in test code under `phantom-app`, out of scope per the issue)
- [x] Existing tests still pass — `cargo test -p phantom-brain` is green; the `investigate` test path does not assert on id

## Test plan
- [x] `cargo build -p phantom-brain`
- [x] `cargo test -p phantom-brain` — 441 unit + 5 e2e + 10 doctests all pass
- [x] `cargo clippy -p phantom-brain --all-targets -- -D warnings` clean
- [x] `./scripts/pre-pr-check.sh phantom-brain` passes

Closes #523.

Status: ready-for-review.

Generated with [Claude Code](https://claude.com/claude-code)