### PR TITLE
fix(phantom-app+phantom-ui): three pane management bugs — zero-px collapse, split depth, stale focus

### DIFF
--- a/crates/phantom-app/src/coordinator.rs
+++ b/crates/phantom-app/src/coordinator.rs
@@ -60,7 +60,7 @@ impl AppCoordinator {
     /// The arbiter is initialized with zero size; call
     /// `set_arbiter_size()` once the window content area and cell size
     /// are known (typically right after window creation).
-    #[must_use] 
+    #[must_use]
     pub fn new(bus: EventBus) -> Self {
         Self {
             registry: AppRegistry::new(),
@@ -93,6 +93,11 @@ impl AppCoordinator {
         self.run_arbiter_negotiation(layout);
     }
 
+    /// Minimum pane width in pixels — approximately 10 characters at 8px per char.
+    const MIN_PANE_WIDTH_PX: f32 = 80.0;
+    /// Minimum pane height in pixels — approximately 2 lines at 12px per line.
+    const MIN_PANE_HEIGHT_PX: f32 = 24.0;
+
     /// Collect spatial preferences from all running adapters, run the arbiter,
     /// and apply the resulting allocations as Taffy `min_size` / `max_size`
     /// constraints on the matching pane nodes.
@@ -101,6 +106,10 @@ impl AppCoordinator {
     /// `app_pane_map` and forwarded to [`LayoutEngine::set_pane_size_constraints`].
     /// Adapters that have no pane mapping (e.g. headless adapters registered
     /// without a layout pane) are skipped silently.
+    ///
+    /// Allocated dimensions are clamped to a minimum of
+    /// [`MIN_PANE_WIDTH_PX`] × [`MIN_PANE_HEIGHT_PX`] so that a denied arbiter
+    /// allocation never collapses a pane to zero pixels.
     fn run_arbiter_negotiation(&mut self, layout: &mut LayoutEngine) {
         let default_pref = SpatialPreference::simple(40, 10);
 
@@ -140,8 +149,10 @@ impl AppCoordinator {
                 continue;
             };
 
-            let min = Some((rect.width, rect.height));
-            let max = Some((rect.width, rect.height));
+            let clamped_width = rect.width.max(Self::MIN_PANE_WIDTH_PX);
+            let clamped_height = rect.height.max(Self::MIN_PANE_HEIGHT_PX);
+            let min = Some((clamped_width, clamped_height));
+            let max = Some((clamped_width, clamped_height));
             if let Err(e) = layout.set_pane_size_constraints(pane_id, min, max) {
                 log::warn!("Failed to apply arbiter constraints for adapter {id}: {e}");
             }
@@ -284,9 +295,9 @@ impl AppCoordinator {
 
         self.cadences.remove(&app_id);
 
-        if self.focused == Some(app_id) {
-            self.focused = self.registry.all_running().into_iter().next();
-        }
+        // Shift focus if the removed adapter was focused, or if the focused
+        // adapter's pane entry was otherwise invalidated.
+        self.validate_focus();
 
         // Re-negotiate so remaining adapters can claim freed space.
         self.run_arbiter_negotiation(layout);
@@ -379,7 +390,7 @@ impl AppCoordinator {
     ///
     /// `cell_size` is required because chrome insets are expressed in
     /// multiples of cell metrics (see [`crate::pane::pane_inner_rect`]).
-    #[must_use] 
+    #[must_use]
     pub fn render_all(
         &self,
         layout: &LayoutEngine,
@@ -448,41 +459,43 @@ impl AppCoordinator {
     pub fn sync_arbiter_to_scene(&self, plan: &LayoutPlan, scene: &mut SceneTree) {
         for (&app_id, rect) in &plan.allocations {
             if let Some(&node_id) = self.scene_map.get(&app_id)
-                && let Some(node) = scene.get_mut(node_id) {
-                    node.transform.x = rect.x;
-                    node.transform.y = rect.y;
-                    node.transform.width = rect.width;
-                    node.transform.height = rect.height;
-                    node.dirty |= DirtyFlags::TRANSFORM;
-                    log::debug!(
-                        "Scene sync: adapter {app_id} -> node {node_id} at ({:.0}, {:.0}, {:.0}x{:.0})",
-                        rect.x,
-                        rect.y,
-                        rect.width,
-                        rect.height,
-                    );
-                }
+                && let Some(node) = scene.get_mut(node_id)
+            {
+                node.transform.x = rect.x;
+                node.transform.y = rect.y;
+                node.transform.width = rect.width;
+                node.transform.height = rect.height;
+                node.dirty |= DirtyFlags::TRANSFORM;
+                log::debug!(
+                    "Scene sync: adapter {app_id} -> node {node_id} at ({:.0}, {:.0}, {:.0}x{:.0})",
+                    rect.x,
+                    rect.y,
+                    rect.width,
+                    rect.height,
+                );
+            }
         }
     }
 
     /// Build a `LayoutPlan` from the current Taffy layout.
-    #[must_use] 
+    #[must_use]
     pub fn build_layout_plan(&self, layout: &LayoutEngine) -> LayoutPlan {
         let mut allocations = HashMap::new();
         for id in self.registry.all_running() {
             if let Some(pane_id) = self.app_pane_map.get(&id)
-                && let Ok(r) = layout.get_pane_rect(*pane_id) {
-                    allocations.insert(
-                        id,
-                        Rect {
-                            x: r.x,
-                            y: r.y,
-                            width: r.width,
-                            height: r.height,
-                            ..Default::default()
-                        },
-                    );
-                }
+                && let Ok(r) = layout.get_pane_rect(*pane_id)
+            {
+                allocations.insert(
+                    id,
+                    Rect {
+                        x: r.x,
+                        y: r.y,
+                        width: r.width,
+                        height: r.height,
+                        ..Default::default()
+                    },
+                );
+            }
         }
         LayoutPlan { allocations }
     }
@@ -490,7 +503,7 @@ impl AppCoordinator {
     /// Scene-graph-aware render: reads positions from world_transform,
     /// sorted by z_order (lowest first = drawn first = behind).
     /// Focused adapter gets +1 z_order bonus.
-    #[must_use] 
+    #[must_use]
     pub fn render_all_with_scene(&self, scene: &SceneTree) -> Vec<(AppId, Rect, RenderOutput)> {
         let mut outputs = Vec::new();
         for id in self.registry.all_running() {
@@ -540,7 +553,7 @@ impl AppCoordinator {
     }
 
     /// Query which render layer an adapter's scene node belongs to.
-    #[must_use] 
+    #[must_use]
     pub fn render_layer_for(&self, app_id: AppId, scene: &SceneTree) -> RenderLayer {
         self.scene_map
             .get(&app_id)
@@ -551,7 +564,7 @@ impl AppCoordinator {
 
     /// Collect render outputs partitioned by RenderLayer.
     #[allow(dead_code)]
-    #[must_use] 
+    #[must_use]
     pub fn render_all_layered(
         &self,
         layout: &LayoutEngine,
@@ -604,19 +617,24 @@ impl AppCoordinator {
             let _ = layout.remove_pane(pane_id);
         }
 
+        // The floating adapter is removed from the tiled pane map; ensure focus
+        // does not point at an adapter without a tiled pane entry.
+        self.validate_focus();
+
         self.floating.insert(app_id);
         self.float_rects.insert(app_id, rect.clone());
 
         if let Some(&node_id) = self.scene_map.get(&app_id)
-            && let Some(node) = scene.get_mut(node_id) {
-                node.z_order = 50;
-                node.render_layer = RenderLayer::Overlay;
-                node.transform.x = rect.x;
-                node.transform.y = rect.y;
-                node.transform.width = rect.width;
-                node.transform.height = rect.height;
-                node.dirty |= DirtyFlags::TRANSFORM;
-            }
+            && let Some(node) = scene.get_mut(node_id)
+        {
+            node.z_order = 50;
+            node.render_layer = RenderLayer::Overlay;
+            node.transform.x = rect.x;
+            node.transform.y = rect.y;
+            node.transform.width = rect.width;
+            node.transform.height = rect.height;
+            node.dirty |= DirtyFlags::TRANSFORM;
+        }
 
         self.run_arbiter_negotiation(layout);
         log::info!(
@@ -629,16 +647,16 @@ impl AppCoordinator {
     }
 
     /// Get the scene node ID for an adapter, if it exists.
-    #[must_use] 
+    #[must_use]
     pub fn scene_node_for(&self, app_id: AppId) -> Option<phantom_scene::node::NodeId> {
         self.scene_map.get(&app_id).copied()
     }
 
-    #[must_use] 
+    #[must_use]
     pub fn is_floating(&self, app_id: AppId) -> bool {
         self.floating.contains(&app_id)
     }
-    #[must_use] 
+    #[must_use]
     pub fn float_rect(&self, app_id: AppId) -> Option<&Rect> {
         self.float_rects.get(&app_id)
     }
@@ -684,11 +702,12 @@ impl AppCoordinator {
         }
 
         if let Some(&node_id) = self.scene_map.get(&app_id)
-            && let Some(node) = scene.get_mut(node_id) {
-                node.z_order = 0;
-                node.render_layer = RenderLayer::Scene;
-                node.dirty |= DirtyFlags::TRANSFORM;
-            }
+            && let Some(node) = scene.get_mut(node_id)
+        {
+            node.z_order = 0;
+            node.render_layer = RenderLayer::Scene;
+            node.dirty |= DirtyFlags::TRANSFORM;
+        }
 
         self.run_arbiter_negotiation(layout);
         log::info!("Docked adapter {app_id} back to grid");
@@ -698,10 +717,11 @@ impl AppCoordinator {
     #[allow(dead_code)]
     pub fn set_render_layer(&self, app_id: AppId, layer: RenderLayer, scene: &mut SceneTree) {
         if let Some(&node_id) = self.scene_map.get(&app_id)
-            && let Some(node) = scene.get_mut(node_id) {
-                node.render_layer = layer;
-                node.dirty |= DirtyFlags::VISIBILITY;
-            }
+            && let Some(node) = scene.get_mut(node_id)
+        {
+            node.render_layer = layer;
+            node.dirty |= DirtyFlags::VISIBILITY;
+        }
     }
 
     /// Mark all adapter scene nodes as dirty (call on window resize).
@@ -786,7 +806,7 @@ impl AppCoordinator {
     /// Checks the adapter's state JSON for a `mouse_mode` field that is
     /// not `"none"`. Terminal adapters report this based on DEC mode
     /// tracking (modes 1000/1002/1003).
-    #[must_use] 
+    #[must_use]
     pub fn adapter_wants_mouse(&self, app_id: AppId) -> bool {
         self.registry
             .get_adapter(app_id)
@@ -818,14 +838,28 @@ impl AppCoordinator {
         self.focused = Some(app_id);
     }
 
+    /// Ensure the focused adapter still has a valid pane.
+    ///
+    /// If the currently focused `AppId` is no longer present in
+    /// `app_pane_map` (because its pane was removed), the focus is shifted
+    /// to the next available adapter. This prevents `route_input` and
+    /// `send_command_to_focused` from operating on a pane-less adapter.
+    fn validate_focus(&mut self) {
+        if let Some(focused_id) = self.focused {
+            if !self.app_pane_map.contains_key(&focused_id) {
+                self.focused = self.app_pane_map.keys().next().copied();
+            }
+        }
+    }
+
     /// The currently focused adapter, if any.
-    #[must_use] 
+    #[must_use]
     pub fn focused(&self) -> Option<AppId> {
         self.focused
     }
 
     /// Get the current state JSON from an adapter.
-    #[must_use] 
+    #[must_use]
     pub fn get_state(&self, app_id: AppId) -> Option<serde_json::Value> {
         let adapter = self.registry.get_adapter(app_id)?;
         Some(adapter.get_state())
@@ -864,7 +898,7 @@ impl AppCoordinator {
     }
 
     /// Number of adapters currently registered (including dead, pre-GC).
-    #[must_use] 
+    #[must_use]
     pub fn adapter_count(&self) -> usize {
         self.registry.count()
     }
@@ -884,25 +918,25 @@ impl AppCoordinator {
     }
 
     /// All app IDs that are currently running.
-    #[must_use] 
+    #[must_use]
     pub fn all_app_ids(&self) -> Vec<AppId> {
         self.registry.all_running()
     }
 
     /// The layout pane associated with an adapter.
-    #[must_use] 
+    #[must_use]
     pub fn pane_id_for(&self, app_id: AppId) -> Option<PaneId> {
         self.app_pane_map.get(&app_id).copied()
     }
 
     /// Look up which adapter owns a given layout pane.
-    #[must_use] 
+    #[must_use]
     pub fn app_id_for_pane(&self, pane_id: PaneId) -> Option<AppId> {
         self.pane_map.get(&pane_id).copied()
     }
 
     /// Immutable access to the event bus.
-    #[must_use] 
+    #[must_use]
     pub fn bus(&self) -> &EventBus {
         &self.bus
     }
@@ -913,7 +947,7 @@ impl AppCoordinator {
     }
 
     /// Immutable access to the app registry.
-    #[must_use] 
+    #[must_use]
     pub fn registry(&self) -> &AppRegistry {
         &self.registry
     }
@@ -928,11 +962,7 @@ impl AppCoordinator {
         self.registry
             .all_running()
             .into_iter()
-            .find(|&id| {
-                self.registry
-                    .get(id)
-                    .is_some_and(|e| e.app_type == ty)
-            })
+            .find(|&id| self.registry.get(id).is_some_and(|e| e.app_type == ty))
     }
 
     /// Mutable access to the app registry.
@@ -946,7 +976,7 @@ impl AppCoordinator {
     ///
     /// Used by the bus-drain loop to populate `ParsedOutput::raw_output`
     /// when a `CommandComplete` event fires (issue #226).
-    #[must_use] 
+    #[must_use]
     pub fn terminal_output_buf(&self, app_id: AppId) -> Option<String> {
         self.registry.get_adapter(app_id)?.output_buf_snapshot()
     }
@@ -2180,5 +2210,102 @@ mod tests {
             rect.width,
             available.0,
         );
+    }
+
+    // ── Bug-fix: arbiter zero-pixel clamp ────────────────────────────────────
+
+    /// When the arbiter allocates 0 × 0 px (window too small to satisfy
+    /// minimums), the negotiation must clamp to at least MIN_PANE_WIDTH_PX ×
+    /// MIN_PANE_HEIGHT_PX rather than collapsing the pane to invisible.
+    #[test]
+    fn pane_arbiter_clamps_to_min_width() {
+        let mut coord = AppCoordinator::new_test(EventBus::new());
+        let mut layout = LayoutEngine::new().unwrap();
+        let mut scene = SceneTree::new();
+        let content = scene.add_node(scene.root(), NodeKind::ContentArea);
+
+        // Configure an absurdly small content area so the arbiter will deny
+        // all spatial requests and return 0-pixel allocations.
+        coord.set_arbiter_size((1.0, 1.0), (8.0, 16.0));
+
+        let id = register_mock(&mut coord, &mut layout, &mut scene, content, "tiny");
+
+        // Recompute at the same tiny size.
+        layout.resize(1.0, 60.0).unwrap(); // 60 ≈ chrome heights
+
+        let pane_id = coord.pane_id_for(id).expect("pane must have a layout node");
+        let rect = layout
+            .get_pane_rect(pane_id)
+            .expect("rect must be computable");
+
+        // The Taffy min_size was clamped, so the pane rect must be at least
+        // MIN_PANE_WIDTH_PX wide and MIN_PANE_HEIGHT_PX tall.
+        assert!(
+            rect.width >= AppCoordinator::MIN_PANE_WIDTH_PX,
+            "pane width {} must be clamped to at least {}",
+            rect.width,
+            AppCoordinator::MIN_PANE_WIDTH_PX,
+        );
+        assert!(
+            rect.height >= AppCoordinator::MIN_PANE_HEIGHT_PX,
+            "pane height {} must be clamped to at least {}",
+            rect.height,
+            AppCoordinator::MIN_PANE_HEIGHT_PX,
+        );
+    }
+
+    // ── Bug-fix: stale focus after pane removal ───────────────────────────────
+
+    /// After removing the focused adapter, `focused()` must return `None` when
+    /// no other adapters remain.
+    #[test]
+    fn focus_clears_when_focused_pane_removed() {
+        let mut coord = AppCoordinator::new_test(EventBus::new());
+        let mut layout = LayoutEngine::new().unwrap();
+        let mut scene = SceneTree::new();
+        let content = scene.add_node(scene.root(), NodeKind::ContentArea);
+
+        let id = register_mock(&mut coord, &mut layout, &mut scene, content, "only");
+        assert_eq!(coord.focused(), Some(id));
+
+        coord.remove_adapter(id, &mut layout, &mut scene);
+
+        assert_eq!(
+            coord.focused(),
+            None,
+            "focus must be None when the focused adapter is removed and no others remain"
+        );
+    }
+
+    /// After removing the focused adapter when another adapter is present,
+    /// focus must shift to the remaining adapter.
+    #[test]
+    fn focus_shifts_to_next_pane_after_close() {
+        let mut coord = AppCoordinator::new_test(EventBus::new());
+        let mut layout = LayoutEngine::new().unwrap();
+        let mut scene = SceneTree::new();
+        let content = scene.add_node(scene.root(), NodeKind::ContentArea);
+
+        let id_a = register_mock(&mut coord, &mut layout, &mut scene, content, "a");
+        let id_b = register_mock(&mut coord, &mut layout, &mut scene, content, "b");
+
+        // First adapter gets auto-focus.
+        assert_eq!(coord.focused(), Some(id_a));
+
+        // Remove the focused adapter.
+        coord.remove_adapter(id_a, &mut layout, &mut scene);
+
+        // Focus must now point at the surviving adapter (not None, not id_a).
+        let focused = coord.focused();
+        assert!(
+            focused.is_some(),
+            "focus must shift to a surviving adapter, got None"
+        );
+        assert_ne!(
+            focused,
+            Some(id_a),
+            "focus must not point at removed adapter"
+        );
+        assert_eq!(focused, Some(id_b), "focus must shift to id_b");
     }
 }

--- a/crates/phantom-ui/src/layout.rs
+++ b/crates/phantom-ui/src/layout.rs
@@ -10,6 +10,32 @@ const TAB_BAR_HEIGHT_LOGICAL: f32 = 30.0;
 /// Logical height of the status bar in points (before DPI scaling).
 const STATUS_BAR_HEIGHT_LOGICAL: f32 = 28.0;
 
+/// Maximum allowed nesting depth for split panes.
+///
+/// Attempting to split a pane that would push any leaf beyond this depth
+/// returns [`LayoutError::MaxDepthExceeded`] so the caller can surface a
+/// notification instead of allowing unbounded recursion.
+const MAX_SPLIT_DEPTH: usize = 20;
+
+/// Errors that can be returned by the layout engine.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LayoutError {
+    /// A split was requested but the target pane is already at the maximum
+    /// allowed nesting depth. Show a notification to the user instead of
+    /// creating an unboundedly deep tree.
+    MaxDepthExceeded,
+}
+
+impl std::fmt::Display for LayoutError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MaxDepthExceeded => write!(f, "maximum split depth ({MAX_SPLIT_DEPTH}) exceeded"),
+        }
+    }
+}
+
+impl std::error::Error for LayoutError {}
+
 /// A rectangle in pixel coordinates, representing the computed position
 /// and size of a layout region.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -40,7 +66,7 @@ pub struct PaneId(NodeId);
 
 impl PaneId {
     /// Returns the underlying taffy `NodeId`.
-    #[must_use] 
+    #[must_use]
     pub fn node_id(self) -> NodeId {
         self.0
     }
@@ -267,7 +293,7 @@ impl LayoutEngine {
     }
 
     /// Return the number of direct children of the content area.
-    #[must_use] 
+    #[must_use]
     pub fn pane_count(&self) -> usize {
         self.tree.child_count(self.content)
     }
@@ -324,13 +350,13 @@ impl LayoutEngine {
     /// status bar) as well as all live pane nodes. Use this to assert that
     /// spawn-close cycles do not permanently grow the tree.
     #[cfg(any(test, feature = "test-utils"))]
-    #[must_use] 
+    #[must_use]
     pub fn total_node_count(&self) -> usize {
         self.tree.total_node_count()
     }
 
     /// Return the root `NodeId` (useful for debugging / printing).
-    #[must_use] 
+    #[must_use]
     pub fn root(&self) -> NodeId {
         self.root
     }
@@ -339,10 +365,33 @@ impl LayoutEngine {
     // Internal helpers
     // ----------------------------------------------------------------
 
+    /// Walk up the Taffy parent chain from `node` and return the depth (number
+    /// of ancestors) not counting `node` itself.  Returns 0 when `node` has no
+    /// parent (i.e. it is the root).
+    fn node_depth(&self, node: NodeId) -> usize {
+        let mut depth = 0usize;
+        let mut current = node;
+        while let Some(parent) = self.tree.parent(current) {
+            depth += 1;
+            current = parent;
+        }
+        depth
+    }
+
     /// Perform a split on an existing pane, converting it into a flex container
     /// in the given direction with two equally-sized children.
+    ///
+    /// Returns [`LayoutError::MaxDepthExceeded`] (wrapped in an `anyhow` error)
+    /// if the pane is already at [`MAX_SPLIT_DEPTH`] and creating children would
+    /// push them past the limit.
     fn split(&mut self, pane: PaneId, direction: FlexDirection) -> Result<(PaneId, PaneId)> {
         let pane_node = pane.0;
+
+        // Guard: children of `pane` will sit one level deeper than `pane`.
+        let depth = self.node_depth(pane_node);
+        if depth >= MAX_SPLIT_DEPTH {
+            return Err(anyhow::Error::new(LayoutError::MaxDepthExceeded));
+        }
 
         // Create the two child panes that will live inside the split container.
         let child_style = Style {
@@ -393,16 +442,31 @@ impl LayoutEngine {
         Ok((PaneId(left), PaneId(right)))
     }
 
-    /// Recursively remove a node and all its descendants from the tree.
+    /// Iteratively remove a node and all its descendants from the tree.
+    ///
+    /// Uses an explicit stack instead of recursion so that a deeply nested
+    /// split tree (up to [`MAX_SPLIT_DEPTH`] levels) cannot overflow the call
+    /// stack.  Nodes are removed in a post-order fashion: each node's children
+    /// are enqueued before the node itself so the Taffy tree remains
+    /// structurally valid throughout.
     fn remove_subtree(&mut self, node: NodeId) -> Result<()> {
-        // Collect children first to avoid borrow issues.
-        let children: Vec<NodeId> = self.tree.children(node).unwrap_or_default();
-        for child in children {
-            self.remove_subtree(child)?;
+        // Build the full visit order iteratively (post-order: children first).
+        let mut to_visit = vec![node];
+        let mut removal_order: Vec<NodeId> = Vec::new();
+
+        while let Some(current) = to_visit.pop() {
+            removal_order.push(current);
+            let children = self.tree.children(current).unwrap_or_default();
+            to_visit.extend(children);
         }
-        self.tree
-            .remove(node)
-            .map_err(|e| anyhow::anyhow!("failed to remove node: {e}"))?;
+
+        // Remove in reverse order so leaves are removed before their parents.
+        for id in removal_order.into_iter().rev() {
+            self.tree
+                .remove(id)
+                .map_err(|e| anyhow::anyhow!("failed to remove node: {e}"))?;
+        }
+
         Ok(())
     }
 
@@ -825,6 +889,84 @@ mod tests {
             approx_eq(rect.height, expected_height),
             "cleared pane should fill content height; got {}",
             rect.height,
+        );
+    }
+
+    // ── Bug-fix: MAX_SPLIT_DEPTH guard ────────────────────────────────────────
+
+    /// Splitting a pane at the maximum allowed nesting depth must return
+    /// `LayoutError::MaxDepthExceeded` instead of creating a deeper tree.
+    #[test]
+    fn split_at_max_depth_returns_error() {
+        let mut engine = LayoutEngine::new().unwrap();
+
+        // Build a chain of single-child splits up to the depth limit.
+        // Each split_horizontal call promotes the current leaf and returns
+        // two children; we keep the left child and recurse into it.
+        let mut current = engine.add_pane().unwrap();
+        engine.resize(WINDOW_W, WINDOW_H).unwrap();
+
+        // Drive the nesting to MAX_SPLIT_DEPTH.
+        //
+        // `add_pane` places the leaf at absolute depth 2 (root → content →
+        // pane).  Each `split_horizontal` promotes the current leaf and returns
+        // children one level deeper.  The guard fires when the current node's
+        // depth reaches MAX_SPLIT_DEPTH (≥ 20).  Starting from depth 2, we
+        // need MAX_SPLIT_DEPTH − 2 successful splits before hitting the limit.
+        for _ in 0..(MAX_SPLIT_DEPTH - 2) {
+            let (left, _right) = engine.split_horizontal(current).unwrap();
+            current = left;
+        }
+
+        // The next split must be rejected — `current` is now at depth MAX_SPLIT_DEPTH.
+        let result = engine.split_horizontal(current);
+        assert!(
+            result.is_err(),
+            "split beyond MAX_SPLIT_DEPTH must return an error"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.downcast_ref::<LayoutError>()
+                .is_some_and(|e| *e == LayoutError::MaxDepthExceeded),
+            "error must be LayoutError::MaxDepthExceeded, got: {err}"
+        );
+    }
+
+    // ── Bug-fix: iterative remove_subtree ─────────────────────────────────────
+
+    /// Removing a deeply nested split subtree must succeed without stack
+    /// overflow.  We build a MAX_SPLIT_DEPTH-deep chain and then close the
+    /// deepest leaf, which triggers `remove_subtree` on the entire sub-chain.
+    #[test]
+    fn remove_subtree_iterative_no_stack_overflow() {
+        let mut engine = LayoutEngine::new().unwrap();
+        let baseline = engine.total_node_count();
+
+        let mut current = engine.add_pane().unwrap();
+        engine.resize(WINDOW_W, WINDOW_H).unwrap();
+
+        // Build a chain split as deep as allowed.
+        // Same depth math as above: MAX_SPLIT_DEPTH − 2 successful splits.
+        let mut right_leaves: Vec<PaneId> = Vec::new();
+        for _ in 0..(MAX_SPLIT_DEPTH - 2) {
+            let (left, right) = engine.split_horizontal(current).unwrap();
+            right_leaves.push(right);
+            current = left;
+        }
+
+        // Close the right leaves from deepest to shallowest, then the deepest left leaf.
+        for r in right_leaves.into_iter().rev() {
+            engine.remove_pane(r).unwrap();
+        }
+        engine.remove_pane(current).unwrap();
+
+        engine.resize(WINDOW_W, WINDOW_H).unwrap();
+
+        // All nodes must be pruned; tree returns to chrome-only baseline.
+        assert_eq!(
+            engine.total_node_count(),
+            baseline,
+            "deep split chain must not leak nodes"
         );
     }
 }


### PR DESCRIPTION
## Summary

- **Bug 1 (HIGH)**: Arbiter allocations of 0px no longer collapse panes to invisible. `run_arbiter_negotiation` now clamps each allocation to `MIN_PANE_WIDTH_PX` (80px) × `MIN_PANE_HEIGHT_PX` (24px) before passing to Taffy `min_size`/`max_size`.
- **Bug 2 (MEDIUM)**: `split()` in `LayoutEngine` now guards against unbounded nesting with `MAX_SPLIT_DEPTH = 20`, returning `LayoutError::MaxDepthExceeded` when a split would push a leaf past the limit. `remove_subtree()` was converted from stack recursion to an iterative post-order walk using an explicit `Vec` stack, eliminating stack-overflow risk on deep trees.
- **Bug 3 (MEDIUM)**: Added `validate_focus()` helper to `AppCoordinator` that clears/shifts `self.focused` when the focused adapter's pane entry is no longer in `app_pane_map`. Called after every pane removal in `remove_adapter()` and the float-detach path.

## Files changed

- `crates/phantom-app/src/coordinator.rs` — Bug 1 clamp, Bug 3 `validate_focus`
- `crates/phantom-ui/src/layout.rs` — Bug 2 `MAX_SPLIT_DEPTH`, iterative `remove_subtree`, `LayoutError` type

## Tests added

- `pane_arbiter_clamps_to_min_width` — tiny content area forces 0px arbiter allocation; asserts pane rect ≥ 80×24
- `split_at_max_depth_returns_error` — builds tree to depth limit; asserts `LayoutError::MaxDepthExceeded`
- `remove_subtree_iterative_no_stack_overflow` — MAX_SPLIT_DEPTH-deep chain; closes all leaves; asserts zero node leak
- `focus_clears_when_focused_pane_removed` — single adapter removed; asserts `focused() == None`
- `focus_shifts_to_next_pane_after_close` — two adapters; remove focused one; asserts focus shifts to survivor

## Test plan

- [ ] `cargo check -p phantom-ui` passes (verified locally)
- [ ] `cargo fmt --check -p phantom-ui` passes (verified locally)
- [ ] `cargo fmt --check -p phantom-app` passes (verified locally)
- [ ] `cargo test -p phantom-ui` (blocked by disk space in this environment; requires CI)
- [ ] `cargo test -p phantom-app coordinator` (blocked by disk space in this environment; requires CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)