### PR TITLE
docs: remove stale keyring/keychain references after #539 file-backend swap (closes #548)

### DIFF
--- a/crates/phantom-app/src/app.rs
+++ b/crates/phantom-app/src/app.rs
@@ -1059,10 +1059,11 @@ impl App {
         // this Phantom instance so Claude can reach it remotely.  If the env
         // var is absent this is a graceful no-op.
         //
-        // The identity and JWT are loaded from the OS keychain inside
-        // spawn_hub on each connection attempt (issue #398).  Run
-        // `phantom auth register --hub <url>` before launching to populate
-        // the JWT entry; without it the hub will reject the connection.
+        // The identity and JWT are loaded from the on-disk identity and
+        // credentials files inside spawn_hub on each connection attempt
+        // (issue #398, file-backed per #539).  Run `phantom auth register
+        // --hub <url>` before launching to populate the credentials file;
+        // without it the hub will reject the connection.
         let hub_listener = {
             let hub_url = std::env::var("PHANTOM_HUB_URL").unwrap_or_default();
             match phantom_mcp::spawn_hub(&hub_url, hub_cmd_tx) {

--- a/crates/phantom-app/src/inspector.rs
+++ b/crates/phantom-app/src/inspector.rs
@@ -22,13 +22,13 @@ use phantom_ui::tokens::Tokens;
 use crate::adapters::inspector::InspectorAdapter;
 use crate::app::App;
 
-/// Load the local peer identity from the OS keyring and return its string
-/// representation.
+/// Load the local peer identity from the on-disk identity file and return
+/// its string representation.
 ///
 /// Uses the `"phantom"` service namespace so the key is shared across all
 /// code paths that call `Identity::load_or_generate("phantom")`.  Falls back
-/// to `"unknown"` when the keyring is unavailable (e.g. in CI or sandboxed
-/// environments) so the Peers tab always renders something legible.
+/// to `"unknown"` when the identity file is unavailable (e.g. in CI or
+/// sandboxed environments) so the Peers tab always renders something legible.
 fn load_local_peer_id() -> String {
     match phantom_net::identity::Identity::load_or_generate("phantom") {
         Ok(id) => id.peer_id.to_string(),
@@ -440,10 +440,11 @@ mod tests {
     /// `load_local_peer_id` must invoke the load-or-generate path and return a
     /// non-empty string that is not the old hard-coded sentinel `"localhost"`.
     ///
-    /// In test builds the `keyring` crate uses an in-process mock backend, so
-    /// `Identity::load_or_generate` works without OS keyring access.  Two calls
-    /// with the same service namespace must return the same peer-id (stable
-    /// identity contract from phantom-net).
+    /// `Identity::load_or_generate` reads from (and writes to) an on-disk
+    /// JSON file under the user's config directory; tests can redirect it via
+    /// `PHANTOM_IDENTITY_FILE` so no OS-level secret store is involved.  Two
+    /// calls with the same service namespace must return the same peer-id
+    /// (stable identity contract from phantom-net).
     #[test]
     fn load_local_peer_id_is_stable_and_not_localhost() {
         let id1 = super::load_local_peer_id();

--- a/crates/phantom-mcp/src/hub_listener.rs
+++ b/crates/phantom-mcp/src/hub_listener.rs
@@ -11,8 +11,8 @@
 //! spawn_hub()
 //!   └─ hub_loop  (OS thread with its own tokio runtime, or spawned on
 //!                 the caller's tokio runtime when one is already active)
-//!        ├─ Identity::load_or_generate (keychain lookup per attempt)
-//!        ├─ DeviceCredentials::load    (JWT from keychain — empty string if absent)
+//!        ├─ Identity::load_or_generate (identity file lookup per attempt)
+//!        ├─ DeviceCredentials::load    (JWT from credentials file — empty string if absent)
 //!        ├─ RelayClient::connect  (HELLO/HELLO_ACK handshake)
 //!        ├─ send_registration     (phantom_id, device_token, host, version)
 //!        └─ recv loop
@@ -27,17 +27,19 @@
 //! spawned.  The caller does not need to guard against a missing hub URL.
 //!
 //! # Auth (issue #398)
-//! The `device_token` is a JWT loaded from the OS keyring via
-//! [`phantom_net::DeviceCredentials::load`].  Run `phantom auth register
-//! --hub <url>` first to populate the keyring entry.  If no credentials are
-//! found the registration frame sends an empty token; the hub will reject the
-//! connection with code 4401.
+//! The `device_token` is a JWT loaded from the on-disk credentials file via
+//! [`phantom_net::DeviceCredentials::load`].  The default path is
+//! `{config_dir}/phantom/credentials/{namespace}.json` (mode `0600`); override
+//! with `PHANTOM_CREDENTIALS_FILE`.  Run `phantom auth register --hub <url>`
+//! first to populate the credentials file.  If no credentials are found the
+//! registration frame sends an empty token; the hub will reject the connection
+//! with code 4401.
 //!
 //! # #487 coordination
 //! `spawn_hub` no longer accepts an `Identity` parameter.  The identity is
-//! always reloaded from the OS keychain on each connection attempt — the
-//! keychain is the source of truth.  The call site in `phantom-app` has been
-//! updated accordingly.
+//! always reloaded from the on-disk identity file on each connection
+//! attempt — the file is the source of truth.  The call site in
+//! `phantom-app` has been updated accordingly.
 //!
 //! # Relation to Unix-socket listener
 //! The Unix-socket listener (`listener.rs`) is sync and thread-per-connection.
@@ -69,7 +71,7 @@ use crate::server::PhantomMcpServer;
 /// The peer-id string the hub registers under on the relay.
 const HUB_PEER_ID: &str = "hub";
 
-/// Keyring namespace used for the Phantom instance identity.
+/// Identity-file namespace used for the Phantom instance identity.
 const IDENTITY_NAMESPACE: &str = "phantom";
 
 // ---------------------------------------------------------------------------
@@ -111,12 +113,14 @@ impl HubListener {
 /// Returns `Ok(None)` immediately and without spawning anything when `hub_url`
 /// is empty.
 ///
-/// The identity and JWT are loaded from the OS keychain on each connection
-/// attempt.  The keychain is the source of truth — run `phantom auth register
-/// --hub <url>` before starting Phantom to populate the JWT entry.
+/// The identity and JWT are loaded from the on-disk identity and credentials
+/// files on each connection attempt — those files are the source of truth.
+/// Run `phantom auth register --hub <url>` before starting Phantom to populate
+/// the credentials file.  Override the file paths with `PHANTOM_IDENTITY_FILE`
+/// and `PHANTOM_CREDENTIALS_FILE` for tests.
 ///
-/// The keychain namespace defaults to `"phantom"`.  Use [`spawn_hub_ns`] to
-/// override the namespace for QA or dev instances.
+/// The identity-file namespace defaults to `"phantom"`.  Use [`spawn_hub_ns`]
+/// to override the namespace for QA or dev instances.
 pub fn spawn_hub(
     hub_url: &str,
     cmd_tx: Sender<AppCommand>,
@@ -126,7 +130,7 @@ pub fn spawn_hub(
 
 /// Like [`spawn_hub`] but accepts an explicit `identity_namespace` override.
 ///
-/// Used internally and in tests to isolate keychain slots.
+/// Used internally and in tests to isolate identity-file slots.
 pub fn spawn_hub_ns(
     hub_url: &str,
     identity_namespace: Option<String>,
@@ -190,14 +194,14 @@ async fn hub_loop(hub_url: String, identity_ns: String, cmd_tx: Sender<AppComman
             }
         };
 
-        // Load the JWT from the OS keychain (populated by `phantom auth register`).
-        // If no credentials are stored, send an empty token; the hub will respond
-        // with code 4401.  This lets Phantom start gracefully even before
-        // registration has run.
+        // Load the JWT from the on-disk credentials file (populated by
+        // `phantom auth register`).  If no credentials are stored, send an
+        // empty token; the hub will respond with code 4401.  This lets Phantom
+        // start gracefully even before registration has run.
         let device_token = match DeviceCredentials::load(&identity_ns) {
             Ok(Some(creds)) => creds.jwt,
             Ok(None) => {
-                warn!("hub_listener: no device credentials in keychain — hub will reject connection; run `phantom auth register --hub <url>`");
+                warn!("hub_listener: no device credentials on disk — hub will reject connection; run `phantom auth register --hub <url>`");
                 String::new()
             }
             Err(e) => {
@@ -536,7 +540,7 @@ mod tests {
 
         let listener_id = match NetIdentity::load_or_generate(&ns) {
             Ok(id) => id,
-            Err(_) => return, // Keychain unavailable in CI; skip routing test.
+            Err(_) => return, // Identity file unavailable in CI; skip routing test.
         };
         let listener_peer = NetPeerId::from(listener_id.peer_id.as_str().to_owned());
 

--- a/crates/phantom-net/src/lib.rs
+++ b/crates/phantom-net/src/lib.rs
@@ -4,7 +4,8 @@
 //! # Overview
 //!
 //! Each Phantom instance has a stable [`identity::Identity`] backed by an
-//! OS keyring (macOS Keychain / libsecret / wincred).  It connects to a
+//! on-disk JSON file (mode `0600`) under the user's config directory — see
+//! [`identity`] for the rationale and override env var.  It connects to a
 //! relay server over WebSocket, exchanges a handshake, and then sends and
 //! receives signed [`envelope::Envelope`]s to peer instances.
 //!
@@ -18,7 +19,7 @@
 //! without changing the public API.
 //!
 //! # Modules
-//! - [`identity`] — Ed25519 keypair + [`identity::PeerId`] + keyring persistence
+//! - [`identity`] — Ed25519 keypair + [`identity::PeerId`] + on-disk identity file
 //! - [`envelope`] — signed, nonce-stamped message envelope
 //! - [`transport`] — WebSocket framing (QUIC upgrade path noted)
 //! - [`client`]    — [`client::RelayClient`]: connect / send / recv / heartbeat


### PR DESCRIPTION
## Summary

After #539 swapped phantom-net's identity and credentials storage from the OS keyring to an on-disk JSON file (mode 0600) under `dirs::config_dir()`, doc comments in phantom-net, phantom-mcp, and phantom-app still claimed the OS keyring/keychain was the source of truth. This PR scrubs those stale references.

- `phantom-net/src/lib.rs` — module-level overview now describes the on-disk identity file
- `phantom-mcp/src/hub_listener.rs` — Lifecycle table, Auth section, #487 coordination note, public API doc, and inline log/comment text all describe the on-disk identity + credentials files; mentions the `PHANTOM_IDENTITY_FILE` / `PHANTOM_CREDENTIALS_FILE` overrides
- `phantom-app/src/app.rs` — hub-listener spawn comment now references `#539` and the on-disk credentials file (the bundle-store keychain comments are intentionally kept — phantom-bundle-store still legitimately uses the OS keyring for its master key)
- `phantom-app/src/inspector.rs` — `load_local_peer_id` doc and the test rationale comment now match the file-backed path

Doc-only — no runtime behaviour change.

## Out of scope (intentionally retained)

- `phantom-bundle-store` references in `phantom-app` (bundle-store still uses the OS keyring for its SQLCipher master key)
- "Why a file, not the OS keyring" rationale sections in `phantom-net/identity.rs` and `phantom-net/credentials.rs` (legitimate historical context)
- `phantom-net/Cargo.toml` historical comment about replacing the prior `keyring` backend

## Verification

```text
$ rg -i 'keyring|keychain' crates/phantom-net crates/phantom-mcp crates/phantom-app
crates/phantom-net/src/identity.rs:5:    #  rationale: "Why a file, not the OS keyring"
crates/phantom-net/src/identity.rs:7:    #  rationale heading
crates/phantom-net/src/identity.rs:8:    #  macOS Keychain ACL explanation
crates/phantom-net/src/credentials.rs:8:  #  rationale: "Why a file, not the OS keyring"
crates/phantom-net/src/credentials.rs:23: #  Keychain login keychain threat-model comparison
crates/phantom-net/Cargo.toml:33:         #  "Replaces the prior keyring backend"
crates/phantom-app/src/capture.rs:26:     #  bundle-store keychain (out of scope)
crates/phantom-app/src/app.rs:411,778,1595,1600,1606,1609: bundle-store keychain (out of scope)
```

All in-scope stale claims removed; remaining hits are either rationale sections or bundle-store references (out of scope per #548).

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `./scripts/pre-pr-check.sh phantom-net` — pass (build, test, clippy)
- [x] `./scripts/pre-pr-check.sh phantom-mcp` — pass
- [x] `./scripts/pre-pr-check.sh phantom-app` — pass
- [x] `cargo doc -p phantom-net -p phantom-mcp --no-deps` — preexisting rustdoc warnings unchanged; no new ones introduced

Closes #548.

🤖 Generated with [Claude Code](https://claude.com/claude-code)