### PR TITLE
feat(phantom): implement phantom auth register CLI for hub registration (closes #563)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,6 +1056,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5608,8 +5648,14 @@ name = "phantom"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "axum",
+ "chrono",
+ "clap",
+ "dirs 5.0.1",
  "dotenvy",
+ "ed25519-dalek",
  "env_logger",
+ "jsonwebtoken",
  "libc",
  "log",
  "phantom-agents",
@@ -5617,14 +5663,20 @@ dependencies = [
  "phantom-brain",
  "phantom-context",
  "phantom-history",
+ "phantom-hub",
  "phantom-memory",
+ "phantom-net",
  "phantom-nlp",
  "phantom-protocol",
  "phantom-renderer",
  "phantom-semantic",
  "phantom-terminal",
  "phantom-ui",
+ "reqwest",
+ "serde",
  "serde_json",
+ "tempfile",
+ "tokio",
  "uuid",
  "winit",
 ]
@@ -6813,6 +6865,7 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",

--- a/crates/phantom/Cargo.toml
+++ b/crates/phantom/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lib]
+name = "phantom"
+path = "src/lib.rs"
+
 [[bin]]
 name = "phantom"
 path = "src/main.rs"
@@ -24,14 +28,47 @@ phantom-agents = { path = "../phantom-agents" }
 phantom-semantic = { path = "../phantom-semantic" }
 phantom-nlp = { path = "../phantom-nlp" }
 
+# Hub registration: identity + credentials persistence (issue #563).
+phantom-net = { path = "../phantom-net" }
+
 winit.workspace = true
 anyhow.workspace = true
 log.workspace = true
 env_logger.workspace = true
 uuid.workspace = true
 dotenvy = "0.15"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 libc = "0.2"
+
+# CLI parsing for `phantom auth ...` subcommands (issue #563).
+clap = { version = "4", features = ["derive"] }
+
+# Blocking HTTP client for `phantom auth register` POST to the hub.
+reqwest = { version = "0.12", features = ["json", "blocking"] }
+
+# Ed25519 signature handling for the hub registration challenge.
+ed25519-dalek = "2"
+
+# JWT decoding (no verification — only to extract `exp` for display).
+# Matches the hub's `jsonwebtoken` version so encoded tokens round-trip cleanly.
+jsonwebtoken = "9"
+
+# Unix-time formatting for human-readable JWT expiry output.
+chrono = { workspace = true }
+
+# Config-directory resolution for the `auth status` display path.  Mirrors
+# the resolver used inside `phantom_net::credentials` so the printed path
+# matches the actual storage location.
+dirs = "5"
+
+[dev-dependencies]
+tempfile = "3"
+# Lightweight in-process HTTP server for `register` happy-path tests.
+axum = "0.7"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }
+# Cross-validate the wire signature against the real hub verifier.
+phantom-hub = { path = "../phantom-hub" }
 
 [lints]
 workspace = true

--- a/crates/phantom/src/auth_cli.rs
+++ b/crates/phantom/src/auth_cli.rs
@@ -1,0 +1,347 @@
+//! `phantom auth` CLI surface — register / status / clear (issue #563).
+//!
+//! This module owns the user-facing commands that move a Phantom instance
+//! from "unregistered" to "holding a hub-issued JWT in the credentials
+//! store".  It is the local half of the registration handshake whose remote
+//! half lives in `phantom-hub::phantom_endpoint::register`.
+//!
+//! # Wire predicate
+//!
+//! The signed challenge **must** be produced byte-for-byte the same way the
+//! hub will verify it.  The hub's verifier is
+//! [`phantom_hub::auth::verify_registration_signature`] which builds the
+//! signed message as:
+//!
+//! ```text
+//! msg = nonce.as_bytes() || peer_id.as_bytes()
+//! ```
+//!
+//! (see `crates/phantom-hub/src/auth.rs` near line 575).  Any deviation —
+//! reversing the order, inserting a domain-separation prefix, hashing
+//! first — fails verification and the hub returns `401`.  This module
+//! mirrors that predicate exactly in [`build_register_payload`] which is
+//! the single place the message bytes are constructed.
+//!
+//! # Hex encodings on the wire
+//!
+//! The `RegisterRequest` schema (see
+//! `crates/phantom-hub/src/phantom_endpoint.rs`) uses three hex fields:
+//!
+//! | Field             | Bytes hex-encoded                                          |
+//! |-------------------|-----------------------------------------------------------|
+//! | `public_key_hex`  | 32 raw Ed25519 public-key bytes → 64 hex chars            |
+//! | `nonce_hex`       | UTF-8 bytes of the nonce string → variable hex length     |
+//! | `signature_hex`   | 64 raw Ed25519 signature bytes → 128 hex chars            |
+//!
+//! The nonce is a freshly generated UUID-v4 string; the hub decodes its
+//! UTF-8 bytes back to a string and uses it both for replay protection
+//! and as the first half of the signed message.
+//!
+//! # Storage
+//!
+//! On success the JWT is written via
+//! [`phantom_net::DeviceCredentials::store`] which already provides
+//! atomic-create + mode-`0600` semantics (post-#555).  We do not roll our
+//! own file write.
+
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow, bail};
+use ed25519_dalek::Signature;
+use phantom_net::{DeviceCredentials, Identity};
+use serde::{Deserialize, Serialize};
+
+/// Default namespace for both the [`Identity`] file and
+/// [`DeviceCredentials`] file when the user does not pass `--service`.
+pub const DEFAULT_SERVICE: &str = "phantom";
+
+// ---------------------------------------------------------------------------
+// Wire types — mirror `phantom_hub::phantom_endpoint::{Register{Request,Response}}`
+// ---------------------------------------------------------------------------
+//
+// We duplicate the wire shape rather than depending on `phantom-hub` so that
+// `phantom-hub`'s heavy axum/tracing/jsonwebtoken transitive dep tree is not
+// pulled into the GUI binary.  The two sides are validated against each
+// other in `tests/auth_cli.rs` which imports the real hub verifier and
+// asserts the signature this module produces is accepted.
+
+#[derive(Debug, Serialize)]
+struct RegisterRequest {
+    peer_id: String,
+    public_key_hex: String,
+    nonce_hex: String,
+    signature_hex: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RegisterResponse {
+    device_token: String,
+    exp: u64,
+    phantom_id: String,
+}
+
+// ---------------------------------------------------------------------------
+// Payload builder — the byte-level contract with the hub
+// ---------------------------------------------------------------------------
+
+/// Inputs to the registration payload, kept separate from network concerns
+/// so the byte-construction step is unit-testable in isolation.
+pub struct RegisterPayload {
+    pub peer_id: String,
+    pub public_key_hex: String,
+    pub nonce_hex: String,
+    pub signature_hex: String,
+}
+
+/// Build the JSON body for `POST /auth/register` from an [`Identity`] and a
+/// nonce string.
+///
+/// The signed message is constructed byte-for-byte the same way as the
+/// hub's verifier (`phantom_hub::auth::verify_registration_signature`):
+///
+/// ```text
+/// msg = nonce.as_bytes() || peer_id.as_bytes()
+/// ```
+///
+/// Any deviation here causes the hub to return `401 Unauthorized`.
+#[must_use]
+pub fn build_register_payload(identity: &Identity, nonce: &str) -> RegisterPayload {
+    let peer_id = identity.peer_id.as_str().to_owned();
+    let public_key_hex = encode_hex(identity.verifying_key().as_bytes());
+
+    // Mirror the hub predicate exactly — see auth.rs:576-578.
+    let mut msg = Vec::with_capacity(nonce.len() + peer_id.len());
+    msg.extend_from_slice(nonce.as_bytes());
+    msg.extend_from_slice(peer_id.as_bytes());
+
+    let signature: Signature = identity.sign(&msg);
+    let signature_hex = encode_hex(&signature.to_bytes());
+    let nonce_hex = encode_hex(nonce.as_bytes());
+
+    RegisterPayload {
+        peer_id,
+        public_key_hex,
+        nonce_hex,
+        signature_hex,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public commands — wired into clap subcommands in main.rs
+// ---------------------------------------------------------------------------
+
+/// `phantom auth register --hub <url> [--service <name>]`.
+///
+/// 1. Loads (or generates) the on-disk identity for `service`.
+/// 2. Builds the registration payload and POSTs it to `<hub_url>/auth/register`.
+/// 3. Persists the returned JWT via [`DeviceCredentials::store`].
+/// 4. Prints peer-id, expiry (ISO-8601), and the credentials file path.
+pub fn register(hub_url: &str, service: &str) -> Result<()> {
+    let hub_url = hub_url.trim().trim_end_matches('/');
+    if hub_url.is_empty() {
+        bail!("--hub URL must not be empty");
+    }
+
+    let identity =
+        Identity::load_or_generate(service).context("failed to load or generate identity")?;
+    let nonce = uuid::Uuid::new_v4().to_string();
+    let payload = build_register_payload(&identity, &nonce);
+
+    let body = RegisterRequest {
+        peer_id: payload.peer_id.clone(),
+        public_key_hex: payload.public_key_hex,
+        nonce_hex: payload.nonce_hex,
+        signature_hex: payload.signature_hex,
+    };
+
+    let endpoint = format!("{hub_url}/auth/register");
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .context("failed to construct HTTP client")?;
+
+    let response = client
+        .post(&endpoint)
+        .json(&body)
+        .send()
+        .with_context(|| format!("POST {endpoint} failed"))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        // Body may contain a server-side reason; surface it but never the JWT.
+        let server_msg = response.text().unwrap_or_default();
+        bail!("hub rejected registration: {status} {server_msg}");
+    }
+
+    let parsed: RegisterResponse = response
+        .json()
+        .context("hub response was not valid RegisterResponse JSON")?;
+
+    if parsed.phantom_id != payload.peer_id {
+        bail!(
+            "hub echoed peer_id {} but we sent {}",
+            parsed.phantom_id,
+            payload.peer_id
+        );
+    }
+
+    DeviceCredentials::store(service, hub_url, &parsed.device_token)
+        .context("failed to persist device credentials")?;
+
+    let creds_path = credentials_path_for_display(service);
+    println!("Registered with hub at {hub_url}");
+    println!("  peer_id : {}", payload.peer_id);
+    println!("  expires : {} (unix={})", format_expiry(parsed.exp), parsed.exp);
+    println!("  stored  : {creds_path}");
+
+    Ok(())
+}
+
+/// `phantom auth status [--service <name>]`.
+///
+/// Prints the stored credentials' peer-id and expiry without verifying the
+/// JWT signature.  When no credentials are stored, prints a friendly
+/// "not registered" message and exits successfully (status is informational,
+/// not a probe).
+pub fn status(service: &str) -> Result<()> {
+    let Some(creds) =
+        DeviceCredentials::load(service).context("failed to load credentials")?
+    else {
+        println!("No credentials stored for service '{service}' — run `phantom auth register --hub <url>`");
+        return Ok(());
+    };
+
+    let claims = decode_jwt_claims(&creds.jwt)?;
+    println!("Credentials present for service '{service}':");
+    println!("  hub_url : {}", creds.hub_url);
+    if let Some(peer_id) = &claims.sub {
+        println!("  peer_id : {peer_id}");
+    }
+    println!("  expires : {} (unix={})", format_expiry(claims.exp), claims.exp);
+
+    Ok(())
+}
+
+/// `phantom auth clear [--service <name>]`.
+///
+/// Deletes the on-disk credentials file.  Idempotent — succeeds even when
+/// no credentials are stored, mirroring `DeviceCredentials::delete`.
+pub fn clear(service: &str) -> Result<()> {
+    DeviceCredentials::delete(service).context("failed to delete credentials")?;
+    println!("Cleared credentials for service '{service}'");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// JWT decoding (no verification)
+// ---------------------------------------------------------------------------
+
+/// The two JWT claims `phantom auth status` cares about.
+///
+/// The hub signs additional fields (issuer, audience, …) but we deliberately
+/// do not import the hub's claims struct — `auth status` is a local diagnostic
+/// and must work without the hub's signing key.
+#[derive(Debug, Deserialize)]
+struct DisplayClaims {
+    /// Subject — the `peer_id` the JWT was issued for.
+    #[serde(default)]
+    sub: Option<String>,
+    /// Expiry as a Unix timestamp (seconds).
+    exp: u64,
+}
+
+fn decode_jwt_claims(jwt: &str) -> Result<DisplayClaims> {
+    // Insecure decode is correct here: we are not making a trust decision
+    // off these claims, only displaying them to the user.  The hub
+    // re-validates on every request.
+    let mut validation = jsonwebtoken::Validation::default();
+    validation.insecure_disable_signature_validation();
+    validation.validate_exp = false;
+    validation.required_spec_claims.clear();
+
+    let dummy_key = jsonwebtoken::DecodingKey::from_secret(b"unused");
+    let data = jsonwebtoken::decode::<DisplayClaims>(jwt, &dummy_key, &validation)
+        .map_err(|e| anyhow!("could not decode JWT for display: {e}"))?;
+    Ok(data.claims)
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+fn encode_hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push(hex_digit(b >> 4));
+        s.push(hex_digit(b & 0x0f));
+    }
+    s
+}
+
+fn hex_digit(nibble: u8) -> char {
+    match nibble {
+        0..=9 => (b'0' + nibble) as char,
+        10..=15 => (b'a' + (nibble - 10)) as char,
+        _ => unreachable!("nibble out of range: {nibble}"),
+    }
+}
+
+fn format_expiry(unix_ts: u64) -> String {
+    use chrono::{DateTime, Utc};
+    let secs = i64::try_from(unix_ts).unwrap_or(i64::MAX);
+    DateTime::<Utc>::from_timestamp(secs, 0)
+        .map(|dt| dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+        .unwrap_or_else(|| format!("unix={unix_ts}"))
+}
+
+/// Best-effort display path for the credentials file.
+///
+/// The real storage logic in `phantom_net::credentials` honours
+/// `PHANTOM_CREDENTIALS_FILE` first, then falls back to
+/// `{config_dir}/phantom/credentials/{service}.json`.  We replicate that
+/// resolution here for display only — `DeviceCredentials::store` is what
+/// actually performs the write.
+fn credentials_path_for_display(service: &str) -> String {
+    if let Some(p) = std::env::var_os("PHANTOM_CREDENTIALS_FILE") {
+        return std::path::PathBuf::from(p).display().to_string();
+    }
+    let base = dirs::config_dir().or_else(dirs::home_dir);
+    match base {
+        Some(p) => p
+            .join("phantom")
+            .join("credentials")
+            .join(format!("{service}.json"))
+            .display()
+            .to_string(),
+        None => format!("<config_dir>/phantom/credentials/{service}.json"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pure unit tests — hex round-trip only
+//
+// Tests that need an `Identity` live in `tests/auth_cli.rs` so they can use
+// the `PHANTOM_IDENTITY_FILE` env-override against a tempfile.  Doing that
+// from in-crate `cfg(test)` is risky because env vars are process-global
+// and would clobber other in-crate tests in the same binary.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_hex_lower_case_zero_padded() {
+        assert_eq!(encode_hex(&[]), "");
+        assert_eq!(encode_hex(&[0x00]), "00");
+        assert_eq!(encode_hex(&[0xab, 0xcd, 0xef]), "abcdef");
+        assert_eq!(encode_hex(&[0x01, 0x0f, 0xf0]), "010ff0");
+    }
+
+    #[test]
+    fn format_expiry_handles_well_known_timestamp() {
+        // 2026-01-01T00:00:00Z = 1767225600
+        let s = format_expiry(1767225600);
+        assert!(s.starts_with("2026-01-01T"), "got {s}");
+    }
+}

--- a/crates/phantom/src/lib.rs
+++ b/crates/phantom/src/lib.rs
@@ -1,0 +1,15 @@
+//! `phantom` library surface.
+//!
+//! The phantom binary is the primary product of this crate.  This `lib.rs`
+//! exposes a small library face whose sole purpose is to make
+//! integration-test fixtures importable — the binary's `main.rs` modules
+//! cannot otherwise be reached from `tests/`.
+//!
+//! Concretely: `auth_cli` is re-exported so `tests/auth_cli.rs` can
+//! cross-validate the registration payload against `phantom-hub`'s
+//! verifier without a runtime HTTP round-trip.
+//!
+//! No other code in the workspace depends on this lib target — the GUI
+//! and headless surfaces are entry points, not library consumers.
+
+pub mod auth_cli;

--- a/crates/phantom/src/main.rs
+++ b/crates/phantom/src/main.rs
@@ -13,6 +13,7 @@ use winit::{
     window::{Window, WindowAttributes, WindowId},
 };
 
+mod auth_cli;
 mod headless;
 mod path_resolver;
 
@@ -238,9 +239,10 @@ fn print_help() {
         r#"PHANTOM v0.1.0 — AI-native terminal emulator
 
 USAGE:
-    phantom [OPTIONS]
+    phantom [OPTIONS]              Launch the terminal (default).
+    phantom auth <SUBCOMMAND>      Manage hub credentials.
 
-OPTIONS:
+GUI / RUN OPTIONS:
     --headless               Run in headless REPL mode (no window, no GPU)
     --theme <NAME>          Theme: phosphor, amber, ice, blood, vapor
     --font-size <PT>        Font size in points (default: 14.0)
@@ -254,13 +256,25 @@ OPTIONS:
     --init-config            Write default config to ~/.config/phantom/config.toml
     --help                   Print this help message
 
+AUTH SUBCOMMANDS:
+    phantom auth register --hub <URL> [--service <NAME>]
+        Register this Phantom with the hub at <URL>.  Generates an Ed25519
+        identity if one does not exist, signs a registration challenge,
+        receives a JWT, and stores it under {{config_dir}}/phantom/credentials.
+    phantom auth status [--service <NAME>]
+        Print stored credentials' peer-id and expiry.
+    phantom auth clear [--service <NAME>]
+        Delete stored credentials (idempotent).
+
 CONFIG:
     ~/.config/phantom/config.toml
 
 EXAMPLES:
     phantom --theme amber --curvature 0.1
     phantom --bloom 0 --scanlines 0 --curvature 0
-    phantom --theme ice --font-size 16"#
+    phantom --theme ice --font-size 16
+    phantom auth register --hub https://hub.example.com
+    phantom auth status"#
     );
 }
 
@@ -462,6 +476,62 @@ fn chrono_timestamp() -> String {
     )
 }
 
+// ---------------------------------------------------------------------------
+// `phantom auth ...` clap surface (issue #563)
+// ---------------------------------------------------------------------------
+
+#[derive(clap::Parser)]
+#[command(name = "phantom", bin_name = "phantom", disable_help_flag = false)]
+struct AuthCli {
+    #[command(subcommand)]
+    cmd: AuthRoot,
+}
+
+#[derive(clap::Subcommand)]
+enum AuthRoot {
+    /// Manage hub credentials (register / status / clear).
+    Auth {
+        #[command(subcommand)]
+        action: AuthAction,
+    },
+}
+
+#[derive(clap::Subcommand)]
+enum AuthAction {
+    /// Register this Phantom with the hub and persist the issued JWT.
+    Register {
+        /// Hub base URL, e.g. `https://hub.example.com`.
+        #[arg(long)]
+        hub: String,
+        /// Identity / credentials namespace.  Defaults to `"phantom"`.
+        #[arg(long, default_value = auth_cli::DEFAULT_SERVICE)]
+        service: String,
+    },
+    /// Print stored credentials' peer-id and expiry.
+    Status {
+        /// Identity / credentials namespace.  Defaults to `"phantom"`.
+        #[arg(long, default_value = auth_cli::DEFAULT_SERVICE)]
+        service: String,
+    },
+    /// Delete stored credentials (idempotent).
+    Clear {
+        /// Identity / credentials namespace.  Defaults to `"phantom"`.
+        #[arg(long, default_value = auth_cli::DEFAULT_SERVICE)]
+        service: String,
+    },
+}
+
+fn run_auth_subcommand(args: &[String]) -> Result<()> {
+    use clap::Parser;
+    let parsed = AuthCli::parse_from(args);
+    let AuthRoot::Auth { action } = parsed.cmd;
+    match action {
+        AuthAction::Register { hub, service } => auth_cli::register(&hub, &service),
+        AuthAction::Status { service } => auth_cli::status(&service),
+        AuthAction::Clear { service } => auth_cli::clear(&service),
+    }
+}
+
 fn main() -> Result<()> {
     // Resolve desktop PATH before any tool is spawned. When Phantom is launched
     // via a .app bundle or .desktop file the inherited PATH is typically missing
@@ -490,6 +560,21 @@ fn main() -> Result<()> {
     }
 
     let args: Vec<String> = std::env::args().collect();
+
+    // -- Subcommand routing --
+    // The very first argument after argv[0] may be a subcommand (e.g.
+    // `auth`).  When it is, we hand all remaining args to a clap parser
+    // that owns that subcommand's flags.  When it is not — including the
+    // common case of legacy flat flags like `phantom --theme amber` —
+    // fall through to the legacy flat-flag parser below.
+    //
+    // We deliberately check argv[1] directly (not "first non-flag arg") so
+    // a value-of-flag like `phantom --theme amber` cannot accidentally
+    // route into the subcommand parser if a future theme were named
+    // `auth`.
+    if args.get(1).map(String::as_str) == Some("auth") {
+        return run_auth_subcommand(&args);
+    }
 
     // Quick exits
     if args.iter().any(|a| a == "--help" || a == "-h") {

--- a/crates/phantom/tests/auth_cli.rs
+++ b/crates/phantom/tests/auth_cli.rs
@@ -1,0 +1,283 @@
+//! Integration tests for `phantom auth` (issue #563).
+//!
+//! These tests live outside the bin module so they can:
+//!   - import `phantom::auth_cli` through the small lib surface in `lib.rs`,
+//!   - import `phantom_hub::auth::verify_registration_signature` to
+//!     cross-validate the wire signature against the actual hub verifier,
+//!   - drive `PHANTOM_IDENTITY_FILE` and `PHANTOM_CREDENTIALS_FILE` against
+//!     per-test tempfiles so we never touch the user's real config dir.
+//!
+//! Env mutation is process-global so every test that touches an env var
+//! holds the `ENV_SERIAL` mutex for its duration.  The mutex is poison-tolerant.
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use phantom::auth_cli;
+use phantom_net::{DeviceCredentials, Identity};
+
+static ENV_SERIAL: Mutex<()> = Mutex::new(());
+static TEST_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+/// Unique service name per test so the per-process Identity cache cannot
+/// leak state between cases.
+fn unique_service() -> String {
+    let n = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let pid = std::process::id();
+    format!("phantom-563-{pid}-{n}")
+}
+
+fn tmp_path(label: &str) -> PathBuf {
+    let n = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let pid = std::process::id();
+    std::env::temp_dir().join(format!("phantom-563-{label}-{pid}-{n}"))
+}
+
+/// RAII guard that restores env state and removes a tempfile on drop.
+/// Cleanup runs even if the test panics.
+struct EnvGuard {
+    var: &'static str,
+    file: PathBuf,
+}
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: env mutation is serialised by ENV_SERIAL.
+        unsafe { std::env::remove_var(self.var) };
+        let _ = std::fs::remove_file(&self.file);
+    }
+}
+
+fn set_identity_override(path: &PathBuf) -> EnvGuard {
+    // SAFETY: env mutation is serialised by ENV_SERIAL.
+    unsafe { std::env::set_var("PHANTOM_IDENTITY_FILE", path) };
+    EnvGuard {
+        var: "PHANTOM_IDENTITY_FILE",
+        file: path.clone(),
+    }
+}
+
+fn set_credentials_override(path: &PathBuf) -> EnvGuard {
+    unsafe { std::env::set_var("PHANTOM_CREDENTIALS_FILE", path) };
+    EnvGuard {
+        var: "PHANTOM_CREDENTIALS_FILE",
+        file: path.clone(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Signature contract — wire payload must verify against the hub's verifier
+// ---------------------------------------------------------------------------
+
+#[test]
+fn register_payload_includes_correct_signature() {
+    let _serial = ENV_SERIAL.lock().unwrap_or_else(|p| p.into_inner());
+    let id_file = tmp_path("id");
+    let _id_guard = set_identity_override(&id_file);
+
+    let service = unique_service();
+    let identity = Identity::load_or_generate(&service).expect("identity must load");
+
+    let nonce = "uuid-v4-style-nonce-AB12cd";
+    let payload = auth_cli::build_register_payload(&identity, nonce);
+
+    // Decode the hex fields back into raw bytes — these are the exact
+    // bytes the hub will see on the wire after `hex_decode_exact`/`hex_decode_vec`.
+    let pubkey_bytes = decode_hex(&payload.public_key_hex).expect("pubkey hex");
+    let signature_bytes = decode_hex(&payload.signature_hex).expect("sig hex");
+    let nonce_bytes = decode_hex(&payload.nonce_hex).expect("nonce hex");
+    let nonce_str = std::str::from_utf8(&nonce_bytes).expect("nonce decodes to UTF-8");
+    assert_eq!(nonce_str, nonce, "nonce hex must round-trip via UTF-8");
+
+    // The byte-level contract: hand exactly what the hub will hand its
+    // verifier and assert success.  This is the critical guard.
+    phantom_hub::auth::verify_registration_signature(
+        &payload.peer_id,
+        nonce_str,
+        &pubkey_bytes,
+        &signature_bytes,
+    )
+    .expect("hub verifier MUST accept the CLI-built signature");
+
+    // Sanity: a different nonce must NOT verify under the same signature.
+    let bad = phantom_hub::auth::verify_registration_signature(
+        &payload.peer_id,
+        "different-nonce",
+        &pubkey_bytes,
+        &signature_bytes,
+    );
+    assert!(
+        bad.is_err(),
+        "verifier must reject signature when the nonce changes"
+    );
+
+    // Sanity: a different peer_id must NOT verify either.
+    let bad2 = phantom_hub::auth::verify_registration_signature(
+        "not-the-real-peer-id",
+        nonce_str,
+        &pubkey_bytes,
+        &signature_bytes,
+    );
+    assert!(
+        bad2.is_err(),
+        "verifier must reject signature when the peer_id changes"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. status with no credentials prints "not registered" and exits Ok
+// ---------------------------------------------------------------------------
+
+#[test]
+fn status_reports_no_credentials_when_file_missing() {
+    let _serial = ENV_SERIAL.lock().unwrap_or_else(|p| p.into_inner());
+    let creds_file = tmp_path("creds");
+    let _creds_guard = set_credentials_override(&creds_file);
+    assert!(
+        !creds_file.exists(),
+        "precondition: creds file must not exist"
+    );
+
+    let service = unique_service();
+    // status returns Ok(()) even when nothing is stored — it's a probe.
+    auth_cli::status(&service).expect("status must succeed when nothing is stored");
+}
+
+// ---------------------------------------------------------------------------
+// 3. clear removes the credentials file (and is idempotent)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn clear_removes_credentials_file() {
+    let _serial = ENV_SERIAL.lock().unwrap_or_else(|p| p.into_inner());
+    let creds_file = tmp_path("creds");
+    let _creds_guard = set_credentials_override(&creds_file);
+
+    let service = unique_service();
+    DeviceCredentials::store(&service, "https://hub.example.com", "fake-jwt")
+        .expect("seed credentials");
+    assert!(creds_file.exists(), "credentials file must exist after store");
+
+    auth_cli::clear(&service).expect("clear must succeed");
+    assert!(
+        !creds_file.exists(),
+        "credentials file must be removed after clear"
+    );
+
+    // Idempotent: a second clear is a no-op.
+    auth_cli::clear(&service).expect("second clear must also succeed");
+}
+
+// ---------------------------------------------------------------------------
+// 4. register against an in-process axum mock writes credentials on 200
+// ---------------------------------------------------------------------------
+
+#[test]
+fn register_writes_credentials_on_200_response() {
+    use axum::Json;
+    use axum::Router;
+    use axum::routing::post;
+
+    let _serial = ENV_SERIAL.lock().unwrap_or_else(|p| p.into_inner());
+    let id_file = tmp_path("id");
+    let creds_file = tmp_path("creds");
+    let _id_guard = set_identity_override(&id_file);
+    let _creds_guard = set_credentials_override(&creds_file);
+
+    let service = unique_service();
+    // Pre-load the identity so we know the peer_id the hub-mock should echo.
+    let identity = Identity::load_or_generate(&service).expect("identity must load");
+    let expected_peer_id = identity.peer_id.as_str().to_owned();
+    drop(identity);
+
+    // Build a tokio runtime to run the hub mock.  Spawn the mock on a fresh
+    // background thread — the `register` call we make below uses
+    // `reqwest::blocking`, so we cannot share a runtime with it.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    listener.set_nonblocking(true).expect("set nonblocking");
+    let local_addr = listener.local_addr().expect("local addr");
+    let hub_url = format!("http://{local_addr}");
+
+    // `auth_cli::register` only stores the JWT — it never decodes it.
+    // A simple opaque string is sufficient for this test.
+    let mock_jwt = "mock-device-jwt-issued-by-test-hub".to_owned();
+    let mock_jwt_for_handler = mock_jwt.clone();
+    let echo_peer_id = expected_peer_id.clone();
+
+    let server_thread = std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        rt.block_on(async move {
+            let app = Router::new().route(
+                "/auth/register",
+                post(move |Json(_body): Json<serde_json::Value>| {
+                    let device_token = mock_jwt_for_handler.clone();
+                    let phantom_id = echo_peer_id.clone();
+                    async move {
+                        Json(serde_json::json!({
+                            "device_token": device_token,
+                            "exp": 4_102_444_800u64,
+                            "phantom_id": phantom_id,
+                        }))
+                    }
+                }),
+            );
+            let listener = tokio::net::TcpListener::from_std(listener).expect("from_std");
+            // Serve a single connection then exit.
+            let _ = axum::serve(listener, app)
+                .with_graceful_shutdown(async {
+                    // Stay alive long enough for the test client to finish.
+                    tokio::time::sleep(std::time::Duration::from_secs(15)).await;
+                })
+                .await;
+        });
+    });
+
+    // Give the server a beat to actually bind.
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    auth_cli::register(&hub_url, &service).expect("register must succeed against the mock hub");
+
+    // The credentials file must now exist and contain the JWT we returned.
+    let loaded = DeviceCredentials::load(&service)
+        .expect("load must succeed")
+        .expect("credentials must be present after register");
+    assert_eq!(loaded.jwt, mock_jwt, "stored JWT must match server response");
+    assert!(
+        loaded.hub_url.starts_with("http://127.0.0.1:"),
+        "stored hub URL must match the mock hub: got {}",
+        loaded.hub_url
+    );
+
+    // Best-effort cleanup — let the server's graceful_shutdown timeout run out.
+    drop(server_thread);
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+fn decode_hex(s: &str) -> Result<Vec<u8>, String> {
+    if !s.len().is_multiple_of(2) {
+        return Err("odd hex length".into());
+    }
+    let mut out = Vec::with_capacity(s.len() / 2);
+    for chunk in s.as_bytes().chunks(2) {
+        let hi = from_hex_digit(chunk[0])?;
+        let lo = from_hex_digit(chunk[1])?;
+        out.push((hi << 4) | lo);
+    }
+    Ok(out)
+}
+
+fn from_hex_digit(b: u8) -> Result<u8, String> {
+    match b {
+        b'0'..=b'9' => Ok(b - b'0'),
+        b'a'..=b'f' => Ok(b - b'a' + 10),
+        b'A'..=b'F' => Ok(b - b'A' + 10),
+        _ => Err(format!("bad hex digit: {}", b as char)),
+    }
+}
+


### PR DESCRIPTION
## Summary

Implements `phantom auth register --hub <url>` and the surrounding
`phantom auth status` / `phantom auth clear` CLI surface (issue #563).
This is the chokepoint that gates "Claude Code drives phantom via MCP" —
PR #562 (chat_with_brain) and the actual MCP-over-hub wiring follow this PR.

- New `phantom auth register --hub <url> [--service <name>]` performs the
  Ed25519 registration handshake, POSTs to `<hub>/auth/register`, and
  persists the issued JWT via `phantom_net::DeviceCredentials::store`
  (atomic-create + mode-0600 from post-#555).
- New `phantom auth status` prints stored credentials' peer-id and
  expiry without verifying the JWT signature; reports a friendly
  "not registered" message when nothing is stored.
- New `phantom auth clear` deletes the on-disk credentials file
  (idempotent).

## Wire-predicate fidelity

The signing predicate mirrors `phantom_hub::auth::verify_registration_signature`
**byte-for-byte**:

```
msg = nonce.as_bytes() || peer_id.as_bytes()
```

(see `crates/phantom-hub/src/auth.rs:576-578`). The integration test
`register_payload_includes_correct_signature` cross-validates the
CLI-built signature against the real hub verifier — any future drift in
the signed message construction (re-ordering, prefix injection, hashing)
fails this test before the bytes ever reach the wire.

## CLI restructure preserves all existing GUI usage

The dispatcher in `main.rs` checks `argv[1]` directly: only the literal
`phantom auth ...` invocation routes into the new clap parser. Every
existing flat-flag invocation — `phantom --headless`, `phantom --theme amber`,
`phantom --bloom 0 --scanlines 0` — falls through to the unchanged legacy
parser. Smoke-tested against `--headless`, `--theme amber`, `--help`, and
the new `auth --help` / `auth status` paths.

## Tests

4 integration tests in `crates/phantom/tests/auth_cli.rs` plus 2 unit tests:

- **`register_payload_includes_correct_signature`** — feeds the
  CLI-produced (peer_id, nonce, pubkey, signature) tuple into the real
  `phantom_hub::auth::verify_registration_signature` and asserts success;
  also asserts that flipping nonce or peer_id produces verification
  failure.
- **`status_reports_no_credentials_when_file_missing`** — friendly
  empty-state path returns `Ok(())`.
- **`clear_removes_credentials_file`** — also exercises idempotent
  second-clear.
- **`register_writes_credentials_on_200_response`** — drives `register`
  against an in-process axum mock hub on an ephemeral TCP port and
  asserts the credentials file is populated with the returned JWT.
- **Unit tests** — hex encoding lower-case round-trip; ISO-8601 expiry
  formatting.

## Dependencies added

- `clap` (workspace already uses derive elsewhere)
- `reqwest` blocking client (already present in `phantom-vision`,
  `phantom-stt`, `phantom-voice`, `phantom-embeddings`)
- `ed25519-dalek`, `jsonwebtoken`, `chrono`, `dirs`, `phantom-net`
  (runtime); `axum`, `tokio`, `tempfile`, `phantom-hub` (dev-only)

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test -p phantom` — 4/4 integration + 2/2 unit pass
- [x] `cargo test --workspace --no-run` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `./scripts/pre-pr-check.sh phantom` — PASS
- [x] `phantom --help` shows GUI flags AND auth subcommands
- [x] `phantom auth --help` shows register/status/clear
- [x] `phantom auth status` reports "not registered" gracefully
- [x] `phantom --theme amber` and `phantom --headless` preserved

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>