### PR TITLE
fix(phantom-terminal): batch takeover.rs tech-debt one-liners (closes #453, #454)

### DIFF
--- a/crates/phantom-terminal/src/takeover.rs
+++ b/crates/phantom-terminal/src/takeover.rs
@@ -20,11 +20,11 @@
 //! # Usage
 //!
 //! ```rust,ignore
-//! use phantom_terminal::takeover::{TakeoverCandidate, TakeoverDetector};
+//! use phantom_terminal::takeover::{TakeoverCandidate, TakeoverDetector, TakeoverEvent};
 //!
 //! let mut detector = TakeoverDetector::default();
 //! // Call once per frame after pty_read().
-//! if let Some(candidate) = detector.poll(term.term(), term.pty_fd()) {
+//! if let TakeoverEvent::Detected(candidate) = detector.tick(term.term(), term.pty_fd()) {
 //!     // candidate.signal tells you why it triggered
 //! }
 //! ```
@@ -76,7 +76,7 @@ pub enum TakeoverSignal {
 
 /// A structured description of a subprocess that has taken over the terminal.
 ///
-/// Produced by [`TakeoverDetector::poll`] on a rising edge (candidate appeared)
+/// Produced by [`TakeoverDetector::tick`] on a rising edge (candidate appeared)
 /// and consumed by `phantom-app` to emit bus events and, optionally, split panes.
 ///
 /// The payload is intentionally rich so that the pane lineage model (#365) can
@@ -159,7 +159,11 @@ impl TakeoverDetector {
         self.was_takeover = is_takeover;
 
         if rising {
-            // candidate is Some when is_takeover is true (see classify).
+            // SAFETY: `classify` returns `(true, Some(_))` together — every code
+            // path in `classify` that yields `is_takeover == true` (alt-screen
+            // branch and known-program fallback branch) constructs a
+            // `Some(TakeoverCandidate)` in the same tuple. The `(true, None)`
+            // shape is unreachable, so `expect` here is safe.
             TakeoverEvent::Detected(candidate.expect("classify guarantees Some on takeover"))
         } else if falling {
             TakeoverEvent::Cleared


### PR DESCRIPTION
## Summary

Batch of small tech-debt one-liners against `crates/phantom-terminal/src/takeover.rs`. Two of the five originally-bundled issues were active on main; the other three were already-fixed and were closed during triage.

### Active fixes in this PR

- **#453 (docs)** — usage example used the renamed `poll(...)` API. Switched to `tick(...)` returning `TakeoverEvent`, added the missing `TakeoverEvent` import to the example, and corrected the `[TakeoverDetector::poll]` doc link on `TakeoverCandidate` to `[TakeoverDetector::tick]`.
- **#454 (tech-debt)** — replaced the informational comment above `candidate.expect("classify guarantees Some on takeover")` with a proper `// SAFETY:` block per project rubric §5.1, spelling out which `classify` paths produce `(true, Some(_))` so the `(true, None)` shape is unreachable.

### Triaged and already-fixed (closed during this batch)

- **#451** — `update.rs:1073` comment misattribution. Verified: the active comment block at `update.rs:1273-1278` correctly references the git-refresh reap path at line 315 and the `drain_bus_to_brain` setter. Closed.
- **#452** — `update.rs:1114` stub missing `#28`/`#62` refs. Verified: the active comment at `update.rs:1316` already reads `// new_pattern_detected: not yet wired; requires memory pattern engine (#28, #62)`. Closed.
- **#458** — `coordinator.rs` lineage wrapper `#[must_use]`. Verified: all five wrappers (`lineage_parent_of`, `lineage_children_of`, `lineage_is_root`, `lineage_chain`, `lineage_subtree`) already carry `#[must_use]` at lines 971/979/985/993/1001. Closed.

## Test plan

- [x] `cargo build -p phantom-app -p phantom-terminal`
- [x] `cargo test -p phantom-app --lib` — 474 passed
- [x] `cargo test -p phantom-terminal --lib` — 106 passed
- [x] `cargo clippy -p phantom-app -p phantom-terminal --all-targets -- -D warnings` — clean
- [x] `./scripts/pre-pr-check.sh phantom-app` — PASS
- [x] `./scripts/pre-pr-check.sh phantom-terminal` — PASS

Generated with [Claude Code](https://claude.com/claude-code)