### PR TITLE
feat(phantom-voice+phantom-app): wire TTS end-to-end for agent responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alsa"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.11.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "android-activity"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,7 +146,7 @@ dependencies = [
  "jni 0.22.4",
  "libc",
  "log",
- "ndk",
+ "ndk 0.9.0",
  "ndk-context",
  "ndk-sys 0.6.0+11769913",
  "num_enum",
@@ -735,6 +757,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.2",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,6 +1036,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,6 +1116,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,6 +1165,12 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "claxon"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bfbf56724aa9eca8afa4fcfadeb479e722935bb2a0900c2d37e0cc477af0688"
 
 [[package]]
 name = "clipboard-win"
@@ -1308,6 +1374,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "coreaudio-rs"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation-sys",
+ "coreaudio-sys",
+]
+
+[[package]]
+name = "coreaudio-sys"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
 name = "cosmic-text"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1328,6 +1414,29 @@ dependencies = [
  "unicode-linebreak",
  "unicode-script",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cpal"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+dependencies = [
+ "alsa",
+ "core-foundation-sys",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni 0.21.1",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk 0.8.0",
+ "ndk-context",
+ "oboe",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -1679,6 +1788,12 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "data-encoding"
@@ -3109,7 +3224,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 1.0.69",
- "windows",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -3292,6 +3407,12 @@ checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "hound"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
 
 [[package]]
 name = "htmlescape"
@@ -4541,6 +4662,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 
 [[package]]
+name = "lewton"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777b48df9aaab155475a83a7df3070395ea1ac6902f5cd062b8f2b028075c030"
+dependencies = [
+ "byteorder",
+ "ogg",
+ "tinyvec",
+]
+
+[[package]]
 name = "lexical-core"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5019,6 +5151,20 @@ dependencies = [
 
 [[package]]
 name = "ndk"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+dependencies = [
+ "bitflags 2.11.1",
+ "jni-sys 0.3.1",
+ "log",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
@@ -5127,6 +5273,17 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "num-integer"
@@ -5495,6 +5652,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "oboe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
+dependencies = [
+ "jni 0.21.1",
+ "ndk 0.8.0",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "oboe-sys",
+]
+
+[[package]]
+name = "oboe-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "ogg"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6951b4e8bf21c8193da321bcce9c9dd2e13c858fe078bf9054a288b419ae5d6e"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5786,6 +5975,7 @@ dependencies = [
  "anyhow",
  "arboard",
  "bitflags 2.11.1",
+ "futures-core",
  "image",
  "libc",
  "log",
@@ -5813,6 +6003,7 @@ dependencies = [
  "phantom-terminal",
  "phantom-ui",
  "phantom-vision",
+ "phantom-voice",
  "png 0.17.16",
  "pollster",
  "serde",
@@ -6227,8 +6418,10 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "log",
  "lru",
  "reqwest",
+ "rodio",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -7006,6 +7199,20 @@ checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",
+]
+
+[[package]]
+name = "rodio"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6006a627c1a38d37f3d3a85c6575418cfe34a5392d60a686d0071e1c8d427acb"
+dependencies = [
+ "claxon",
+ "cpal",
+ "hound",
+ "lewton",
+ "symphonia",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7862,6 +8069,55 @@ name = "symlink"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
+name = "symphonia"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+dependencies = [
+ "lazy_static",
+ "symphonia-bundle-mp3",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-mp3"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4872dd6bb56bf5eac799e3e957aa1981086c3e613b27e0ac23b176054f7c57ed"
+dependencies = [
+ "lazy_static",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "bytemuck",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+dependencies = [
+ "encoding_rs",
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
 
 [[package]]
 name = "syn"
@@ -9563,7 +9819,7 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
- "windows",
+ "windows 0.58.0",
  "windows-core 0.58.0",
 ]
 
@@ -9614,11 +9870,31 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
  "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result 0.1.2",
  "windows-targets 0.52.6",
 ]
 
@@ -9707,6 +9983,15 @@ dependencies = [
  "windows-link",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -10065,7 +10350,7 @@ dependencies = [
  "js-sys",
  "libc",
  "memmap2",
- "ndk",
+ "ndk 0.9.0",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",

--- a/crates/phantom-app/Cargo.toml
+++ b/crates/phantom-app/Cargo.toml
@@ -28,7 +28,9 @@ phantom-bundles = { path = "../phantom-bundles" }
 phantom-bundle-store = { path = "../phantom-bundle-store" }
 phantom-embeddings = { path = "../phantom-embeddings" }
 phantom-stt = { path = "../phantom-stt" }
+phantom-voice = { path = "../phantom-voice" }
 phantom-dag = { path = "../phantom-dag" }
+futures-core = "0.3"
 
 winit.workspace = true
 wgpu.workspace = true

--- a/crates/phantom-app/src/agent_pane/mod.rs
+++ b/crates/phantom-app/src/agent_pane/mod.rs
@@ -15,7 +15,7 @@ mod tests;
 
 use std::sync::{Arc, Mutex};
 
-use log::{info, warn};
+use log::{debug, info, warn};
 
 use phantom_agents::agent::{Agent, AgentMessage, allocate_agent_id};
 use phantom_agents::api::{ApiEvent, ApiHandle, ClaudeConfig};
@@ -303,6 +303,13 @@ pub(crate) struct AgentPane {
     /// richer message timeline instead of the raw `output` string.
     #[allow(dead_code)] // Read by the timeline adapter (Phase 2) and tests
     pub(super) pane_messages: Vec<PaneMessage>,
+
+    /// Optional TTS sender: when `Some`, every completed assistant message is
+    /// forwarded here for audio playback.  `None` when TTS is disabled or
+    /// unavailable.  The pipeline's background worker is the only consumer;
+    /// `try_send` is used (non-blocking) so a slow audio device never stalls
+    /// the agent pane's render loop.
+    pub(super) tts_tx: Option<tokio::sync::mpsc::Sender<String>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -364,6 +371,7 @@ impl AgentPane {
             capture_tool_calls: Vec::new(),
             dag_explorer: None,
             pane_messages: Vec::new(),
+            tts_tx: None,
         }
     }
 
@@ -551,6 +559,7 @@ impl AgentPane {
                 PaneMessageRole::System,
                 "● Agent working...",
             )],
+            tts_tx: None,
         }
     }
 
@@ -584,6 +593,15 @@ impl AgentPane {
     /// App's canonical queue receives the snapshot at completion time.
     pub(crate) fn set_snapshot_sink(&mut self, sink: AgentSnapshotQueue) {
         self.snapshot_sink = Some(sink);
+    }
+
+    /// Wire the TTS sender so completed assistant messages are spoken aloud.
+    ///
+    /// Called by `App::spawn_agent_pane_with_opts` when a [`TtsPipeline`] is
+    /// active. When `None` (no TTS available) this is never called; the field
+    /// stays `None` and the TTS path is silently skipped on every `poll()`.
+    pub(crate) fn set_tts_tx(&mut self, tx: tokio::sync::mpsc::Sender<String>) {
+        self.tts_tx = Some(tx);
     }
 
     /// Wire the shared [`GhTicketDispatcher`] handle for Dispatcher-role panes.
@@ -717,6 +735,15 @@ impl AgentPane {
                     // Flush accumulated assistant text into the conversation.
                     if !self.current_assistant_text.is_empty() {
                         let text = std::mem::take(&mut self.current_assistant_text);
+                        // Forward to TTS pipeline (non-blocking; drops silently
+                        // if the channel is full or TTS is disabled).
+                        if self
+                            .tts_tx
+                            .as_ref()
+                            .is_some_and(|tx| tx.try_send(text.clone()).is_err())
+                        {
+                            debug!("TTS channel full or closed — skipping speech");
+                        }
                         self.agent.push_message(AgentMessage::Assistant(text));
                     }
 

--- a/crates/phantom-app/src/agent_pane/spawn.rs
+++ b/crates/phantom-app/src/agent_pane/spawn.rs
@@ -205,6 +205,15 @@ impl App {
             agent_pane.set_agent_capture(capture.clone(), self.session_uuid);
         }
 
+        // Wire TTS: when a pipeline is active, hand the pane a clone of the
+        // sender so completed assistant messages are forwarded for speech
+        // playback. No-op when TTS is disabled (None).
+        if let Some(ref tts) = self.tts
+            && let Some(ref tx) = tts.tts_tx
+        {
+            agent_pane.set_tts_tx(tx.clone());
+        }
+
         // Capture the stable AgentId BEFORE the pane is moved into the adapter.
         // This is the value returned to MCP callers (issue #399).
         let agent_id = agent_pane.agent_id();

--- a/crates/phantom-app/src/agent_pane/tests.rs
+++ b/crates/phantom-app/src/agent_pane/tests.rs
@@ -71,6 +71,7 @@ fn agent_with_handle() -> (AgentPane, mpsc::Sender<ApiEvent>) {
         capture_tool_calls: Vec::new(),
         dag_explorer: None,
         pane_messages: Vec::new(),
+        tts_tx: None,
     };
     (pane, tx)
 }
@@ -174,6 +175,7 @@ fn poll_returns_false_when_no_handle() {
         capture_tool_calls: Vec::new(),
         dag_explorer: None,
         pane_messages: Vec::new(),
+        tts_tx: None,
     };
     assert!(!pane.poll());
 }
@@ -1050,6 +1052,7 @@ fn spawn_agent_pane_task_matches_prompt() {
         capture_tool_calls: Vec::new(),
         dag_explorer: None,
         pane_messages: Vec::new(),
+        tts_tx: None,
     };
     let _ = tx; // keep sender alive so handle stays live
     assert_eq!(pane.task, "fix the failing tests");

--- a/crates/phantom-app/src/app.rs
+++ b/crates/phantom-app/src/app.rs
@@ -512,6 +512,14 @@ pub struct App {
     // `tick_alt_screen_fade` into `collapse_alt_screen_pane`.
     pub(crate) alt_screen_pending_collapses: Vec<phantom_adapter::AppId>,
 
+    // -- TTS pipeline (optional: None when OPENAI_API_KEY is absent or TTS
+    //    is otherwise unavailable). Receives full assistant messages from
+    //    agent panes and speaks them aloud via the system audio device.
+    pub(crate) tts: Option<crate::tts::TtsPipeline>,
+    // Keeps the background worker task alive for the process lifetime.
+    #[allow(dead_code)]
+    pub(crate) _tts_handles: Option<crate::tts::TtsTaskHandles>,
+
     // -- Privacy mode: hard block on cloud API calls.
     //    Mirrors `PhantomConfig::privacy_mode`. Toggled at runtime by the
     //    `ghost privacy on/off` command. When `true`:
@@ -1257,6 +1265,19 @@ impl App {
             }
         }
 
+        // -- TTS pipeline (best-effort; no-op when OPENAI_API_KEY is absent) --
+        // Privacy mode blocks cloud API calls, so we skip TTS init to avoid
+        // a live network call on first synthesis.
+        let (tts, _tts_handles) = if config.privacy_mode {
+            debug!("TTS pipeline disabled (privacy mode)");
+            (None, None)
+        } else {
+            match crate::tts::build_tts_pipeline_from_env() {
+                Some((p, h)) => (Some(p), Some(h)),
+                None => (None, None),
+            }
+        };
+
         let now = Instant::now();
 
         Ok(Self {
@@ -1382,6 +1403,8 @@ impl App {
             alt_screen_pending_collapses: Vec::new(),
             privacy_mode: config.privacy_mode,
             peer_grant_registry: crate::peer_grants::load_peer_grant_registry(),
+            tts,
+            _tts_handles,
             // OODA signal cache — all start zeroed; populated by drain_bus_to_brain.
             ooda_last_parsed: None,
             ooda_agent_just_completed: false,

--- a/crates/phantom-app/src/lib.rs
+++ b/crates/phantom-app/src/lib.rs
@@ -36,5 +36,6 @@ pub mod settings;
 pub(crate) mod settings_ui;
 pub mod supervisor_client;
 mod sysmon;
+pub mod tts;
 mod update;
 mod video;

--- a/crates/phantom-app/src/tts.rs
+++ b/crates/phantom-app/src/tts.rs
@@ -1,0 +1,381 @@
+//! TTS pipeline integration for phantom-app.
+//!
+//! Mirrors the [`crate::stt`] module but in the outbound direction: text goes
+//! in, synthesized speech comes out through the system audio device.
+//!
+//! # Architecture
+//!
+//! The pipeline has two layers:
+//!
+//! 1. **Tokio worker** (`run_tts_worker`) — waits for text on an async mpsc
+//!    channel, calls the [`VoiceSynth`] backend to get f32 PCM samples, and
+//!    forwards the fully-collected samples to a blocking thread via a
+//!    `std::sync::mpsc` channel.
+//! 2. **Audio thread** (`run_audio_thread`) — a plain `std::thread::spawn`
+//!    that owns the `rodio` `OutputStream` (which is `!Send`) and plays each
+//!    received sample buffer sequentially.
+//!
+//! Splitting the two layers keeps the `rodio` audio objects off the async
+//! executor (they are `!Send`) while still driving synthesis through the
+//! async [`VoiceSynth`] API.
+//!
+//! # Lifecycle
+//!
+//! 1. At startup, call [`TtsPipeline::start`] with a backend.
+//! 2. Whenever a full agent assistant message arrives, call
+//!    [`TtsPipeline::speak`].
+//! 3. Drop [`TtsPipeline`] to stop the worker gracefully.
+//!
+//! # Error handling
+//!
+//! All errors inside the worker and audio thread are logged; they never
+//! surface to callers. [`TtsPipeline::speak`] returns `false` only when the
+//! channel has closed (worker exited).
+
+use std::sync::Arc;
+
+use log::{debug, warn};
+use tokio::sync::mpsc as async_mpsc;
+
+use phantom_voice::{
+    VoiceSynth,
+    openai::OpenAiTtsBackend,
+};
+
+// ── TtsPipeline ───────────────────────────────────────────────────────────────
+
+/// Handle to a running TTS worker task.
+///
+/// Drop this value to stop the worker (the `text_tx` drop closes the channel,
+/// which terminates the worker's `recv()` loop).
+pub struct TtsPipeline {
+    /// Send text to the background synthesizer.  `None` when TTS is disabled.
+    pub tts_tx: Option<async_mpsc::Sender<String>>,
+}
+
+/// Join handles for background tasks spawned by [`TtsPipeline::start`].
+pub struct TtsTaskHandles {
+    /// The Tokio task that drives synthesis (async).
+    pub worker: tokio::task::JoinHandle<()>,
+    /// The OS thread that owns the rodio output stream (sync).
+    #[allow(dead_code)]
+    audio_thread: std::thread::JoinHandle<()>,
+}
+
+impl TtsPipeline {
+    /// Start the TTS pipeline with the given backend.
+    ///
+    /// Spawns:
+    /// * A Tokio task that receives text, synthesizes PCM, and forwards it.
+    /// * A dedicated OS thread that owns `rodio::OutputStream` (which is
+    ///   `!Send`) and plays each buffer sequentially.
+    ///
+    /// Returns the pipeline handle and the task/thread join handles.
+    pub fn start(
+        backend: Arc<dyn VoiceSynth + Send + Sync>,
+    ) -> (Self, TtsTaskHandles) {
+        let (tts_tx, tts_rx) = async_mpsc::channel::<String>(32);
+
+        // Channel from the async worker to the audio thread.
+        // Each message is a fully-collected Vec<f32> of mono samples plus the
+        // sample rate the backend reported.
+        let (audio_tx, audio_rx) = std::sync::mpsc::sync_channel::<(Vec<f32>, u32)>(4);
+
+        let audio_thread = std::thread::spawn(move || {
+            run_audio_thread(audio_rx);
+        });
+
+        let worker = tokio::spawn(run_tts_worker(backend, tts_rx, audio_tx));
+
+        let pipeline = Self {
+            tts_tx: Some(tts_tx),
+        };
+        let handles = TtsTaskHandles {
+            worker,
+            audio_thread,
+        };
+        (pipeline, handles)
+    }
+
+    /// Create a no-op pipeline (TTS disabled).
+    ///
+    /// All [`TtsPipeline::speak`] calls return `false` immediately.
+    #[must_use]
+    pub fn disabled() -> Self {
+        Self { tts_tx: None }
+    }
+
+    /// Send `text` to the background synthesizer.
+    ///
+    /// Returns `true` on success, `false` if TTS is disabled or the worker
+    /// has already exited.
+    #[must_use]
+    pub fn speak(&self, text: String) -> bool {
+        match &self.tts_tx {
+            Some(tx) => tx.try_send(text).is_ok(),
+            None => false,
+        }
+    }
+
+    /// Returns `true` if the pipeline is active and accepting text.
+    #[must_use]
+    pub fn is_active(&self) -> bool {
+        self.tts_tx
+            .as_ref()
+            .map(|tx| !tx.is_closed())
+            .unwrap_or(false)
+    }
+}
+
+// ── Audio thread (owns rodio — is !Send) ──────────────────────────────────────
+
+/// Dedicated OS thread that owns the `rodio` output stream and plays each
+/// (samples, sample_rate) pair it receives from the async worker.
+///
+/// Blocks until the sender is dropped.
+fn run_audio_thread(rx: std::sync::mpsc::Receiver<(Vec<f32>, u32)>) {
+    use phantom_voice::player::AudioPlayer;
+
+    let player = match AudioPlayer::new() {
+        Ok(p) => p,
+        Err(e) => {
+            warn!("[tts-audio-thread] failed to open audio device: {e} — audio playback disabled");
+            return;
+        }
+    };
+
+    while let Ok((samples, sample_rate)) = rx.recv() {
+        if samples.is_empty() {
+            continue;
+        }
+
+        // Encode the f32 samples as a WAV buffer and play via the player's
+        // synchronous play_bytes path.
+        let wav = encode_wav_f32(&samples, sample_rate);
+        if let Err(e) = player.play_bytes(&wav) {
+            warn!("[tts-audio-thread] play_bytes failed: {e}");
+        }
+    }
+
+    debug!("[tts-audio-thread] channel closed — exiting");
+}
+
+/// Encode mono f32 samples as a 32-bit IEEE floating-point WAV buffer.
+///
+/// This is a minimal in-memory encoder that avoids pulling in a WAV library.
+/// The format is:
+///   - RIFF/WAVE header
+///   - `fmt ` chunk with AudioFormat = 3 (IEEE float), 1 channel, given rate
+///   - `data` chunk with raw little-endian f32 samples
+fn encode_wav_f32(samples: &[f32], sample_rate: u32) -> Vec<u8> {
+    let num_channels: u16 = 1;
+    let bits_per_sample: u16 = 32;
+    let byte_rate = sample_rate * u32::from(num_channels) * u32::from(bits_per_sample / 8);
+    let block_align = num_channels * (bits_per_sample / 8);
+    let data_size = (samples.len() * 4) as u32; // 4 bytes per f32
+    let chunk_size = 36 + data_size;
+
+    let mut wav = Vec::with_capacity(44 + samples.len() * 4);
+    // RIFF header
+    wav.extend_from_slice(b"RIFF");
+    wav.extend_from_slice(&chunk_size.to_le_bytes());
+    wav.extend_from_slice(b"WAVE");
+    // fmt sub-chunk
+    wav.extend_from_slice(b"fmt ");
+    wav.extend_from_slice(&16u32.to_le_bytes()); // PCM fmt chunk size
+    wav.extend_from_slice(&3u16.to_le_bytes()); // AudioFormat = IEEE float
+    wav.extend_from_slice(&num_channels.to_le_bytes());
+    wav.extend_from_slice(&sample_rate.to_le_bytes());
+    wav.extend_from_slice(&byte_rate.to_le_bytes());
+    wav.extend_from_slice(&block_align.to_le_bytes());
+    wav.extend_from_slice(&bits_per_sample.to_le_bytes());
+    // data sub-chunk
+    wav.extend_from_slice(b"data");
+    wav.extend_from_slice(&data_size.to_le_bytes());
+    for &s in samples {
+        wav.extend_from_slice(&s.to_le_bytes());
+    }
+    wav
+}
+
+// ── Tokio worker ──────────────────────────────────────────────────────────────
+
+/// Async worker: receive text, synthesize, collect samples, forward to audio thread.
+async fn run_tts_worker(
+    backend: Arc<dyn VoiceSynth + Send + Sync>,
+    mut rx: async_mpsc::Receiver<String>,
+    audio_tx: std::sync::mpsc::SyncSender<(Vec<f32>, u32)>,
+) {
+    // Resolve a voice profile once from the backend.
+    let voice = match backend.list_voices().await {
+        Ok(voices) if !voices.is_empty() => voices.into_iter().next().unwrap(),
+        Ok(_) => {
+            warn!("[tts-worker] backend returned no voices — TTS disabled");
+            return;
+        }
+        Err(e) => {
+            warn!("[tts-worker] list_voices failed: {e} — TTS disabled");
+            return;
+        }
+    };
+
+    while let Some(text) = rx.recv().await {
+        if text.trim().is_empty() {
+            continue;
+        }
+
+        debug!("[tts-worker] synthesizing: {} chars", text.len());
+
+        let stream = match backend.synthesize(text, &voice).await {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("[tts-worker] synthesize failed: {e}");
+                continue;
+            }
+        };
+
+        // Collect all PCM chunks into a single buffer.
+        let (all_samples, sample_rate) = collect_stream(stream).await;
+        if all_samples.is_empty() {
+            continue;
+        }
+
+        // Forward to the audio thread (non-blocking try_send: skip if full).
+        if audio_tx.try_send((all_samples, sample_rate)).is_err() {
+            warn!("[tts-worker] audio queue full — dropping utterance");
+        }
+    }
+
+    debug!("[tts-worker] channel closed — exiting");
+}
+
+/// Drain a [`BoxedVoiceStream`] into a flat `Vec<f32>` and return the sample
+/// rate from the last chunk (or 24_000 as a sensible default).
+///
+/// Uses `std::future::poll_fn` with `futures_core::Stream::poll_next` so we
+/// don't need `futures-util` in phantom-app's dependency tree.
+async fn collect_stream(
+    stream: phantom_voice::BoxedVoiceStream,
+) -> (Vec<f32>, u32) {
+    use std::future::poll_fn;
+    use std::pin::Pin;
+    use futures_core::Stream as _;
+
+    let mut pinned = stream;
+    let mut all_samples: Vec<f32> = Vec::new();
+    let mut sample_rate: u32 = 24_000;
+
+    loop {
+        let item = poll_fn(|cx| Pin::new(&mut pinned).poll_next(cx)).await;
+
+        match item {
+            Some(Ok(chunk)) => {
+                sample_rate = chunk.sample_rate;
+                all_samples.extend_from_slice(&chunk.samples);
+            }
+            Some(Err(e)) => {
+                warn!("[tts-worker] stream error while collecting: {e}");
+                break;
+            }
+            None => break,
+        }
+    }
+
+    (all_samples, sample_rate)
+}
+
+// ── Startup helper ────────────────────────────────────────────────────────────
+
+/// Try to build a [`TtsPipeline`] from environment variables.
+///
+/// * Checks `OPENAI_API_KEY`.  If set, constructs [`OpenAiTtsBackend`] and
+///   starts the pipeline.
+/// * Otherwise returns [`None`] (caller should store `tts: None` in `App`).
+///
+/// All failures are logged; this function never panics.
+#[must_use]
+pub fn build_tts_pipeline_from_env() -> Option<(TtsPipeline, TtsTaskHandles)> {
+    match OpenAiTtsBackend::from_env() {
+        Ok(backend) => {
+            let arc: Arc<dyn VoiceSynth + Send + Sync> = Arc::new(backend);
+            let (pipeline, handles) = TtsPipeline::start(arc);
+            log::info!("TTS pipeline started (OpenAI backend)");
+            Some((pipeline, handles))
+        }
+        Err(e) => {
+            debug!("TTS pipeline disabled: {e}");
+            None
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use phantom_voice::MockVoiceSynth;
+
+    /// A [`TtsPipeline`] built from [`MockVoiceSynth`] must accept text without
+    /// panicking and report `is_active() == true` before the channel closes.
+    #[tokio::test]
+    async fn tts_pipeline_sends_text_to_backend() {
+        let backend: Arc<dyn VoiceSynth + Send + Sync> =
+            Arc::new(MockVoiceSynth::new());
+
+        let (pipeline, handles) = TtsPipeline::start(backend);
+
+        assert!(pipeline.is_active(), "pipeline must be active after start");
+
+        // Sending text should succeed.
+        let sent = pipeline.speak("Hello, Phantom.".to_string());
+        assert!(sent, "speak() must succeed while pipeline is active");
+
+        // Drop the pipeline to close the channel so the worker exits.
+        drop(pipeline);
+
+        // Worker should exit cleanly (no panic).
+        let _ = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            handles.worker,
+        )
+        .await;
+    }
+
+    /// A disabled pipeline (no backend) must never panic and always return
+    /// `false` from [`TtsPipeline::speak`].
+    #[test]
+    fn tts_pipeline_skips_when_no_backend() {
+        let pipeline = TtsPipeline::disabled();
+        assert!(
+            !pipeline.is_active(),
+            "disabled pipeline must not be active"
+        );
+        let sent = pipeline.speak("should be ignored".to_string());
+        assert!(!sent, "speak() on disabled pipeline must return false");
+    }
+
+    /// When `OPENAI_API_KEY` is absent, [`build_tts_pipeline_from_env`] must
+    /// return `None` without panicking.
+    #[test]
+    fn build_tts_pipeline_returns_none_without_api_key() {
+        // Snapshot current env state.
+        let prior = std::env::var("OPENAI_API_KEY").ok();
+        // SAFETY: only this test touches the var; no parallel env mutation.
+        unsafe { std::env::remove_var("OPENAI_API_KEY") };
+
+        let result = build_tts_pipeline_from_env();
+
+        unsafe {
+            match prior {
+                Some(v) => std::env::set_var("OPENAI_API_KEY", v),
+                None => std::env::remove_var("OPENAI_API_KEY"),
+            }
+        }
+
+        assert!(
+            result.is_none(),
+            "must return None when OPENAI_API_KEY is absent"
+        );
+    }
+}

--- a/crates/phantom-voice/Cargo.toml
+++ b/crates/phantom-voice/Cargo.toml
@@ -15,6 +15,8 @@ thiserror = "2"
 reqwest = { version = "0.12", features = ["json", "stream"] }
 bytes = "1"
 lru = "0.12"
+rodio = { version = "0.19", features = ["mp3"] }
+log = "0.4"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["sync", "rt", "macros"] }

--- a/crates/phantom-voice/src/lib.rs
+++ b/crates/phantom-voice/src/lib.rs
@@ -28,6 +28,7 @@ use futures_core::Stream;
 use lru::LruCache;
 
 pub mod openai;
+pub mod player;
 
 // ── OpenAiVoice enum ──────────────────────────────────────────────────────────
 

--- a/crates/phantom-voice/src/player.rs
+++ b/crates/phantom-voice/src/player.rs
@@ -1,0 +1,187 @@
+//! Audio output for synthesized speech chunks.
+//!
+//! [`AudioPlayer`] wraps a `rodio` output stream and exposes two ergonomic
+//! play surfaces:
+//!
+//! * [`AudioPlayer::play_bytes`] — decode and play a raw byte slice (e.g.
+//!   MP3 or WAV bytes returned by a batch TTS backend).
+//! * [`AudioPlayer::play_f32_chunks`] — receive streamed [`SynthAudioChunk`]
+//!   values from an [`mpsc::Receiver`] and queue them into the `rodio` sink as
+//!   they arrive.  Designed for the streaming OpenAI backend path.
+//!
+//! The `rodio` `OutputStream` must live as long as the player; we keep it in
+//! the struct (prefixed with `_` to suppress the unused-field lint) so the
+//! stream is kept alive for the lifetime of `AudioPlayer`.
+
+use std::io::Cursor;
+
+use rodio::{Decoder, OutputStream, OutputStreamHandle, Sink};
+use tokio::sync::mpsc;
+
+use crate::SynthAudioChunk;
+
+// ── Error type ────────────────────────────────────────────────────────────────
+
+/// Errors produced by [`AudioPlayer`].
+#[derive(Debug, thiserror::Error)]
+pub enum PlayerError {
+    /// The platform audio device could not be opened.
+    #[error("failed to open audio output stream: {0}")]
+    StreamOpen(String),
+    /// A [`Sink`] could not be constructed from the stream handle.
+    #[error("failed to create audio sink: {0}")]
+    SinkCreate(String),
+    /// The byte buffer could not be decoded as audio.
+    #[error("failed to decode audio bytes: {0}")]
+    Decode(String),
+}
+
+// ── AudioPlayer ───────────────────────────────────────────────────────────────
+
+/// Platform audio output backed by `rodio`.
+///
+/// Holds the `rodio` output stream alive for the lifetime of this value.
+/// Cheap to clone if you need multiple sinks — each clone shares the same
+/// underlying `OutputStreamHandle`.
+pub struct AudioPlayer {
+    /// Keep the stream alive; dropping it would silence all sinks.
+    _stream: OutputStream,
+    stream_handle: OutputStreamHandle,
+}
+
+impl AudioPlayer {
+    /// Open the default system audio output device.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PlayerError::StreamOpen`] when no audio output is available
+    /// (e.g. headless CI environment or no sound card).
+    pub fn new() -> Result<Self, PlayerError> {
+        let (_stream, stream_handle) = OutputStream::try_default()
+            .map_err(|e| PlayerError::StreamOpen(e.to_string()))?;
+        Ok(Self {
+            _stream,
+            stream_handle,
+        })
+    }
+
+    /// Play raw audio bytes (MP3, WAV, OGG, FLAC, etc.) through the default
+    /// audio output.
+    ///
+    /// Decodes `audio` with `rodio::Decoder` and blocks the current thread
+    /// until the clip finishes playing (unless the `Sink` is dropped early).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PlayerError::SinkCreate`] when the `rodio` sink cannot be
+    /// constructed, or [`PlayerError::Decode`] when the byte buffer is not a
+    /// recognised audio format.
+    pub fn play_bytes(&self, audio: &[u8]) -> Result<(), PlayerError> {
+        let sink = Sink::try_new(&self.stream_handle)
+            .map_err(|e| PlayerError::SinkCreate(e.to_string()))?;
+
+        let cursor = Cursor::new(audio.to_vec());
+        let source = Decoder::new(cursor).map_err(|e| PlayerError::Decode(e.to_string()))?;
+        sink.append(source);
+        sink.sleep_until_end();
+        Ok(())
+    }
+
+    /// Spawn a Tokio task that receives [`SynthAudioChunk`] values from `rx`
+    /// and queues them into a `rodio` sink for sequential playback.
+    ///
+    /// Each chunk's `f32` samples are wrapped in `rodio::buffer::SamplesBuffer`
+    /// so they are played back at the sample rate reported by the chunk.
+    /// The task exits when the sender is dropped (channel closed) or when a
+    /// chunk with `is_final == true` has been queued.
+    ///
+    /// Errors are logged rather than propagated — if the sink cannot be
+    /// created the task returns immediately.
+    pub fn play_f32_chunks(&self, mut rx: mpsc::Receiver<SynthAudioChunk>) {
+        let handle = self.stream_handle.clone();
+        tokio::spawn(async move {
+            let sink = match Sink::try_new(&handle) {
+                Ok(s) => s,
+                Err(e) => {
+                    log::error!("[phantom-voice] AudioPlayer: failed to create sink: {e}");
+                    return;
+                }
+            };
+
+            while let Some(chunk) = rx.recv().await {
+                let is_final = chunk.is_final;
+                let source = rodio::buffer::SamplesBuffer::new(
+                    1, // mono
+                    chunk.sample_rate,
+                    chunk.samples,
+                );
+                sink.append(source);
+                if is_final {
+                    break;
+                }
+            }
+
+            // Let `sink` drop here; it will drain its internal queue before
+            // being freed, so playback finishes naturally.
+            sink.sleep_until_end();
+        });
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Minimal valid 44-byte WAV: 1 channel, 8-bit PCM, 8000 Hz, 1 sample of silence.
+    // Constructed from the RIFF/WAVE spec by hand so the test has zero external deps.
+    fn silent_wav_bytes() -> Vec<u8> {
+        let mut wav: Vec<u8> = Vec::new();
+        // RIFF header
+        wav.extend_from_slice(b"RIFF");
+        wav.extend_from_slice(&36u32.to_le_bytes()); // chunk size = 36 + data size
+        wav.extend_from_slice(b"WAVE");
+        // fmt sub-chunk
+        wav.extend_from_slice(b"fmt ");
+        wav.extend_from_slice(&16u32.to_le_bytes()); // sub-chunk size (PCM = 16)
+        wav.extend_from_slice(&1u16.to_le_bytes()); // audio format = PCM
+        wav.extend_from_slice(&1u16.to_le_bytes()); // num channels = 1
+        wav.extend_from_slice(&8000u32.to_le_bytes()); // sample rate = 8000 Hz
+        wav.extend_from_slice(&8000u32.to_le_bytes()); // byte rate = 8000 * 1 * 1
+        wav.extend_from_slice(&1u16.to_le_bytes()); // block align = 1
+        wav.extend_from_slice(&8u16.to_le_bytes()); // bits per sample = 8
+        // data sub-chunk
+        wav.extend_from_slice(b"data");
+        wav.extend_from_slice(&1u32.to_le_bytes()); // data size = 1 byte
+        wav.push(128u8); // one sample of 8-bit silence (unsigned centre = 128)
+        wav
+    }
+
+    /// Verify that the WAV fixture parses as a valid rodio `Decoder` — this
+    /// exercises the actual format detection path without requiring a sound card.
+    #[test]
+    fn silent_wav_bytes_are_decodable_by_rodio() {
+        let wav = silent_wav_bytes();
+        let cursor = std::io::Cursor::new(wav);
+        Decoder::new(cursor).expect("silent WAV must be decodable by rodio");
+    }
+
+    /// `AudioPlayer::new()` may fail in headless CI environments (no audio
+    /// device), so we only assert that — when it succeeds — the player
+    /// produces a valid value, and we skip the test gracefully otherwise.
+    #[test]
+    fn audio_player_plays_silent_wav() {
+        let player = match AudioPlayer::new() {
+            Ok(p) => p,
+            Err(e) => {
+                // No audio device available (CI / headless). Treat as skip.
+                eprintln!("audio_player_plays_silent_wav: skipping — {e}");
+                return;
+            }
+        };
+
+        let wav = silent_wav_bytes();
+        player.play_bytes(&wav).expect("silent WAV must play without error");
+    }
+}


### PR DESCRIPTION
## Summary

- Add `rodio` audio output to `phantom-voice` via new `player.rs` with `AudioPlayer::play_bytes` (sync) and `play_f32_chunks` (async channel-driven)
- Create `TtsPipeline` in `phantom-app/src/tts.rs` mirroring the existing `SttPipeline` pattern — async Tokio worker drives synthesis, dedicated OS thread owns `rodio::OutputStream` (`!Send`) to keep it off the executor
- Auto-initialize pipeline from `OPENAI_API_KEY` at `App::with_config_scaled()` startup; no-op when absent or `privacy_mode` is on
- Hook into `AgentPane::poll()`: when `ApiEvent::Done` fires with a completed assistant message, forward text to `tts_tx` (non-blocking `try_send`)
- Wire the sender clone into every spawned agent pane from `App::spawn_agent_pane_with_opts`

## Architecture

```
AgentPane::poll()
  └─ ApiEvent::Done → tts_tx.try_send(text)
       └─ TtsPipeline Tokio worker (async synthesis)
            └─ collect PCM chunks via futures_core::Stream::poll_next
                 └─ sync_channel → audio OS thread (owns rodio OutputStream)
                      └─ encode_wav_f32 → AudioPlayer::play_bytes → rodio
```

## Test plan

- [x] `phantom-voice`: `audio_player_plays_silent_wav` — validates WAV decode path without requiring a sound card (skips gracefully in headless CI)
- [x] `phantom-app`: `tts_pipeline_sends_text_to_backend` — MockVoiceSynth pipeline accepts text, worker exits cleanly
- [x] `phantom-app`: `tts_pipeline_skips_when_no_backend` — disabled pipeline returns false from speak()
- [x] `phantom-app`: `build_tts_pipeline_returns_none_without_api_key` — env-var gate works
- [x] `./scripts/pre-pr-check.sh phantom-voice` — all gates pass (21 tests, 0 failures)
- [x] `./scripts/pre-pr-check.sh phantom-app` — build/clippy pass; 476 tests pass; 2 pre-existing capture failures unrelated to TTS

🤖 Generated with [Claude Code](https://claude.com/claude-code)