### PR TITLE
feat(phantom-semantic): parse_with_timing + classification_notes

### DIFF
--- a/crates/phantom-agents/src/suggest.rs
+++ b/crates/phantom-agents/src/suggest.rs
@@ -277,6 +277,7 @@ mod tests {
             warnings,
             duration_ms: None,
             raw_output: raw_output.to_string(),
+            classification_notes: vec![],
         }
     }
 

--- a/crates/phantom-app/src/update.rs
+++ b/crates/phantom-app/src/update.rs
@@ -796,6 +796,7 @@ impl App {
                                 warnings: Vec::new(),
                                 duration_ms: None,
                                 raw_output: String::new(),
+                                classification_notes: Vec::new(),
                             });
                         Some(AiEvent::CommandComplete(parsed))
                     }
@@ -1870,6 +1871,7 @@ mod tests {
                 warnings: Vec::new(),
                 duration_ms: None,
                 raw_output: String::new(),
+                classification_notes: Vec::new(),
             }
         }
 

--- a/crates/phantom-app/tests/phase5_integration.rs
+++ b/crates/phantom-app/tests/phase5_integration.rs
@@ -785,5 +785,6 @@ fn error_output(msg: &str) -> phantom_semantic::ParsedOutput {
         warnings: vec![],
         duration_ms: Some(1000),
         raw_output: msg.into(),
+        classification_notes: vec![],
     }
 }

--- a/crates/phantom-brain/src/brain.rs
+++ b/crates/phantom-brain/src/brain.rs
@@ -1652,6 +1652,7 @@ mod tests {
             warnings: vec![],
             duration_ms: Some(10),
             raw_output: "file1\nfile2".into(),
+            classification_notes: vec![],
         };
 
         orient(&AiEvent::CommandComplete(parsed), &mut scorer);
@@ -1730,6 +1731,7 @@ mod tests {
             warnings: vec![],
             duration_ms: Some(2000),
             raw_output: "errors".into(),
+            classification_notes: vec![],
         }
     }
 
@@ -1745,6 +1747,7 @@ mod tests {
             warnings: vec![],
             duration_ms: Some(500),
             raw_output: "error".into(),
+            classification_notes: vec![],
         }
     }
 

--- a/crates/phantom-brain/src/lib.rs
+++ b/crates/phantom-brain/src/lib.rs
@@ -167,6 +167,7 @@ mod tests {
             warnings: vec![],
             duration_ms: Some(1500),
             raw_output: "error[E0308]: mismatched types".into(),
+            classification_notes: vec![],
         }
     }
 
@@ -181,6 +182,7 @@ mod tests {
             warnings: vec![],
             duration_ms: Some(800),
             raw_output: "Compiling phantom v0.1.0\n    Finished".into(),
+            classification_notes: vec![],
         }
     }
 

--- a/crates/phantom-brain/src/proactive.rs
+++ b/crates/phantom-brain/src/proactive.rs
@@ -1310,6 +1310,7 @@ mod tests {
             warnings: vec![],
             duration_ms: Some(800),
             raw_output: "error[E0308]: mismatched types".into(),
+            classification_notes: vec![],
         }
     }
 
@@ -1324,6 +1325,7 @@ mod tests {
             warnings: vec![],
             duration_ms: Some(400),
             raw_output: "Finished".into(),
+            classification_notes: vec![],
         }
     }
 

--- a/crates/phantom-brain/src/router.rs
+++ b/crates/phantom-brain/src/router.rs
@@ -637,6 +637,7 @@ mod tests {
             warnings: vec![],
             duration_ms: Some(5),
             raw_output: "file1".into(),
+            classification_notes: vec![],
         }
     }
 
@@ -650,6 +651,7 @@ mod tests {
             warnings: vec![],
             duration_ms: Some(500),
             raw_output: "error: type mismatch".into(),
+            classification_notes: vec![],
         }
     }
 
@@ -667,6 +669,7 @@ mod tests {
             warnings: vec![],
             duration_ms: Some(2000),
             raw_output: "errors".into(),
+            classification_notes: vec![],
         }
     }
 

--- a/crates/phantom-brain/src/scoring.rs
+++ b/crates/phantom-brain/src/scoring.rs
@@ -440,6 +440,7 @@ impl UtilityScorer {
                     warnings: vec![],
                     duration_ms: None,
                     raw_output: String::new(),
+                    classification_notes: vec![],
                 };
                 candidates.push(self.explain_score(&synthetic, *seconds));
             }

--- a/crates/phantom-semantic/src/errors.rs
+++ b/crates/phantom-semantic/src/errors.rs
@@ -747,6 +747,7 @@ error: aborting due to 1 previous error
             warnings: vec![],
             duration_ms: None,
             raw_output: "error: err1\nerror: err2\n".to_string(),
+            classification_notes: vec![],
         };
         let s = ErrorHighlighter::error_summary(&parsed).unwrap();
         assert!(s.contains("2 errors"), "got: {s}");

--- a/crates/phantom-semantic/src/lib.rs
+++ b/crates/phantom-semantic/src/lib.rs
@@ -590,12 +590,12 @@ found 0 vulnerabilities
         assert!(deser["command_type"].is_object() || deser["command_type"].is_string());
     }
     // =======================================================================
-    // parse_with_timing
+    // parse_with_command_timing
     // =======================================================================
 
     #[test]
-    fn parse_with_timing_stores_elapsed_ms() {
-        let out = SemanticParser::parse_with_timing(
+    fn parse_with_command_timing_stores_elapsed_ms() {
+        let out = SemanticParser::parse_with_command_timing(
             "echo hello",
             "hello",
             "",
@@ -606,13 +606,13 @@ found 0 vulnerabilities
     }
 
     #[test]
-    fn parse_with_timing_same_result_as_parse() {
+    fn parse_with_command_timing_same_result_as_parse() {
         let cmd = "cargo build";
         let stderr = "error[E0308]: mismatched types
   --> src/main.rs:10:5
 ";
         let base = SemanticParser::parse(cmd, "", stderr, Some(101));
-        let timed = SemanticParser::parse_with_timing(cmd, "", stderr, Some(101), 999);
+        let timed = SemanticParser::parse_with_command_timing(cmd, "", stderr, Some(101), 999);
 
         // All fields except duration_ms must match.
         assert_eq!(timed.command, base.command);

--- a/crates/phantom-semantic/src/lib.rs
+++ b/crates/phantom-semantic/src/lib.rs
@@ -589,4 +589,72 @@ found 0 vulnerabilities
         assert_eq!(deser["command"], "git status");
         assert!(deser["command_type"].is_object() || deser["command_type"].is_string());
     }
+    // =======================================================================
+    // parse_with_timing
+    // =======================================================================
+
+    #[test]
+    fn parse_with_timing_stores_elapsed_ms() {
+        let out = SemanticParser::parse_with_timing(
+            "echo hello",
+            "hello",
+            "",
+            Some(0),
+            42,
+        );
+        assert_eq!(out.duration_ms, Some(42));
+    }
+
+    #[test]
+    fn parse_with_timing_same_result_as_parse() {
+        let cmd = "cargo build";
+        let stderr = "error[E0308]: mismatched types
+  --> src/main.rs:10:5
+";
+        let base = SemanticParser::parse(cmd, "", stderr, Some(101));
+        let timed = SemanticParser::parse_with_timing(cmd, "", stderr, Some(101), 999);
+
+        // All fields except duration_ms must match.
+        assert_eq!(timed.command, base.command);
+        assert_eq!(timed.command_type, base.command_type);
+        assert_eq!(timed.exit_code, base.exit_code);
+        assert_eq!(timed.content_type, base.content_type);
+        assert_eq!(timed.errors.len(), base.errors.len());
+        assert_eq!(timed.warnings.len(), base.warnings.len());
+        assert_eq!(timed.raw_output, base.raw_output);
+        // duration_ms differs.
+        assert_eq!(timed.duration_ms, Some(999));
+    }
+
+    // =======================================================================
+    // classification_notes
+    // =======================================================================
+
+    #[test]
+    fn classification_notes_populated_on_json_failure() {
+        // Starts with '{' but is not valid JSON.
+        let stdout = "{not valid json at all";
+        let out = SemanticParser::parse("echo test", stdout, "", Some(0));
+        assert_eq!(out.content_type, ContentType::PlainText);
+        assert!(
+            out.classification_notes
+                .iter()
+                .any(|n| n.starts_with("json_parse_failed")),
+            "expected json_parse_failed note, got: {:?}",
+            out.classification_notes
+        );
+    }
+
+    #[test]
+    fn classification_notes_empty_on_clean_parse() {
+        let stdout = r#"{"name": "phantom", "version": "0.1.0"}"#;
+        let out = SemanticParser::parse("echo test", stdout, "", Some(0));
+        assert_eq!(out.content_type, ContentType::Json);
+        assert!(
+            out.classification_notes.is_empty(),
+            "expected no notes on successful JSON parse, got: {:?}",
+            out.classification_notes
+        );
+    }
+
 }

--- a/crates/phantom-semantic/src/parser.rs
+++ b/crates/phantom-semantic/src/parser.rs
@@ -236,7 +236,7 @@ impl SemanticParser {
             format!("{stdout}\n{stderr}")
         };
 
-        let (content_type, errors, warnings) =
+        let (content_type, errors, warnings, classification_notes) =
             Self::parse_output(&command_type, stdout, stderr, &combined);
 
         ParsedOutput {
@@ -248,7 +248,23 @@ impl SemanticParser {
             warnings,
             duration_ms: None,
             raw_output: combined,
+            classification_notes,
         }
+    }
+
+    /// Like [] but records  in
+    /// [].
+    #[must_use]
+    pub fn parse_with_timing(
+        cmd: &str,
+        stdout: &str,
+        stderr: &str,
+        exit_code: Option<i32>,
+        elapsed_ms: u64,
+    ) -> ParsedOutput {
+        let mut result = Self::parse(cmd, stdout, stderr, exit_code);
+        result.duration_ms = Some(elapsed_ms);
+        result
     }
 
     // -----------------------------------------------------------------------
@@ -328,26 +344,30 @@ impl SemanticParser {
     // -----------------------------------------------------------------------
 
     /// Orchestrate content-type detection and error extraction.
+    /// Returns (content_type, errors, warnings, classification_notes).
     fn parse_output(
         cmd_type: &CommandType,
         stdout: &str,
         stderr: &str,
         combined: &str,
-    ) -> (ContentType, Vec<DetectedError>, Vec<DetectedError>) {
+    ) -> (ContentType, Vec<DetectedError>, Vec<DetectedError>, Vec<String>) {
         match cmd_type {
             CommandType::Git(GitCommand::Status) => {
                 let ct = Self::parse_git_status(combined);
-                (ct, vec![], vec![])
+                (ct, vec![], vec![], vec![])
             }
             CommandType::Git(GitCommand::Log) => {
                 let ct = Self::parse_git_log(combined);
-                (ct, vec![], vec![])
+                (ct, vec![], vec![], vec![])
             }
-            CommandType::Git(GitCommand::Diff) => (ContentType::GitDiff, vec![], vec![]),
-            CommandType::Cargo(_) => Self::parse_cargo_output(stdout, stderr),
+            CommandType::Git(GitCommand::Diff) => (ContentType::GitDiff, vec![], vec![], vec![]),
+            CommandType::Cargo(_) => {
+                let (ct, errs, warns) = Self::parse_cargo_output(stdout, stderr);
+                (ct, errs, warns, vec![])
+            }
             CommandType::Http(_) => {
                 if let Some(ct) = Self::parse_http_response(combined) {
-                    (ct, vec![], vec![])
+                    (ct, vec![], vec![], vec![])
                 } else {
                     Self::fallback_content_type(combined)
                 }
@@ -365,16 +385,42 @@ impl SemanticParser {
     }
 
     /// Try JSON, then table, then plain text.
+    ///
+    /// Pushes a diagnostic note into the returned Vec<String> whenever a
+    /// structured content type could not be detected, so callers (e.g. the
+    /// brain scoring loop) can see that classification was degraded.
     fn fallback_content_type(
         output: &str,
-    ) -> (ContentType, Vec<DetectedError>, Vec<DetectedError>) {
-        if let Some(ct) = Self::parse_json(output) {
-            return (ct, vec![], vec![]);
+    ) -> (ContentType, Vec<DetectedError>, Vec<DetectedError>, Vec<String>) {
+        let trimmed = output.trim();
+
+        // Attempt JSON detection first.
+        if !trimmed.is_empty() && (trimmed.starts_with('{') || trimmed.starts_with('[')) {
+            if serde_json::from_str::<serde_json::Value>(trimmed).is_ok() {
+                return (ContentType::Json, vec![], vec![], vec![]);
+            }
+            // Starts with JSON-like characters but failed to parse.
+            let notes = vec!["json_parse_failed: input not valid JSON".to_string()];
+            if let Some(ct) = Self::detect_table(output) {
+                return (ct, vec![], vec![], notes);
+            }
+            return (ContentType::PlainText, vec![], vec![], notes);
         }
+
+        // No JSON gate triggered — try table.
         if let Some(ct) = Self::detect_table(output) {
-            return (ct, vec![], vec![]);
+            return (ct, vec![], vec![], vec![]);
         }
-        (ContentType::PlainText, vec![], vec![])
+
+        // Table detection failed; emit a note only when there was enough content
+        // to reasonably expect tabular structure (2+ non-empty lines).
+        let line_count = output.lines().filter(|l| !l.trim().is_empty()).count();
+        let notes = if line_count >= 2 {
+            vec!["table_detect_failed: insufficient columns".to_string()]
+        } else {
+            vec![]
+        };
+        (ContentType::PlainText, vec![], vec![], notes)
     }
 
     // -- git status ---------------------------------------------------------
@@ -683,25 +729,6 @@ impl SemanticParser {
             total,
             failures,
         })
-    }
-
-    // -- JSON detection -----------------------------------------------------
-
-    fn parse_json(output: &str) -> Option<ContentType> {
-        let trimmed = output.trim();
-        if trimmed.is_empty() {
-            return None;
-        }
-        // Quick gate: must start with { or [
-        if !trimmed.starts_with('{') && !trimmed.starts_with('[') {
-            return None;
-        }
-        // Try to parse as valid JSON.
-        if serde_json::from_str::<serde_json::Value>(trimmed).is_ok() {
-            Some(ContentType::Json)
-        } else {
-            None
-        }
     }
 
     // -- HTTP response parsing (curl -i) ------------------------------------

--- a/crates/phantom-semantic/src/parser.rs
+++ b/crates/phantom-semantic/src/parser.rs
@@ -252,10 +252,15 @@ impl SemanticParser {
         }
     }
 
-    /// Like [] but records  in
-    /// [].
+    /// Like [`SemanticParser::parse`] but stamps the caller-measured command
+    /// duration `elapsed_ms` into [`ParsedOutput::duration_ms`].
+    ///
+    /// Use this when the shell layer has already measured how long the command
+    /// ran (wall-clock) and wants to embed that into the parsed result for the
+    /// brain scoring loop.  This is distinct from [`parse_with_timing`], which
+    /// measures the latency of the parse operation itself.
     #[must_use]
-    pub fn parse_with_timing(
+    pub fn parse_with_command_timing(
         cmd: &str,
         stdout: &str,
         stderr: &str,
@@ -374,11 +379,11 @@ impl SemanticParser {
             }
             CommandType::Docker(sub) => {
                 let ct = Self::parse_docker_output(sub, combined);
-                (ct, vec![], vec![])
+                (ct, vec![], vec![], vec![])
             }
             CommandType::Npm(sub) => {
                 let ct = Self::parse_npm_output(sub, combined);
-                (ct, vec![], vec![])
+                (ct, vec![], vec![], vec![])
             }
             _ => Self::fallback_content_type(combined),
         }

--- a/crates/phantom-semantic/src/types.rs
+++ b/crates/phantom-semantic/src/types.rs
@@ -224,4 +224,8 @@ pub struct ParsedOutput {
     pub duration_ms: Option<u64>,
     /// Full raw stdout+stderr concatenated.
     pub raw_output: String,
+    /// Diagnostic notes recorded during classification (e.g. why JSON/table
+    /// detection fell back to PlainText).  Empty on a successful classification.
+    #[serde(default)]
+    pub classification_notes: Vec<String>,
 }


### PR DESCRIPTION
## Summary

- **Fix 1 (HIGH)**: `SemanticParser::parse_with_timing()` — wraps `parse()` and stamps `duration_ms` on the returned `ParsedOutput`. Brain scoring loop can now track command duration without re-parsing. Signature: `parse_with_timing(cmd, stdout, stderr, exit_code, elapsed_ms) -> ParsedOutput`.

- **Fix 2 (MED)**: `ParsedOutput::classification_notes: Vec<String>` — when `fallback_content_type()` cannot classify output as JSON or table, it pushes a diagnostic string (`"json_parse_failed: input not valid JSON"` or `"table_detect_failed: insufficient columns"`). Field is `#[serde(default)]` so existing serialized records deserialize cleanly. All `ParsedOutput` struct literals across phantom-app, phantom-agents, and phantom-brain updated with `classification_notes: vec![]`.

- `parse_json()` private helper removed — its logic is inlined into `fallback_content_type()` (no public API change).

- `parse_output()` return type extended to 4-tuple `(ContentType, Vec<DetectedError>, Vec<DetectedError>, Vec<String>)`.

## Test plan

- [ ] `parse_with_timing_stores_elapsed_ms` — `duration_ms` is set on returned output
- [ ] `parse_with_timing_same_result_as_parse` — all other fields match `parse()` return value
- [ ] `classification_notes_populated_on_json_failure` — stdout starting with `{` but invalid JSON emits a note
- [ ] `classification_notes_empty_on_clean_parse` — valid JSON stdout produces empty notes
- [ ] All 56 `phantom-semantic` tests pass (`cargo test -p phantom-semantic`)
- [ ] `scripts/pre-pr-check.sh phantom-semantic` passes (build + test + clippy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)