### PR TITLE
feat(search): find-in-terminal search bar with scrollback index (Cmd+F)

### DIFF
--- a/crates/phantom-app/src/adapters/terminal.rs
+++ b/crates/phantom-app/src/adapters/terminal.rs
@@ -638,6 +638,52 @@ impl Commandable for TerminalAdapter {
                 self.terminal.update_selection(end, Side::Right);
                 Ok("all selected".into())
             }
+            "update_search" => {
+                let query = args
+                    .get("query")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                self.terminal.update_search(query);
+                Ok(format!(
+                    "search updated: {} matches",
+                    self.terminal.search_index.total_matches()
+                ))
+            }
+            "search_info" => {
+                let total = self.terminal.search_index.total_matches();
+                let active = self.terminal.search_active;
+                Ok(serde_json::json!({ "total": total, "active": active }).to_string())
+            }
+            "scroll_to_search_match" => {
+                let idx = args
+                    .get("index")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0) as usize;
+                if let Some((row, _col)) = self.terminal.search_index.nth_match(idx) {
+                    // Convert the signed row (Line) to a display offset.
+                    // Negative rows are above the viewport (in scrollback);
+                    // positive rows are within the viewport.
+                    // To centre the match we scroll so the row lands roughly
+                    // in the middle of the visible area.
+                    let rows = self.terminal.size().rows as i32;
+                    let margin = (rows / 2).max(1);
+                    if row < 0 {
+                        // row = -(distance from top of viewport), so we need
+                        // display_offset = |row| + margin to bring it into view.
+                        let target_offset = ((-row) + margin) as usize;
+                        let current = self.terminal.display_offset();
+                        if target_offset > current {
+                            self.terminal.scroll_up(target_offset - current);
+                        } else if target_offset < current {
+                            self.terminal.scroll_down(current - target_offset);
+                        }
+                    } else {
+                        // Row is within the viewport — scroll to bottom to show it.
+                        self.terminal.scroll_to_bottom();
+                    }
+                }
+                Ok("scrolled to match".into())
+            }
             other => Err(anyhow::anyhow!("unknown command: {other}")),
         }
     }

--- a/crates/phantom-app/src/app.rs
+++ b/crates/phantom-app/src/app.rs
@@ -27,7 +27,7 @@ use phantom_terminal::terminal::PhantomTerminal;
 use phantom_ui::keybinds::KeybindRegistry;
 use phantom_ui::layout::LayoutEngine;
 use phantom_ui::themes::Theme;
-use phantom_ui::widgets::{KeybindHelp, StatusBar, TabBar};
+use phantom_ui::widgets::{KeybindHelp, SearchBar, StatusBar, TabBar};
 
 use phantom_adapter::{DataType, EventBus, TopicId};
 use phantom_brain::brain::{BrainConfig, BrainHandle, spawn_brain};
@@ -128,6 +128,9 @@ pub struct App {
     pub(crate) tab_bar: TabBar,
     /// Full-screen keybind help overlay (F1 / ?).
     pub(crate) keybind_help: KeybindHelp,
+
+    // -- Find-in-terminal search bar (Cmd+F) --
+    pub(crate) search_bar: SearchBar,
 
     // -- Boot sequence --
     pub(crate) boot: BootSequence,
@@ -1327,6 +1330,7 @@ impl App {
             status_bar,
             tab_bar,
             keybind_help: KeybindHelp::new(),
+            search_bar: SearchBar::new(),
             boot,
             state: initial_state,
             demo_mode: config.demo_mode,

--- a/crates/phantom-app/src/input.rs
+++ b/crates/phantom-app/src/input.rs
@@ -541,6 +541,59 @@ impl App {
             return;
         }
 
+        // Cmd+F (super+f on macOS) — toggle find-in-terminal search bar.
+        if modifiers.state().super_key()
+            && matches!(&event.logical_key, Key::Character(s) if s.as_str() == "f" || s.as_str() == "F")
+        {
+            self.search_bar.toggle();
+            debug!("Search bar toggled: visible={}", self.search_bar.visible);
+            return;
+        }
+
+        // Search bar captures keys when visible (before they reach the PTY).
+        if self.search_bar.visible {
+            use phantom_ui::widgets::SearchKey;
+            use phantom_ui::widgets::SearchBarAction;
+
+            let action = match &event.logical_key {
+                Key::Named(NamedKey::Escape) => self.search_bar.handle_key(SearchKey::Escape),
+                Key::Named(NamedKey::Enter) => self.search_bar.handle_key(SearchKey::Enter),
+                Key::Named(NamedKey::Backspace) => self.search_bar.handle_key(SearchKey::Backspace),
+                Key::Named(NamedKey::Delete) => self.search_bar.handle_key(SearchKey::Delete),
+                Key::Named(NamedKey::ArrowLeft) => self.search_bar.handle_key(SearchKey::Left),
+                Key::Named(NamedKey::ArrowRight) => self.search_bar.handle_key(SearchKey::Right),
+                Key::Named(NamedKey::ArrowUp) => self.search_bar.handle_key(SearchKey::Up),
+                Key::Named(NamedKey::ArrowDown) => self.search_bar.handle_key(SearchKey::Down),
+                Key::Named(NamedKey::Home) => self.search_bar.handle_key(SearchKey::Home),
+                Key::Named(NamedKey::End) => self.search_bar.handle_key(SearchKey::End),
+                Key::Character(s) => {
+                    if let Some(ch) = s.chars().next() {
+                        self.search_bar.handle_char(ch)
+                    } else {
+                        SearchBarAction::None
+                    }
+                }
+                _ => SearchBarAction::None,
+            };
+
+            match action {
+                SearchBarAction::QueryChanged(query) => {
+                    self.update_search_query(&query);
+                }
+                SearchBarAction::Next => {
+                    self.advance_search_match(1);
+                }
+                SearchBarAction::Prev => {
+                    self.advance_search_match(-1);
+                }
+                SearchBarAction::Close => {
+                    self.clear_search();
+                }
+                SearchBarAction::None => {}
+            }
+            return;
+        }
+
         if !modifiers.state().control_key()
             && !modifiers.state().alt_key()
             && !modifiers.state().super_key()

--- a/crates/phantom-app/src/lib.rs
+++ b/crates/phantom-app/src/lib.rs
@@ -29,6 +29,7 @@ mod pane;
 pub mod profiler;
 mod render;
 mod render_overlay;
+mod search;
 pub mod resources;
 pub mod runtime;
 mod selftest;

--- a/crates/phantom-app/src/render.rs
+++ b/crates/phantom-app/src/render.rs
@@ -227,6 +227,11 @@ impl App {
                 self.build_keybind_help_overlay(screen_size, &mut chrome_quads, &mut chrome_glyphs);
             }
 
+            // -- Find-in-terminal search bar (Cmd+F) --
+            if self.search_bar.visible {
+                self.build_search_overlay(&mut chrome_quads, &mut chrome_glyphs);
+            }
+
             // -- Alt-screen bezier tether (issue #323) --
             if !self.alt_screen_secondaries.is_empty() {
                 self.build_alt_screen_tether(&mut chrome_quads);

--- a/crates/phantom-app/src/search.rs
+++ b/crates/phantom-app/src/search.rs
@@ -1,0 +1,120 @@
+//! Find-in-terminal search coordination.
+//!
+//! Bridges the [`crate::app::App::search_bar`] widget with the
+//! `update_search` adapter command, routing query changes and navigation
+//! requests through the coordinator.
+//!
+//! Three entry points are called from `input.rs`:
+//! - [`App::update_search_query`] — rebuild the index after the query changed.
+//! - [`App::advance_search_match`] — step forward (+1) or back (-1) through
+//!   the match list, scrolling the terminal to keep the hit in view.
+//! - [`App::clear_search`] — clear the index and deactivate search mode.
+
+use log::debug;
+
+use crate::app::App;
+
+impl App {
+    /// Send the new `query` to the focused terminal adapter and update the
+    /// search bar's match counter from the response.
+    pub(crate) fn update_search_query(&mut self, query: &str) {
+        if let Some(focused) = self.coordinator.focused() {
+            let _ = self.coordinator.send_command(
+                focused,
+                "update_search",
+                &serde_json::json!({ "query": query }),
+            );
+
+            // Read back the match count to update the widget display.
+            if let Ok(info_json) = self.coordinator.send_command(
+                focused,
+                "search_info",
+                &serde_json::json!({}),
+            ) && let Ok(v) = serde_json::from_str::<serde_json::Value>(&info_json) {
+                let total = v.get("total").and_then(|x| x.as_u64()).unwrap_or(0) as usize;
+                // Reset to match 1 on every query change.
+                self.search_bar.set_match_info(total, 1);
+                debug!("Search query {:?}: {} matches", query, total);
+            }
+        }
+    }
+
+    /// Step through search matches by `delta` (+1 = next, -1 = prev).
+    ///
+    /// Wraps around at the boundary so the user can keep pressing and cycle
+    /// through all results. No-ops when there are no matches.
+    pub(crate) fn advance_search_match(&mut self, delta: i32) {
+        // We don't store a "current_match_index" separately — the search bar
+        // tracks `current_match` (1-indexed). Derive the 0-indexed slot.
+        let total = self.search_bar.match_count();
+        if total == 0 {
+            return;
+        }
+
+        let current_1 = self.search_bar.current_match().max(1);
+        let next_0 = (current_1 as i32 - 1 + delta).rem_euclid(total as i32) as usize;
+        let next_1 = next_0 + 1;
+
+        self.search_bar.set_match_info(total, next_1);
+
+        // Scroll the focused terminal to put the nth match in view.
+        if let Some(focused) = self.coordinator.focused() {
+            let _ = self.coordinator.send_command(
+                focused,
+                "scroll_to_search_match",
+                &serde_json::json!({ "index": next_0 }),
+            );
+        }
+    }
+
+    /// Clear the search index and hide the search bar.
+    pub(crate) fn clear_search(&mut self) {
+        self.search_bar.set_match_info(0, 0);
+        if let Some(focused) = self.coordinator.focused() {
+            let _ = self.coordinator.send_command(
+                focused,
+                "update_search",
+                &serde_json::json!({ "query": "" }),
+            );
+        }
+        debug!("Search cleared");
+    }
+
+    /// Render the search bar overlay quads and text into the pre-allocated
+    /// chrome buffers. Called from `render.rs` after the terminal cells are
+    /// rendered.
+    pub(crate) fn build_search_overlay(
+        &mut self,
+        quads: &mut Vec<phantom_renderer::quads::QuadInstance>,
+        glyphs: &mut Vec<phantom_renderer::text::GlyphInstance>,
+    ) {
+        if !self.search_bar.visible {
+            return;
+        }
+
+        // Find the pane rect for the focused adapter.
+        let pane_rect = self
+            .coordinator
+            .focused()
+            .and_then(|id| self.coordinator.pane_id_for(id))
+            .and_then(|pane| self.layout.get_pane_rect(pane).ok());
+
+        let pane_rect = match pane_rect {
+            Some(r) => phantom_ui::layout::Rect {
+                x: r.x,
+                y: r.y,
+                width: r.width,
+                height: r.height,
+            },
+            None => return,
+        };
+
+        // Quads.
+        quads.extend(self.search_bar.render_quads(&pane_rect));
+
+        // Text segments → glyph instances.
+        for seg in self.search_bar.render_text(&pane_rect) {
+            self.render_overlay_text(&seg.text, seg.x, seg.y, seg.color, glyphs);
+        }
+    }
+}

--- a/crates/phantom-terminal/src/lib.rs
+++ b/crates/phantom-terminal/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod alt_screen;
 pub mod process;
+pub mod search;
 pub mod takeover;
 pub mod terminal;
 pub mod input;

--- a/crates/phantom-terminal/src/search.rs
+++ b/crates/phantom-terminal/src/search.rs
@@ -1,0 +1,208 @@
+//! Scrollback search index for find-in-terminal (Cmd+F).
+//!
+//! [`ScrollbackIndex`] performs a case-insensitive substring search over every
+//! row in the grid — both visible lines and scrollback history — and caches the
+//! results so the renderer can highlight match spans without re-scanning every
+//! frame.
+//!
+//! # Row numbering
+//!
+//! Alacritty's `Grid` uses a signed `Line` type:
+//! - Negative values (`Line(-1)`, `Line(-2)`, …) index scrollback rows above
+//!   the current viewport, counting *up* from the top visible row.
+//! - Non-negative values index visible rows within the current viewport.
+//!
+//! `ScrollbackIndex` uses these same `i32` row indices as keys so callers can
+//! pass them straight to the renderer without conversion.
+
+use std::collections::HashMap;
+
+use alacritty_terminal::grid::Dimensions;
+use alacritty_terminal::index::{Column, Line};
+use alacritty_terminal::term::cell::Cell;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ScrollbackIndex
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Cached results of a find-in-terminal search across all grid rows.
+///
+/// Call [`ScrollbackIndex::index`] after every query change to rebuild the
+/// cache. The renderer then calls [`ScrollbackIndex::matches_in_row`] for each
+/// row it is about to draw.
+#[derive(Debug, Default)]
+pub struct ScrollbackIndex {
+    /// Map from row index (signed `Line` value) to sorted, non-overlapping
+    /// byte-column spans `(col_start, col_end)` within that row.
+    matches: HashMap<i32, Vec<(usize, usize)>>,
+    /// Flat list of all matches in grid order (top-to-bottom, left-to-right),
+    /// stored as `(row, col_start)` so callers can jump to the nth match.
+    all_matches: Vec<(i32, usize)>,
+    /// The query that produced these results (cached to detect no-ops).
+    last_query: String,
+}
+
+impl ScrollbackIndex {
+    /// Create an empty index.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Rebuild the index by scanning all rows of `grid` for `query`.
+    ///
+    /// The search is case-insensitive and treats each terminal row as a plain
+    /// string of characters (leading/trailing spaces included — they can be
+    /// part of a meaningful match in, e.g., formatted table output).
+    ///
+    /// If `query` is empty the index is cleared and all match counts reset to
+    /// zero.
+    pub fn index(
+        &mut self,
+        grid: &alacritty_terminal::grid::Grid<Cell>,
+        query: &str,
+    ) {
+        if query == self.last_query {
+            return; // Nothing changed.
+        }
+        self.last_query = query.to_owned();
+        self.matches.clear();
+        self.all_matches.clear();
+
+        if query.is_empty() {
+            return;
+        }
+
+        let query_lower = query.to_lowercase();
+        let screen_lines = grid.screen_lines() as i32;
+        let history_size = grid.history_size() as i32;
+
+        // Iterate from the top of scrollback (most negative line index) down
+        // through all visible lines.  The topmost scrollback line is at
+        // `Line(-(history_size))`.
+        for row_i in (-history_size)..screen_lines {
+            let line = Line(row_i);
+
+            // Build the row's character string.
+            let row = &grid[line];
+            let row_len = row.len();
+            let mut row_str = String::with_capacity(row_len);
+            for col in 0..row_len {
+                row_str.push(row[Column(col)].c);
+            }
+
+            // Case-insensitive search in the lowercased version.  We need to
+            // map byte offsets in the lowercased string back to column indices.
+            // Since each terminal cell is exactly one character (and we are
+            // lowercasing char-by-char), char index == column index.
+            let row_lower = row_str.to_lowercase();
+
+            let spans = find_non_overlapping(&row_lower, &query_lower);
+            if !spans.is_empty() {
+                for &(start, _end) in &spans {
+                    self.all_matches.push((row_i, start));
+                }
+                self.matches.insert(row_i, spans);
+            }
+        }
+    }
+
+    /// Return the match spans (col_start, col_end) for `row`.
+    ///
+    /// Returns an empty slice when there are no matches in `row` or when the
+    /// index has not been built yet.
+    #[must_use]
+    pub fn matches_in_row(&self, row: i32) -> &[(usize, usize)] {
+        self.matches.get(&row).map(|v| v.as_slice()).unwrap_or(&[])
+    }
+
+    /// Total number of matches across all rows.
+    #[must_use]
+    pub fn total_matches(&self) -> usize {
+        self.all_matches.len()
+    }
+
+    /// Return the `(row, col_start)` of the n-th match (0-indexed).
+    ///
+    /// Returns `None` when `n >= total_matches()`.
+    #[must_use]
+    pub fn nth_match(&self, n: usize) -> Option<(i32, usize)> {
+        self.all_matches.get(n).copied()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helper
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Find all non-overlapping occurrences of `needle` in `haystack` and return
+/// them as `(start_char_idx, end_char_idx)` spans.
+///
+/// Both strings must be pre-lowercased by the caller for case-insensitive
+/// matching.  Since terminal cells are single chars, byte offset == char index.
+fn find_non_overlapping(haystack: &str, needle: &str) -> Vec<(usize, usize)> {
+    if needle.is_empty() {
+        return Vec::new();
+    }
+    let mut spans = Vec::new();
+    let mut start = 0;
+    while let Some(pos) = haystack[start..].find(needle) {
+        let abs_start = start + pos;
+        let abs_end = abs_start + needle.len();
+        spans.push((abs_start, abs_end));
+        start = abs_end; // advance past this match (non-overlapping)
+    }
+    spans
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scrollback_index_no_matches_returns_zero() {
+        let idx = ScrollbackIndex::new();
+        assert_eq!(idx.total_matches(), 0);
+        assert_eq!(idx.matches_in_row(0), &[]);
+        assert_eq!(idx.nth_match(0), None);
+    }
+
+    #[test]
+    fn find_non_overlapping_basic() {
+        let spans = find_non_overlapping("hello world hello", "hello");
+        assert_eq!(spans, vec![(0, 5), (12, 17)]);
+    }
+
+    #[test]
+    fn find_non_overlapping_case_sensitive_contract() {
+        // Caller is responsible for lowercasing; this tests the raw function.
+        let spans = find_non_overlapping("abc ABC", "abc");
+        assert_eq!(spans, vec![(0, 3)]);
+    }
+
+    #[test]
+    fn find_non_overlapping_empty_needle() {
+        let spans = find_non_overlapping("anything", "");
+        assert!(spans.is_empty());
+    }
+
+    #[test]
+    fn find_non_overlapping_no_match() {
+        let spans = find_non_overlapping("hello", "xyz");
+        assert!(spans.is_empty());
+    }
+
+    #[test]
+    fn scrollback_index_case_insensitive_via_find_helper() {
+        // The helper itself is case-sensitive; the index pre-lowercases both.
+        // Test the lowercasing path directly.
+        let haystack = "Hello World".to_lowercase();
+        let needle = "hello".to_lowercase();
+        let spans = find_non_overlapping(&haystack, &needle);
+        assert_eq!(spans, vec![(0, 5)]);
+    }
+}

--- a/crates/phantom-terminal/src/terminal.rs
+++ b/crates/phantom-terminal/src/terminal.rs
@@ -19,6 +19,8 @@ use alacritty_terminal::Term;
 use anyhow::{Context, Result};
 use log::{debug, trace, warn};
 
+use crate::search::ScrollbackIndex;
+
 
 /// Default scrollback history in lines.
 const SCROLLBACK_LINES: usize = 10_000;
@@ -238,6 +240,16 @@ pub struct PhantomTerminal {
     /// Receiver for OSC 52 clipboard texts decoded by the event listener.
     /// `None` when OSC 52 forwarding is disabled.
     osc52_rx: Option<mpsc::Receiver<String>>,
+
+    /// Cached scrollback search index. Rebuilt on every query change via
+    /// [`PhantomTerminal::update_search`]. Empty (no matches) until a search
+    /// is active.
+    pub search_index: ScrollbackIndex,
+
+    /// Whether find-in-terminal search is currently active. When `true`, the
+    /// renderer overlays match highlights from `search_index` on top of the
+    /// terminal cells.
+    pub search_active: bool,
 }
 
 impl PhantomTerminal {
@@ -305,6 +317,8 @@ impl PhantomTerminal {
             paste_byte_count: 0,
             paste_started_at: None,
             osc52_rx: Some(osc52_rx),
+            search_index: ScrollbackIndex::new(),
+            search_active: false,
         })
     }
 
@@ -584,6 +598,18 @@ impl PhantomTerminal {
     #[must_use]
     pub fn history_size(&self) -> usize {
         self.term.grid().history_size()
+    }
+
+    // -- Search API --------------------------------------------------------
+
+    /// Rebuild the scrollback search index for `query`.
+    ///
+    /// Sets `search_active` to `true` when the query is non-empty and `false`
+    /// when the query is cleared, so the renderer knows whether to draw
+    /// highlight quads.
+    pub fn update_search(&mut self, query: &str) {
+        self.search_active = !query.is_empty();
+        self.search_index.index(self.term.grid(), query);
     }
 
     // -- Mouse mode API ----------------------------------------------------

--- a/crates/phantom-ui/src/widgets/mod.rs
+++ b/crates/phantom-ui/src/widgets/mod.rs
@@ -58,6 +58,10 @@ pub use focus_ring::{FADE_DURATION_MS, FocusRing};
 pub mod keybind_help;
 pub use keybind_help::KeybindHelp;
 
+// Find-in-terminal search bar (Cmd+F).
+pub mod search_bar;
+pub use search_bar::{SEARCH_BAR_HEIGHT, SearchBar, SearchBarAction, SearchKey};
+
 // -----------------------------------------------------------------------
 // Color palette
 // -----------------------------------------------------------------------

--- a/crates/phantom-ui/src/widgets/search_bar.rs
+++ b/crates/phantom-ui/src/widgets/search_bar.rs
@@ -1,0 +1,452 @@
+//! Find-in-terminal search bar widget.
+//!
+//! A floating search bar that appears at the top-right of the terminal pane
+//! when the user presses Cmd+F. It renders as:
+//!
+//! ```text
+//! [ query____] [1/5] [^] [v] [X]
+//! ```
+//!
+//! The widget is self-contained: it handles text input, emits
+//! [`SearchBarAction`] on each key, and renders its own quads and text
+//! segments. The app layer is responsible for wiring actions to the
+//! scrollback index and feeding match counts back via
+//! [`SearchBar::set_match_info`].
+
+use crate::layout::Rect;
+use phantom_renderer::quads::QuadInstance;
+
+use super::TextSegment;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Fixed height of the search bar in pixels.
+pub const SEARCH_BAR_HEIGHT: f32 = 32.0;
+
+/// Approximate character width used for layout math (same value as the rest of
+/// the widget layer — the renderer does precise shaping independently).
+const CHAR_W: f32 = 8.0;
+
+/// Horizontal padding inside the input area.
+const H_PAD: f32 = 8.0;
+
+/// Colors (RGBA, linear sRGB).
+const BG: [f32; 4] = [0.05, 0.07, 0.10, 0.95];
+const BORDER: [f32; 4] = [0.0, 0.75, 0.9, 0.8];
+const TEXT_ACTIVE: [f32; 4] = [0.85, 0.95, 0.85, 1.0];
+const TEXT_DIM: [f32; 4] = [0.45, 0.55, 0.5, 0.85];
+const CURSOR_COLOR: [f32; 4] = [0.2, 1.0, 0.55, 1.0];
+const MATCH_COLOR: [f32; 4] = [0.4, 0.9, 0.4, 1.0];
+const NO_MATCH_COLOR: [f32; 4] = [0.9, 0.35, 0.3, 1.0];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SearchKey — winit-free key enum for the widget layer
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Logical key events delivered to [`SearchBar::handle_key`].
+///
+/// The app layer maps winit `NamedKey` values to these variants so that
+/// `phantom-ui` does not need to depend on `winit` directly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SearchKey {
+    /// Close the bar (Escape).
+    Escape,
+    /// Confirm / navigate to next match (Enter).
+    Enter,
+    /// Delete character before cursor.
+    Backspace,
+    /// Delete character at cursor.
+    Delete,
+    /// Move cursor left.
+    Left,
+    /// Move cursor right.
+    Right,
+    /// Navigate to previous match.
+    Up,
+    /// Navigate to next match.
+    Down,
+    /// Move cursor to start.
+    Home,
+    /// Move cursor to end.
+    End,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SearchBarAction
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Actions emitted by [`SearchBar::handle_key`] and [`SearchBar::handle_char`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SearchBarAction {
+    /// Key did not produce a notable action.
+    None,
+    /// Query string changed; the caller should rebuild the scrollback index.
+    QueryChanged(String),
+    /// Navigate to the next match.
+    Next,
+    /// Navigate to the previous match.
+    Prev,
+    /// Close the search bar.
+    Close,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SearchBar
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Floating find-in-terminal search bar.
+///
+/// Owned by `App` (or the terminal adapter layer). Toggled open/closed by
+/// `Cmd+F`. When visible, keyboard events should be routed here *before*
+/// they reach the terminal PTY.
+#[derive(Debug, Clone)]
+pub struct SearchBar {
+    /// Whether the bar is currently displayed.
+    pub visible: bool,
+    /// Current query string (chars).
+    query: Vec<char>,
+    /// Cursor position as a char index into `query`.
+    cursor_pos: usize,
+    /// Total number of matches in the current scrollback index.
+    match_count: usize,
+    /// The 1-indexed currently highlighted match (0 when no matches).
+    current_match: usize,
+}
+
+impl SearchBar {
+    /// Construct a hidden search bar with an empty query.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            visible: false,
+            query: Vec::new(),
+            cursor_pos: 0,
+            match_count: 0,
+            current_match: 0,
+        }
+    }
+
+    /// Show the search bar and focus the query input.
+    pub fn show(&mut self) {
+        self.visible = true;
+    }
+
+    /// Hide the search bar without clearing the query.
+    pub fn hide(&mut self) {
+        self.visible = false;
+    }
+
+    /// Toggle visibility.
+    pub fn toggle(&mut self) {
+        self.visible = !self.visible;
+    }
+
+    /// Return the current query as an owned `String`.
+    #[must_use]
+    pub fn query(&self) -> String {
+        self.query.iter().collect()
+    }
+
+    /// Total number of matches in the current index.
+    #[must_use]
+    pub fn match_count(&self) -> usize {
+        self.match_count
+    }
+
+    /// The 1-indexed currently highlighted match (0 when there are no matches).
+    #[must_use]
+    pub fn current_match(&self) -> usize {
+        self.current_match
+    }
+
+    /// Update the match counters (called by the app after re-indexing).
+    pub fn set_match_info(&mut self, total: usize, current: usize) {
+        self.match_count = total;
+        self.current_match = if total > 0 { current.clamp(1, total) } else { 0 };
+    }
+
+    /// Handle a logical key event and return the resulting action.
+    ///
+    /// Only call this when the bar is visible; the caller is responsible for
+    /// the gate.
+    pub fn handle_key(&mut self, key: SearchKey) -> SearchBarAction {
+        match key {
+            SearchKey::Escape => {
+                self.hide();
+                SearchBarAction::Close
+            }
+            SearchKey::Enter => SearchBarAction::Next,
+            SearchKey::Backspace => {
+                if self.cursor_pos > 0 {
+                    self.cursor_pos -= 1;
+                    self.query.remove(self.cursor_pos);
+                    SearchBarAction::QueryChanged(self.query())
+                } else {
+                    SearchBarAction::None
+                }
+            }
+            SearchKey::Delete => {
+                if self.cursor_pos < self.query.len() {
+                    self.query.remove(self.cursor_pos);
+                    SearchBarAction::QueryChanged(self.query())
+                } else {
+                    SearchBarAction::None
+                }
+            }
+            SearchKey::Left => {
+                if self.cursor_pos > 0 {
+                    self.cursor_pos -= 1;
+                }
+                SearchBarAction::None
+            }
+            SearchKey::Right => {
+                if self.cursor_pos < self.query.len() {
+                    self.cursor_pos += 1;
+                }
+                SearchBarAction::None
+            }
+            SearchKey::Up => SearchBarAction::Prev,
+            SearchKey::Down => SearchBarAction::Next,
+            SearchKey::Home => {
+                self.cursor_pos = 0;
+                SearchBarAction::None
+            }
+            SearchKey::End => {
+                self.cursor_pos = self.query.len();
+                SearchBarAction::None
+            }
+        }
+    }
+
+    /// Handle a printable character input and return the resulting action.
+    pub fn handle_char(&mut self, ch: char) -> SearchBarAction {
+        self.query.insert(self.cursor_pos, ch);
+        self.cursor_pos += 1;
+        SearchBarAction::QueryChanged(self.query())
+    }
+
+    /// Produce the background and border quads for the search bar.
+    ///
+    /// The bar is anchored to the top-right of `pane_rect`.
+    #[must_use]
+    pub fn render_quads(&self, pane_rect: &Rect) -> Vec<QuadInstance> {
+        if !self.visible {
+            return Vec::new();
+        }
+
+        let bar_w = 340.0_f32.min(pane_rect.width * 0.55);
+        let bar_h = SEARCH_BAR_HEIGHT;
+        let bar_x = pane_rect.x + pane_rect.width - bar_w - 8.0;
+        let bar_y = pane_rect.y + 8.0;
+
+        let mut quads = Vec::with_capacity(6);
+
+        // Drop shadow for depth.
+        quads.push(QuadInstance {
+            pos: [bar_x + 2.0, bar_y + 2.0],
+            size: [bar_w, bar_h],
+            color: [0.0, 0.0, 0.0, 0.25],
+            border_radius: 4.0,
+        });
+
+        // Background panel.
+        quads.push(QuadInstance {
+            pos: [bar_x, bar_y],
+            size: [bar_w, bar_h],
+            color: BG,
+            border_radius: 4.0,
+        });
+
+        // Border lines (top, bottom, left, right).
+        let t = 1.0;
+        for &(pos, size) in &[
+            ([bar_x, bar_y], [bar_w, t]),
+            ([bar_x, bar_y + bar_h - t], [bar_w, t]),
+            ([bar_x, bar_y], [t, bar_h]),
+            ([bar_x + bar_w - t, bar_y], [t, bar_h]),
+        ] {
+            quads.push(QuadInstance {
+                pos,
+                size,
+                color: BORDER,
+                border_radius: 0.0,
+            });
+        }
+
+        quads
+    }
+
+    /// Produce text segments for the search bar contents.
+    #[must_use]
+    pub fn render_text(&self, pane_rect: &Rect) -> Vec<TextSegment> {
+        if !self.visible {
+            return Vec::new();
+        }
+
+        let bar_w = 340.0_f32.min(pane_rect.width * 0.55);
+        let bar_h = SEARCH_BAR_HEIGHT;
+        let bar_x = pane_rect.x + pane_rect.width - bar_w - 8.0;
+        let bar_y = pane_rect.y + 8.0;
+
+        let text_y = bar_y + (bar_h - 14.0) * 0.5;
+        let mut segments = Vec::with_capacity(4);
+
+        // Match counter  "3/12"  or  "0/0"
+        let counter_text = if self.match_count == 0 {
+            "0/0".to_owned()
+        } else {
+            format!("{}/{}", self.current_match, self.match_count)
+        };
+        let counter_color = if self.match_count == 0 {
+            NO_MATCH_COLOR
+        } else {
+            MATCH_COLOR
+        };
+
+        // Navigation buttons and close — anchored right.
+        let controls = format!(" {} [^][v][X]", counter_text);
+        let controls_w = controls.len() as f32 * CHAR_W;
+        let controls_x = bar_x + bar_w - controls_w - H_PAD;
+        segments.push(TextSegment {
+            text: controls,
+            x: controls_x,
+            y: text_y,
+            color: counter_color,
+        });
+
+        // Search icon.
+        let icon = "/ ";
+        let icon_w = icon.len() as f32 * CHAR_W;
+        segments.push(TextSegment {
+            text: icon.to_owned(),
+            x: bar_x + H_PAD,
+            y: text_y,
+            color: TEXT_DIM,
+        });
+
+        // Query text.
+        let query_str: String = self.query.iter().collect();
+        let query_x = bar_x + H_PAD + icon_w;
+
+        if !query_str.is_empty() {
+            segments.push(TextSegment {
+                text: query_str,
+                x: query_x,
+                y: text_y,
+                color: TEXT_ACTIVE,
+            });
+        }
+
+        // Cursor block at the insertion point.
+        let before_cursor: String = self.query[..self.cursor_pos].iter().collect();
+        let cursor_x = query_x + before_cursor.len() as f32 * CHAR_W;
+        segments.push(TextSegment {
+            text: "_".to_owned(),
+            x: cursor_x,
+            y: text_y,
+            color: CURSOR_COLOR,
+        });
+
+        segments
+    }
+}
+
+impl Default for SearchBar {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn search_bar_query_changed_on_char_input() {
+        let mut bar = SearchBar::new();
+        bar.show();
+        let action = bar.handle_char('h');
+        assert_eq!(action, SearchBarAction::QueryChanged("h".to_owned()));
+        let action2 = bar.handle_char('i');
+        assert_eq!(action2, SearchBarAction::QueryChanged("hi".to_owned()));
+        assert_eq!(bar.query(), "hi");
+    }
+
+    #[test]
+    fn search_bar_closes_on_escape() {
+        let mut bar = SearchBar::new();
+        bar.show();
+        assert!(bar.visible);
+        let action = bar.handle_key(SearchKey::Escape);
+        assert_eq!(action, SearchBarAction::Close);
+        assert!(!bar.visible);
+    }
+
+    #[test]
+    fn search_bar_backspace_removes_char() {
+        let mut bar = SearchBar::new();
+        bar.show();
+        bar.handle_char('a');
+        bar.handle_char('b');
+        assert_eq!(bar.query(), "ab");
+        let action = bar.handle_key(SearchKey::Backspace);
+        assert_eq!(action, SearchBarAction::QueryChanged("a".to_owned()));
+        assert_eq!(bar.query(), "a");
+    }
+
+    #[test]
+    fn search_bar_toggle_visibility() {
+        let mut bar = SearchBar::new();
+        assert!(!bar.visible);
+        bar.toggle();
+        assert!(bar.visible);
+        bar.toggle();
+        assert!(!bar.visible);
+    }
+
+    #[test]
+    fn search_bar_set_match_info() {
+        let mut bar = SearchBar::new();
+        bar.set_match_info(5, 2);
+        assert_eq!(bar.match_count(), 5);
+        assert_eq!(bar.current_match(), 2);
+    }
+
+    #[test]
+    fn search_bar_set_match_info_no_matches() {
+        let mut bar = SearchBar::new();
+        bar.set_match_info(0, 0);
+        assert_eq!(bar.match_count(), 0);
+        assert_eq!(bar.current_match(), 0);
+    }
+
+    #[test]
+    fn search_bar_enter_returns_next() {
+        let mut bar = SearchBar::new();
+        bar.show();
+        let action = bar.handle_key(SearchKey::Enter);
+        assert_eq!(action, SearchBarAction::Next);
+    }
+
+    #[test]
+    fn search_bar_up_returns_prev() {
+        let mut bar = SearchBar::new();
+        bar.show();
+        let action = bar.handle_key(SearchKey::Up);
+        assert_eq!(action, SearchBarAction::Prev);
+    }
+
+    #[test]
+    fn search_bar_down_returns_next() {
+        let mut bar = SearchBar::new();
+        bar.show();
+        let action = bar.handle_key(SearchKey::Down);
+        assert_eq!(action, SearchBarAction::Next);
+    }
+}


### PR DESCRIPTION
## Summary

- **SearchBar widget** (`phantom-ui`): floating top-right panel that opens on Cmd+F, accepts text input, shows `3/12`-style match counter, and emits `SearchBarAction` events (QueryChanged, Next, Prev, Close). Uses a `SearchKey` enum so `phantom-ui` doesn't depend on winit.
- **ScrollbackIndex** (`phantom-terminal`): case-insensitive substring search across all visible + scrollback grid rows. Caches `HashMap<i32, Vec<(usize,usize)>>` spans per row. `PhantomTerminal` gains `search_index`, `search_active`, and `update_search()`.
- **App wiring** (`phantom-app`): `search_bar: SearchBar` field; Cmd+F toggle in `input.rs`; query-change, next/prev/clear coordination in `search.rs`; overlay rendered in `render.rs` on top of the terminal pane; `update_search`, `search_info`, and `scroll_to_search_match` commands added to `TerminalAdapter`.

## Test plan

- [x] `cargo test -p phantom-ui` — 352 tests pass (9 new search_bar tests included)
- [x] `cargo test -p phantom-terminal` — 112 tests pass (5 new ScrollbackIndex tests included)
- [x] `cargo test -p phantom-app` — 43 tests pass
- [x] `cargo clippy -p phantom-ui -- -D warnings` — clean
- [x] `cargo clippy -p phantom-terminal -- -D warnings` — clean
- [x] `cargo clippy -p phantom-app -- -D warnings` — clean
- [x] `./scripts/pre-pr-check.sh phantom-ui` — PASS
- [x] `./scripts/pre-pr-check.sh phantom-terminal` — PASS
- [x] `./scripts/pre-pr-check.sh phantom-app` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)