### PR TITLE
fix(phantom-brain): wire real privacy_mode into capability audit (closes #446)

### DIFF
--- a/crates/phantom-app/src/app.rs
+++ b/crates/phantom-app/src/app.rs
@@ -689,8 +689,11 @@ impl App {
         // short (≤ 2 s Ollama ping).  We run it on this thread because
         // `with_config_scaled` is already called off the render thread.
         {
+            // Mirror the user's `PhantomConfig::privacy_mode` so the audit
+            // report correctly classifies cloud subsystems as
+            // `BlockedByPolicy` when privacy mode is on. See issue #446.
             let audit_config = AuditConfig {
-                privacy_mode: false, // PR #350 will expose privacy_mode from PhantomConfig
+                privacy_mode: config.privacy_mode,
             };
             let report = CapabilityReport::compute(&audit_config);
             report.log_report();

--- a/crates/phantom-brain/src/capability_audit.rs
+++ b/crates/phantom-brain/src/capability_audit.rs
@@ -567,4 +567,63 @@ mod tests {
         assert_eq!(blocked.len(), 2, "both cloud entries should be blocked");
         assert!(blocked.iter().all(|e| e.reason.is_some()));
     }
+
+    // -----------------------------------------------------------------------
+    // End-to-end: AuditConfig.privacy_mode flows through CapabilityReport::compute
+    //
+    // Regression for issue #446: prior to the fix, app.rs hardcoded
+    // `privacy_mode: false` when constructing AuditConfig, so the report
+    // never reflected the user's privacy preference. This asserts the
+    // public `compute` entry point honours the flag.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    #[serial_test::serial(env)]
+    fn compute_with_privacy_mode_blocks_cloud_subsystems() {
+        // Set both keys so the unavailable branch cannot mask the result —
+        // the only way both cloud entries become BlockedByPolicy is if
+        // privacy_mode flowed through AuditConfig into the audit_* helpers.
+        let prev_anthropic = std::env::var("ANTHROPIC_API_KEY").ok();
+        let prev_openai = std::env::var("OPENAI_API_KEY").ok();
+        unsafe {
+            std::env::set_var("ANTHROPIC_API_KEY", "sk-test");
+            std::env::set_var("OPENAI_API_KEY", "sk-test");
+        }
+
+        let report = CapabilityReport::compute(&AuditConfig { privacy_mode: true });
+
+        let claude = report
+            .entries()
+            .iter()
+            .find(|e| e.name == "claude-cloud")
+            .expect("claude-cloud entry present");
+        assert_eq!(
+            claude.status,
+            CapabilityStatus::BlockedByPolicy,
+            "claude-cloud must be BlockedByPolicy when AuditConfig.privacy_mode=true",
+        );
+
+        let openai = report
+            .entries()
+            .iter()
+            .find(|e| e.name == "openai-compat-cloud")
+            .expect("openai-compat-cloud entry present");
+        assert_eq!(
+            openai.status,
+            CapabilityStatus::BlockedByPolicy,
+            "openai-compat-cloud must be BlockedByPolicy when AuditConfig.privacy_mode=true",
+        );
+
+        // Restore env.
+        unsafe {
+            std::env::remove_var("ANTHROPIC_API_KEY");
+            std::env::remove_var("OPENAI_API_KEY");
+        }
+        if let Some(v) = prev_anthropic {
+            unsafe { std::env::set_var("ANTHROPIC_API_KEY", v) };
+        }
+        if let Some(v) = prev_openai {
+            unsafe { std::env::set_var("OPENAI_API_KEY", v) };
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Replaces hardcoded `privacy_mode: false` in `phantom-app/src/app.rs` (line 692-693) with the real value from `PhantomConfig::privacy_mode`. The placeholder dated to PR #430, when the privacy-mode plumbing did not yet exist; PR #350 has since landed it.
- Adds an end-to-end regression test in `phantom-brain/src/capability_audit.rs` that drives `CapabilityReport::compute(&AuditConfig { privacy_mode: true })` with both `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` set, and asserts both cloud entries come back `BlockedByPolicy` — exercising the full path from `AuditConfig` through `compute` into the `audit_*` helpers.

## Why this matters
The audit is reporting-only (the `PrivacyGuard` and router already enforce the block at runtime), but the report drives user UX — status bar and inspector tab. Before this fix, with privacy mode on, the audit would still report cloud subsystems as `Available` or `Unavailable` based on env vars alone, misrepresenting capability state.

## Scope
- `crates/phantom-app/src/app.rs` — single-line wiring change
- `crates/phantom-brain/src/capability_audit.rs` — new test only; no production logic change in this crate

## Test plan
- [x] `cargo build -p phantom-brain -p phantom-app` — clean
- [x] `cargo test -p phantom-brain --lib capability_audit` — 17/17 pass, including new `compute_with_privacy_mode_blocks_cloud_subsystems`
- [x] `cargo clippy -p phantom-brain -p phantom-app --all-targets -- -D warnings` — clean
- [x] `./scripts/pre-pr-check.sh phantom-brain` — PASS
- [x] `./scripts/pre-pr-check.sh phantom-app` — PASS
- [x] `cargo test --workspace --no-run` — clean

Closes #446