### PR TITLE
fix(phantom-net+phantom-mcp): send Authorization header on WS upgrade (closes #566)

### DIFF
--- a/crates/phantom-mcp/src/hub_listener.rs
+++ b/crates/phantom-mcp/src/hub_listener.rs
@@ -247,7 +247,17 @@ async fn connect_and_run(
 ) -> Result<()> {
     let peer_id_str = identity.peer_id.as_str().to_owned();
 
-    let mut client = RelayClient::connect(hub_url, identity).await?;
+    // Pass the device JWT through to the WS upgrade as
+    // `Authorization: Bearer <token>`.  An empty token means the credentials
+    // file has not been populated yet — connect without the header so the
+    // existing graceful-degradation path is preserved (the hub will reject
+    // with 4401 and the back-off loop will retry).
+    let token_opt = if device_token.is_empty() {
+        None
+    } else {
+        Some(device_token)
+    };
+    let mut client = RelayClient::connect_with_token(hub_url, identity, token_opt).await?;
     info!("hub_listener: connected — phantom_id={peer_id_str}");
 
     send_registration(&mut client, &peer_id_str, device_token).await?;

--- a/crates/phantom-net/src/client.rs
+++ b/crates/phantom-net/src/client.rs
@@ -75,8 +75,37 @@ impl RelayClient {
     /// Connect to the relay at `relay_url` and complete the handshake.
     ///
     /// Sends a `HELLO` control envelope and waits for a `HELLO_ACK` response.
+    ///
+    /// This variant performs the WebSocket upgrade with no `Authorization`
+    /// header.  Use [`RelayClient::connect_with_token`] when dialing a hub
+    /// that requires device-token auth.
     pub async fn connect(relay_url: &str, identity: Identity) -> Result<Self> {
-        let transport = WsTransport::connect(relay_url)
+        Self::connect_with_token(relay_url, identity, None).await
+    }
+
+    /// Connect to the relay at `relay_url` with an optional `Bearer` token
+    /// attached to the WebSocket upgrade request.
+    ///
+    /// When `device_token` is `Some(t)` and `t` is non-empty, the upgrade
+    /// request carries `Authorization: Bearer <t>`.  When the token is
+    /// `None` or `Some("")` no `Authorization` header is added — this
+    /// preserves the graceful-degradation path used before
+    /// `phantom auth register` has populated the credentials file.
+    pub async fn connect_with_token(
+        relay_url: &str,
+        identity: Identity,
+        device_token: Option<&str>,
+    ) -> Result<Self> {
+        let auth_value;
+        let headers: Vec<(&str, &str)> = match device_token {
+            Some(t) if !t.is_empty() => {
+                auth_value = format!("Bearer {t}");
+                vec![("Authorization", auth_value.as_str())]
+            }
+            _ => Vec::new(),
+        };
+
+        let transport = WsTransport::connect_with_headers(relay_url, &headers)
             .await
             .with_context(|| format!("failed to connect to relay: {relay_url}"))?;
 

--- a/crates/phantom-net/src/tests.rs
+++ b/crates/phantom-net/src/tests.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use futures_util::{SinkExt, StreamExt};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::Mutex;
 use tokio_tungstenite::{accept_async, tungstenite::Message};
@@ -23,6 +24,7 @@ use tokio_tungstenite::{accept_async, tungstenite::Message};
 use crate::{
     envelope::Envelope,
     identity::Identity,
+    transport::WsTransport,
 };
 
 // ---------------------------------------------------------------------------
@@ -198,4 +200,170 @@ async fn two_clients_exchange_one_message() {
 
     assert_eq!(received.from, alice_peer.to_string());
     assert_eq!(received.payload, payload);
+}
+
+// ---------------------------------------------------------------------------
+// Authorization header tests (issue #566)
+// ---------------------------------------------------------------------------
+
+/// Spawn a one-shot raw-TCP listener that captures the first request line
+/// and headers, then replies with `401 Unauthorized` to terminate the
+/// connection before any WebSocket upgrade completes.
+///
+/// Returns the bound address and a handle that resolves once the request
+/// has been read and the captured headers are available.
+async fn spawn_capture_listener() -> (SocketAddr, Arc<Mutex<Option<String>>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let captured: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+    let captured_writer = Arc::clone(&captured);
+
+    tokio::spawn(async move {
+        let (mut stream, _) = match listener.accept().await {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        let mut buf = [0u8; 4096];
+        let mut total = String::new();
+        // Read until we have a full HTTP request header block.
+        loop {
+            let n = match stream.read(&mut buf).await {
+                Ok(0) => break,
+                Ok(n) => n,
+                Err(_) => return,
+            };
+            if let Ok(s) = std::str::from_utf8(&buf[..n]) {
+                total.push_str(s);
+            }
+            if total.contains("\r\n\r\n") {
+                break;
+            }
+        }
+        *captured_writer.lock().await = Some(total);
+        // Reply with 401 to cleanly terminate the connection.
+        let _ = stream
+            .write_all(b"HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\n\r\n")
+            .await;
+        let _ = stream.shutdown().await;
+    });
+
+    (addr, captured)
+}
+
+#[tokio::test]
+async fn ws_transport_sends_authorization_header_when_provided() {
+    let (addr, captured) = spawn_capture_listener().await;
+    let url = format!("ws://{addr}");
+
+    // Connect with the Authorization header — the listener will reply 401
+    // so the connect call itself errors, but we only care about the
+    // captured request.
+    let _ = WsTransport::connect_with_headers(&url, &[("Authorization", "Bearer testjwt")])
+        .await;
+
+    // Give the listener a moment to record the request.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let req = captured
+        .lock()
+        .await
+        .clone()
+        .expect("listener must capture the upgrade request");
+    let lower = req.to_lowercase();
+    assert!(
+        lower.contains("authorization: bearer testjwt"),
+        "upgrade request must carry Authorization header — got:\n{req}"
+    );
+}
+
+#[tokio::test]
+async fn ws_transport_omits_authorization_header_when_no_headers() {
+    let (addr, captured) = spawn_capture_listener().await;
+    let url = format!("ws://{addr}");
+
+    let _ = WsTransport::connect(&url).await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let req = captured
+        .lock()
+        .await
+        .clone()
+        .expect("listener must capture the upgrade request");
+    assert!(
+        !req.to_lowercase().contains("authorization:"),
+        "plain connect must not add Authorization header — got:\n{req}"
+    );
+}
+
+#[tokio::test]
+async fn relay_client_connect_with_token_attaches_bearer_header() {
+    let (addr, captured) = spawn_capture_listener().await;
+    let url = format!("ws://{addr}");
+
+    // Connect attempts will fail (handshake never completes — the listener
+    // returns 401), but the request line will be captured first.
+    let id = Identity::generate_ephemeral();
+    let _ = crate::client::RelayClient::connect_with_token(
+        &url,
+        id,
+        Some("token-abc"),
+    )
+    .await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let req = captured
+        .lock()
+        .await
+        .clone()
+        .expect("listener must capture the upgrade request");
+    let lower = req.to_lowercase();
+    assert!(
+        lower.contains("authorization: bearer token-abc"),
+        "RelayClient::connect_with_token must attach Bearer header — got:\n{req}"
+    );
+}
+
+#[tokio::test]
+async fn relay_client_connect_with_empty_token_omits_authorization() {
+    let (addr, captured) = spawn_capture_listener().await;
+    let url = format!("ws://{addr}");
+
+    let id = Identity::generate_ephemeral();
+    let _ =
+        crate::client::RelayClient::connect_with_token(&url, id, Some("")).await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let req = captured
+        .lock()
+        .await
+        .clone()
+        .expect("listener must capture the upgrade request");
+    assert!(
+        !req.to_lowercase().contains("authorization:"),
+        "empty device_token must not produce an Authorization header — got:\n{req}"
+    );
+}
+
+#[tokio::test]
+async fn relay_client_connect_with_none_token_omits_authorization() {
+    let (addr, captured) = spawn_capture_listener().await;
+    let url = format!("ws://{addr}");
+
+    let id = Identity::generate_ephemeral();
+    let _ = crate::client::RelayClient::connect_with_token(&url, id, None).await;
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let req = captured
+        .lock()
+        .await
+        .clone()
+        .expect("listener must capture the upgrade request");
+    assert!(
+        !req.to_lowercase().contains("authorization:"),
+        "None token must not produce an Authorization header — got:\n{req}"
+    );
 }

--- a/crates/phantom-net/src/transport.rs
+++ b/crates/phantom-net/src/transport.rs
@@ -14,7 +14,11 @@ use futures_util::{SinkExt, StreamExt};
 use tokio::net::TcpStream;
 use tokio_tungstenite::{
     connect_async,
-    tungstenite::Message,
+    tungstenite::{
+        client::IntoClientRequest,
+        http::{HeaderName, HeaderValue},
+        Message,
+    },
     MaybeTlsStream, WebSocketStream,
 };
 
@@ -34,9 +38,41 @@ pub struct WsTransport {
 impl WsTransport {
     /// Open a WebSocket connection to `url` (e.g. `"wss://relay.example.com"`).
     pub async fn connect(url: &str) -> Result<Self> {
-        let (ws, _response) = connect_async(url)
-            .await
-            .with_context(|| format!("WebSocket connect failed: {url}"))?;
+        Self::connect_with_headers(url, &[]).await
+    }
+
+    /// Open a WebSocket connection to `url` with extra HTTP headers attached
+    /// to the upgrade request.
+    ///
+    /// Each `(name, value)` pair is inserted into the upgrade request's
+    /// header map verbatim.  Use this to send `Authorization: Bearer <jwt>`
+    /// when dialing a hub that requires device-token auth.
+    ///
+    /// When `headers` is empty this is equivalent to [`Self::connect`].
+    pub async fn connect_with_headers(
+        url: &str,
+        headers: &[(&str, &str)],
+    ) -> Result<Self> {
+        let (ws, _response) = if headers.is_empty() {
+            connect_async(url)
+                .await
+                .with_context(|| format!("WebSocket connect failed: {url}"))?
+        } else {
+            let mut request = url
+                .into_client_request()
+                .with_context(|| format!("invalid WS URL: {url}"))?;
+            let header_map = request.headers_mut();
+            for (name, value) in headers {
+                let header_name = HeaderName::from_bytes(name.as_bytes())
+                    .with_context(|| format!("invalid header name: {name}"))?;
+                let header_value = HeaderValue::from_str(value)
+                    .with_context(|| format!("invalid header value for {name}"))?;
+                header_map.insert(header_name, header_value);
+            }
+            connect_async(request)
+                .await
+                .with_context(|| format!("WebSocket connect failed: {url}"))?
+        };
         Ok(Self {
             ws,
             connected: true,


### PR DESCRIPTION
## Summary

Hub-side `GET /phantom/connect` verifies a Bearer JWT on the upgrade request and rejects with 401 when it is missing. `phantom-net::WsTransport::connect` was calling `tokio_tungstenite::connect_async(url)` with no header support, so `phantom-mcp::hub_listener` could never authenticate. This blocks the entire MCP control plane from connecting to a hub that has auth enabled.

## Changes

- **phantom-net::transport** — `WsTransport` gains `connect_with_headers(url, &[(name, value)])` using tungstenite's `IntoClientRequest` path. The bare `connect(url)` is preserved.
- **phantom-net::client** — `RelayClient` gains `connect_with_token(url, identity, Option<&str>)`. Existing `connect(url, identity)` signature is preserved (relay tests + peer-to-peer code rely on it). Empty or `None` token results in NO `Authorization` header being added — preserves graceful-degradation path before `phantom auth register` has populated credentials.
- **phantom-mcp::hub_listener** — `connect_and_run` now passes the loaded device JWT through to the upgrade. Empty token still attempts the connection so the existing retry-with-back-off path keeps working.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test -p phantom-net` — 40 passed (5 new)
- [x] `cargo test -p phantom-mcp` — 77 passed (existing hub_listener tests still green)
- [x] `cargo test -p phantom-relay` — 5 passed (mock-relay path uses `RelayClient::connect`, unchanged)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `./scripts/pre-pr-check.sh phantom-net` PASS
- [x] `./scripts/pre-pr-check.sh phantom-mcp` PASS

### New tests

All five use a raw TCP listener that captures the HTTP upgrade request line and headers, then replies `401` to terminate cleanly:

- `ws_transport_sends_authorization_header_when_provided`
- `ws_transport_omits_authorization_header_when_no_headers`
- `relay_client_connect_with_token_attaches_bearer_header`
- `relay_client_connect_with_empty_token_omits_authorization`
- `relay_client_connect_with_none_token_omits_authorization`

Header matching is case-insensitive — tungstenite lowercases header names on the wire (`authorization` vs `Authorization`).

## Back-compat

- `WsTransport::connect(url)` signature preserved.
- `RelayClient::connect(url, identity)` signature preserved.
- `phantom-relay` mock-hub tests unaffected (they call `connect`, not `connect_with_token`).
- Empty `device_token` still produces no `Authorization` header — graceful degradation when credentials file has not been populated yet.

Closes #566

Generated with [Claude Code](https://claude.com/claude-code)