### PR TITLE
feat(phantom-relay): add proof-of-possession to IdentityProof handshake (closes #526)

### DIFF
--- a/crates/phantom-relay/src/server.rs
+++ b/crates/phantom-relay/src/server.rs
@@ -1,11 +1,33 @@
 //! WebSocket server: accepts connections and drives per-peer tasks.
+//!
+//! # Handshake (proof-of-possession, issue #526)
+//!
+//! The relay rejects trust-on-first-use. On every new connection:
+//!
+//! 1. Server sends a [`Challenge`] frame containing 32 bytes of fresh entropy
+//!    (hex-encoded).
+//! 2. Client replies with an [`IdentityProof`] containing:
+//!    - `peer_id` — claimed identity string
+//!    - `public_key` — 32-byte Ed25519 verifying key (64 hex chars)
+//!    - `signature` — 64-byte Ed25519 signature (128 hex chars) over the
+//!      canonical proof-of-possession bytes (see [`pop_canonical_bytes`])
+//! 3. Server verifies the signature with the supplied public key. If it does
+//!    not bind `peer_id` to the challenge under the claimed key, the
+//!    connection is rejected with an `auth_failed` error.
+//!
+//! Only after a verified signature does the server register the peer and
+//! grant the [`CapabilityClass::Relay`] capability. This replaces the
+//! previous TOFU model where the client self-asserted its key.
 
 use std::net::SocketAddr;
 use std::sync::Arc;
 
 use anyhow::Result;
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use futures_util::{SinkExt, StreamExt};
 use log::{error, info, warn};
+use rand::rngs::OsRng;
+use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::Mutex;
@@ -18,14 +40,38 @@ use crate::session::Session;
 
 // ── Handshake types ──────────────────────────────────────────────────────────
 
-/// First message a connecting client must send.
+/// Length of the proof-of-possession nonce in bytes.
+const POP_CHALLENGE_LEN: usize = 32;
+
+/// Domain-separation prefix for the proof-of-possession message.
+///
+/// Mixed into the canonical bytes so a signature minted for some other
+/// protocol can never be replayed against the relay handshake.
+const POP_DOMAIN_TAG: &[u8] = b"phantom-relay-pop-v1\0";
+
+/// Server-issued challenge sent before [`IdentityProof`].
+#[derive(Debug, Serialize)]
+struct Challenge<'a> {
+    /// Message tag for clients that dispatch on `type`.
+    #[serde(rename = "type")]
+    kind: &'static str,
+    /// 32 random bytes, hex-encoded (64 chars).
+    challenge: &'a str,
+}
+
+/// First message a connecting client must send after receiving the challenge.
+///
+/// All fields are required. The legacy `proof` field is no longer accepted —
+/// trust-on-first-use was removed in issue #526.
 #[derive(Debug, Deserialize)]
 struct IdentityProof {
     /// Requested peer identity string.
     peer_id: String,
-    /// Client-provided proof (e.g. JWT, bearer token, or Ed25519 sig).
-    /// Currently accepted as-is; real auth can be layered here.
-    proof: String,
+    /// 32-byte Ed25519 public key, lowercase hex (64 chars).
+    public_key: String,
+    /// 64-byte Ed25519 signature over [`pop_canonical_bytes`], lowercase hex
+    /// (128 chars).
+    signature: String,
 }
 
 /// Relay's response to a successful handshake.
@@ -33,6 +79,82 @@ struct IdentityProof {
 struct HandshakeAck {
     session_token: String,
     peer_id: String,
+}
+
+// ── Proof-of-possession helpers ──────────────────────────────────────────────
+
+/// Canonical bytes the client signs and the server verifies.
+///
+/// Layout:
+///
+/// ```text
+/// POP_DOMAIN_TAG || peer_id_utf8 || 0x00 || challenge_bytes
+/// ```
+///
+/// The domain tag prevents cross-protocol signature reuse; the trailing NUL
+/// byte separates the variable-length `peer_id` from the fixed-length
+/// challenge so two distinct (peer_id, challenge) pairs cannot produce the
+/// same byte string.
+pub(crate) fn pop_canonical_bytes(peer_id: &str, challenge: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(POP_DOMAIN_TAG.len() + peer_id.len() + 1 + challenge.len());
+    buf.extend_from_slice(POP_DOMAIN_TAG);
+    buf.extend_from_slice(peer_id.as_bytes());
+    buf.push(0);
+    buf.extend_from_slice(challenge);
+    buf
+}
+
+/// Decode a hex string of exactly `N` bytes (`2*N` hex chars).
+fn decode_hex<const N: usize>(s: &str) -> Result<[u8; N], &'static str> {
+    if s.len() != N * 2 {
+        return Err("unexpected hex length");
+    }
+    let mut out = [0u8; N];
+    for (i, chunk) in s.as_bytes().chunks(2).enumerate() {
+        let hi = from_hex_digit(chunk[0]).ok_or("invalid hex digit")?;
+        let lo = from_hex_digit(chunk[1]).ok_or("invalid hex digit")?;
+        out[i] = (hi << 4) | lo;
+    }
+    Ok(out)
+}
+
+fn from_hex_digit(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Encode bytes as lowercase hex.
+fn encode_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Generate a fresh proof-of-possession challenge.
+fn fresh_challenge() -> [u8; POP_CHALLENGE_LEN] {
+    let mut buf = [0u8; POP_CHALLENGE_LEN];
+    OsRng.fill_bytes(&mut buf);
+    buf
+}
+
+/// Verify that `proof` cryptographically binds `peer_id` to `challenge`.
+///
+/// On success returns the verified [`VerifyingKey`]. On failure returns a
+/// short stable reason string suitable for an `auth_failed` error message.
+fn verify_pop(proof: &IdentityProof, challenge: &[u8]) -> Result<VerifyingKey, &'static str> {
+    let pk_bytes: [u8; 32] = decode_hex::<32>(&proof.public_key)
+        .map_err(|_| "public_key must be 64 lowercase hex chars")?;
+    let sig_bytes: [u8; 64] = decode_hex::<64>(&proof.signature)
+        .map_err(|_| "signature must be 128 lowercase hex chars")?;
+
+    let vk = VerifyingKey::from_bytes(&pk_bytes).map_err(|_| "public_key is not a valid Ed25519 point")?;
+    let sig = Signature::from_bytes(&sig_bytes);
+    let canonical = pop_canonical_bytes(&proof.peer_id, challenge);
+
+    vk.verify(&canonical, &sig).map_err(|_| "signature did not verify")?;
+    Ok(vk)
 }
 
 // ── Server ───────────────────────────────────────────────────────────────────
@@ -82,7 +204,26 @@ async fn handle_connection(
 
     info!("new connection from {}", peer_addr);
 
-    // ── 1. Handshake ──────────────────────────────────────────────────────────
+    // ── 1. Handshake (proof-of-possession, issue #526) ───────────────────────
+    //
+    // Server sends a fresh 32-byte challenge BEFORE expecting an
+    // IdentityProof. Client must sign the canonical bytes (see
+    // `pop_canonical_bytes`) with the private half of the public key it
+    // claims. This replaces the prior trust-on-first-use scheme.
+    let challenge_bytes = fresh_challenge();
+    let challenge_hex = encode_hex(&challenge_bytes);
+    let challenge_msg = Challenge {
+        kind: "challenge",
+        challenge: &challenge_hex,
+    };
+    if let Err(e) = ws_sink
+        .send(Message::from(serde_json::to_string(&challenge_msg)?))
+        .await
+    {
+        warn!("failed to send challenge to {}: {}", peer_addr, e);
+        return Ok(());
+    }
+
     let raw = match ws_source.next().await {
         Some(Ok(msg)) => msg,
         Some(Err(e)) => return Err(e.into()),
@@ -93,24 +234,53 @@ async fn handle_connection(
     };
 
     let proof: IdentityProof = match raw {
-        Message::Text(text) => serde_json::from_str(&text)?,
+        Message::Text(text) => match serde_json::from_str(&text) {
+            Ok(p) => p,
+            Err(e) => {
+                warn!("malformed IdentityProof from {}: {}", peer_addr, e);
+                let err = RelayMessage::Error {
+                    code: "auth_failed".into(),
+                    message: format!("malformed identity proof: {e}"),
+                };
+                let _ = ws_sink
+                    .send(Message::from(serde_json::to_string(&err)?))
+                    .await;
+                return Ok(());
+            }
+        },
         other => {
             warn!("unexpected handshake message type from {}: {:?}", peer_addr, other);
             return Ok(());
         }
     };
 
-    // Minimal proof validation placeholder — real implementations can verify
-    // an Ed25519 or JWT here.
-    if proof.proof.is_empty() {
-        warn!("empty proof from {}; rejecting", peer_addr);
+    if proof.peer_id.is_empty() {
+        warn!("empty peer_id from {}; rejecting", peer_addr);
         let err = RelayMessage::Error {
             code: "auth_failed".into(),
-            message: "empty identity proof".into(),
+            message: "peer_id must not be empty".into(),
         };
-        ws_sink
+        let _ = ws_sink
             .send(Message::from(serde_json::to_string(&err)?))
-            .await?;
+            .await;
+        return Ok(());
+    }
+
+    // Verify proof-of-possession: the supplied signature must bind the
+    // claimed peer_id to the server-issued challenge under the supplied
+    // public key. Reject the connection on any failure.
+    if let Err(reason) = verify_pop(&proof, &challenge_bytes) {
+        warn!(
+            "proof-of-possession failed for peer_id={} from {}: {}",
+            proof.peer_id, peer_addr, reason
+        );
+        let err = RelayMessage::Error {
+            code: "auth_failed".into(),
+            message: format!("proof-of-possession failed: {reason}"),
+        };
+        let _ = ws_sink
+            .send(Message::from(serde_json::to_string(&err)?))
+            .await;
         return Ok(());
     }
 

--- a/crates/phantom-relay/tests/integration.rs
+++ b/crates/phantom-relay/tests/integration.rs
@@ -11,7 +11,9 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
+use ed25519_dalek::{Signer, SigningKey};
 use futures_util::{SinkExt, StreamExt};
+use rand::rngs::OsRng;
 use serde_json::{json, Value};
 use tokio::net::TcpListener;
 use tokio::sync::Mutex;
@@ -20,6 +22,29 @@ use uuid::Uuid;
 
 use phantom_relay::router::Router;
 use phantom_relay::server::run_with_listener;
+
+/// Domain-separation prefix matching `phantom_relay::server::POP_DOMAIN_TAG`.
+const POP_DOMAIN_TAG: &[u8] = b"phantom-relay-pop-v1\0";
+
+fn pop_canonical_bytes(peer_id: &str, challenge: &[u8]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(POP_DOMAIN_TAG.len() + peer_id.len() + 1 + challenge.len());
+    buf.extend_from_slice(POP_DOMAIN_TAG);
+    buf.extend_from_slice(peer_id.as_bytes());
+    buf.push(0);
+    buf.extend_from_slice(challenge);
+    buf
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+fn decode_hex(s: &str) -> Vec<u8> {
+    (0..s.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&s[i..i + 2], 16).unwrap())
+        .collect()
+}
 
 // ── Test helpers ──────────────────────────────────────────────────────────────
 
@@ -44,18 +69,50 @@ type WsStream = futures_util::stream::SplitStream<
     >,
 >;
 
-/// Connect a WebSocket client, perform the relay handshake, return sink/stream.
+/// Connect a WebSocket client, perform the relay proof-of-possession
+/// handshake, and return the sink/stream split halves.
+///
+/// Generates a fresh Ed25519 key, receives the server's challenge, signs
+/// the canonical proof-of-possession bytes, and sends the resulting
+/// `IdentityProof`.
 async fn handshake(addr: SocketAddr, peer_id: &str) -> (WsSink, WsStream) {
+    let key = SigningKey::generate(&mut OsRng);
     let url = format!("ws://{}", addr);
     let (ws, _) = connect_async(url).await.expect("ws connect failed");
     let (mut sink, mut stream) = ws.split();
 
+    // 1. Receive the server's challenge.
+    let challenge_raw = stream.next().await.unwrap().unwrap();
+    let challenge_msg: Value = match challenge_raw {
+        Message::Text(t) => serde_json::from_str(&t).unwrap(),
+        other => panic!("expected challenge frame, got {:?}", other),
+    };
+    assert_eq!(
+        challenge_msg["type"].as_str().unwrap(),
+        "challenge",
+        "expected challenge frame, got: {challenge_msg}"
+    );
+    let challenge_hex = challenge_msg["challenge"].as_str().unwrap();
+    let challenge_bytes = decode_hex(challenge_hex);
+
+    // 2. Sign the canonical proof-of-possession bytes.
+    let canonical = pop_canonical_bytes(peer_id, &challenge_bytes);
+    let signature = key.sign(&canonical);
+    let public_key_hex = encode_hex(key.verifying_key().as_bytes());
+    let signature_hex = encode_hex(&signature.to_bytes());
+
     sink.send(Message::from(
-        json!({ "peer_id": peer_id, "proof": "test-proof" }).to_string(),
+        json!({
+            "peer_id": peer_id,
+            "public_key": public_key_hex,
+            "signature": signature_hex,
+        })
+        .to_string(),
     ))
     .await
     .unwrap();
 
+    // 3. Read the ack.
     let ack_raw = stream.next().await.unwrap().unwrap();
     let ack: Value = match ack_raw {
         Message::Text(t) => serde_json::from_str(&t).unwrap(),
@@ -221,3 +278,162 @@ async fn rate_limiter_trips_on_burst_without_disconnect() {
         .await
         .expect("connection should remain open after rate limiting");
 }
+
+// ── Test 3 — proof-of-possession (issue #526) ────────────────────────────────
+//
+// These tests cover the proof-of-possession handshake added in #526. The
+// helper `handshake` already exercises the success path on every other test
+// in this file, but we add an explicit success-path test here for clarity
+// and pin two failure modes that must be rejected: an unsigned response
+// and a signature minted with a different key than the one being claimed.
+
+/// The next text frame from `stream` parsed as JSON. Helper used by the
+/// negative-path tests to capture the relay's `auth_failed` reply.
+async fn recv_text_json(stream: &mut WsStream) -> Value {
+    let raw = tokio::time::timeout(Duration::from_secs(3), stream.next())
+        .await
+        .expect("timeout waiting for frame")
+        .unwrap()
+        .unwrap();
+    match raw {
+        Message::Text(t) => serde_json::from_str(&t).expect("invalid JSON in text frame"),
+        other => panic!("expected text frame, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_proof_of_possession_succeeds_with_valid_signature() {
+    let addr = spawn_relay(100).await;
+    tokio::time::sleep(Duration::from_millis(30)).await;
+
+    let url = format!("ws://{}", addr);
+    let (ws, _) = connect_async(url).await.expect("ws connect failed");
+    let (mut sink, mut stream) = ws.split();
+
+    // 1. Server must send a challenge frame first.
+    let challenge_msg = recv_text_json(&mut stream).await;
+    assert_eq!(
+        challenge_msg["type"].as_str().unwrap(),
+        "challenge",
+        "expected challenge frame, got: {challenge_msg}"
+    );
+    let challenge_hex = challenge_msg["challenge"].as_str().unwrap();
+    assert_eq!(
+        challenge_hex.len(),
+        64,
+        "challenge must be 32 bytes / 64 hex chars"
+    );
+    let challenge_bytes = decode_hex(challenge_hex);
+
+    // 2. Sign the canonical bytes with a fresh key.
+    let key = SigningKey::generate(&mut OsRng);
+    let canonical = pop_canonical_bytes("alice", &challenge_bytes);
+    let signature = key.sign(&canonical);
+
+    sink.send(Message::from(
+        json!({
+            "peer_id": "alice",
+            "public_key": encode_hex(key.verifying_key().as_bytes()),
+            "signature": encode_hex(&signature.to_bytes()),
+        })
+        .to_string(),
+    ))
+    .await
+    .unwrap();
+
+    // 3. Server must respond with a HandshakeAck.
+    let ack = recv_text_json(&mut stream).await;
+    assert_eq!(
+        ack["peer_id"].as_str().unwrap(),
+        "alice",
+        "ack peer_id mismatch"
+    );
+    assert!(
+        ack["session_token"].is_string(),
+        "ack must contain session_token"
+    );
+}
+
+#[tokio::test]
+async fn test_proof_of_possession_rejects_unsigned_challenge() {
+    let addr = spawn_relay(100).await;
+    tokio::time::sleep(Duration::from_millis(30)).await;
+
+    let url = format!("ws://{}", addr);
+    let (ws, _) = connect_async(url).await.expect("ws connect failed");
+    let (mut sink, mut stream) = ws.split();
+
+    // Drain the challenge but ignore it.
+    let challenge_msg = recv_text_json(&mut stream).await;
+    assert_eq!(challenge_msg["type"].as_str().unwrap(), "challenge");
+
+    // Send an IdentityProof with no public_key / signature pair —
+    // mimicking the legacy TOFU shape the relay no longer accepts.
+    sink.send(Message::from(
+        json!({
+            "peer_id": "alice",
+            "proof": "test-proof",
+        })
+        .to_string(),
+    ))
+    .await
+    .unwrap();
+
+    let reply = recv_text_json(&mut stream).await;
+    assert_eq!(
+        reply["type"].as_str().unwrap(),
+        "error",
+        "unsigned handshake must be rejected, got: {reply}"
+    );
+    assert_eq!(
+        reply["code"].as_str().unwrap(),
+        "auth_failed",
+        "unsigned handshake must be rejected with auth_failed, got: {reply}"
+    );
+}
+
+#[tokio::test]
+async fn test_proof_of_possession_rejects_signature_from_different_key() {
+    let addr = spawn_relay(100).await;
+    tokio::time::sleep(Duration::from_millis(30)).await;
+
+    let url = format!("ws://{}", addr);
+    let (ws, _) = connect_async(url).await.expect("ws connect failed");
+    let (mut sink, mut stream) = ws.split();
+
+    let challenge_msg = recv_text_json(&mut stream).await;
+    let challenge_bytes = decode_hex(challenge_msg["challenge"].as_str().unwrap());
+
+    // Two distinct keys: the client SIGNS with `signing_key` but CLAIMS the
+    // `claimed_key`. The relay must reject this because the signature does
+    // not validate under the claimed public key.
+    let signing_key = SigningKey::generate(&mut OsRng);
+    let claimed_key = SigningKey::generate(&mut OsRng);
+
+    let canonical = pop_canonical_bytes("alice", &challenge_bytes);
+    let signature = signing_key.sign(&canonical);
+
+    sink.send(Message::from(
+        json!({
+            "peer_id": "alice",
+            "public_key": encode_hex(claimed_key.verifying_key().as_bytes()),
+            "signature": encode_hex(&signature.to_bytes()),
+        })
+        .to_string(),
+    ))
+    .await
+    .unwrap();
+
+    let reply = recv_text_json(&mut stream).await;
+    assert_eq!(
+        reply["type"].as_str().unwrap(),
+        "error",
+        "signature from a different key must be rejected, got: {reply}"
+    );
+    assert_eq!(
+        reply["code"].as_str().unwrap(),
+        "auth_failed",
+        "signature from different key must yield auth_failed, got: {reply}"
+    );
+}
+


### PR DESCRIPTION
## Summary

Replaces the relay's trust-on-first-use handshake with a cryptographic proof-of-possession. The relay now refuses to register a peer until the client has proven it holds the private half of the public key it claims.

- **Server** sends a 32-byte hex-encoded challenge as the first frame on every WS upgrade (see `Challenge` in `crates/phantom-relay/src/server.rs`).
- **Client** signs `b"phantom-relay-pop-v1\0" || peer_id || 0x00 || challenge_bytes` with its Ed25519 private key and replies with `IdentityProof { peer_id, public_key, signature }`.
- **Server** verifies the signature with the supplied public key before registering the peer or issuing the `CapabilityClass::Relay` grant. On any failure (parse error, malformed hex, invalid Ed25519 point, signature mismatch) it returns an `auth_failed` error and closes the connection.

The domain-tag prefix (`phantom-relay-pop-v1\0`) prevents cross-protocol signature reuse. The fresh per-connection challenge prevents replay. Verification before registration prevents peer-id squatting.

Closes #526.

## Test plan

- [x] `cargo build -p phantom-relay` clean
- [x] `cargo test -p phantom-relay` — all 55 tests pass (50 unit + 5 integration)
- [x] `cargo clippy -p phantom-relay --all-targets --no-deps -- -D warnings` clean
- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace --no-run` clean
- [x] `./scripts/pre-pr-check.sh phantom-relay` PASS
- [x] `test_proof_of_possession_succeeds_with_valid_signature`
- [x] `test_proof_of_possession_rejects_unsigned_challenge`
- [x] `test_proof_of_possession_rejects_signature_from_different_key`

## Wire-protocol notes for reviewers

The legacy `IdentityProof.proof: String` field is removed. Any other consumer of the JSON handshake (currently only this crate's integration tests) must be updated to send the new `{ peer_id, public_key, signature }` shape after first reading the server's challenge frame. The phantom-net `RelayClient` does not use this JSON handshake (it speaks the Envelope HELLO path), so it is unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)