### PR TITLE
feat: wire phantom-bundles CaptureSession + phantom-embeddings OpenAI backend

### DIFF
--- a/crates/phantom-app/src/app.rs
+++ b/crates/phantom-app/src/app.rs
@@ -450,6 +450,15 @@ pub struct App {
     /// into each spawned tokio task without blocking the render thread.
     pub(crate) vision_analyzer: Option<std::sync::Arc<phantom_vision::VisionAnalyzer>>,
 
+    // -- Embedding backend (optional, initialized from OPENAI_API_KEY).
+    //    `None` when `OPENAI_API_KEY` is absent or empty — the capture
+    //    pipeline persists bundles without vector indexing in that case.
+    //    Stored as `Arc<dyn EmbeddingBackend>` so it can be shared with
+    //    off-thread persistence jobs via `Arc::clone` without holding a
+    //    reference back to the `App`.
+    pub(crate) embedding_backend:
+        Option<std::sync::Arc<dyn phantom_embeddings::EmbeddingBackend>>,
+
     // -- Per-pane last-command tracking (issue #226).
     //    Populated from `Event::CommandStarted` so that the subsequent
     //    `Event::CommandComplete` handler in `drain_bus_to_brain` can feed
@@ -830,6 +839,28 @@ impl App {
         } else {
             info!("Bundle store unavailable — per-pane capture disabled");
         }
+
+        // -- Embedding backend (optional). Constructed from OPENAI_API_KEY when
+        //    present so the capture pipeline can vector-index sealed bundles.
+        //    When the key is absent we store None and log at debug level — bundles
+        //    still persist with metadata; only vector search is unavailable.
+        //    The client is cached inside the backend (not per-request) so the
+        //    Arc<dyn EmbeddingBackend> can be shared cheaply with job workers.
+        let embedding_backend: Option<std::sync::Arc<dyn phantom_embeddings::EmbeddingBackend>> =
+            match phantom_embeddings::openai::OpenAiEmbeddingBackend::from_env() {
+                Ok(backend) => {
+                    info!("Embedding backend ready (OpenAI text-embedding-3-large)");
+                    Some(std::sync::Arc::new(backend))
+                }
+                Err(phantom_embeddings::EmbedError::NotConfigured(_)) => {
+                    debug!("OPENAI_API_KEY not set — embedding backend disabled");
+                    None
+                }
+                Err(e) => {
+                    warn!("Embedding backend init failed: {e} — vector indexing disabled");
+                    None
+                }
+            };
 
         // -- Scene graph --
         let mut scene = SceneTree::new();
@@ -1337,6 +1368,7 @@ impl App {
             vision_analyzer: phantom_vision::VisionAnalyzer::from_env()
                 .ok()
                 .map(std::sync::Arc::new),
+            embedding_backend,
             ticket_dispatcher,
             pane_last_command: std::collections::HashMap::new(),
             shader_reloader: phantom_renderer::shader_loader::ShaderReloader::new(),
@@ -1804,6 +1836,66 @@ fn open_bundle_store() -> Option<std::sync::Arc<phantom_bundle_store::BundleStor
 #[cfg(test)]
 mod tests {
     use super::open_bundle_store;
+
+    // -- Helpers for env-var mutation in tests --------------------------------
+
+    /// Serialize env-var mutations so parallel tests in the same binary
+    /// don't stomp on each other.
+    fn with_env_var<F: FnOnce()>(key: &str, value: Option<&str>, f: F) {
+        use std::sync::Mutex;
+        static LOCK: Mutex<()> = Mutex::new(());
+        let _guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prior = std::env::var(key).ok();
+        // SAFETY: serialized by LOCK.
+        unsafe {
+            match value {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+        }
+        f();
+        unsafe {
+            match prior {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+        }
+    }
+
+    // -- Embedding backend construction tests --------------------------------
+
+    /// `embedding_backend_created_when_key_present`
+    ///
+    /// When `OPENAI_API_KEY` is set to a non-empty value,
+    /// `OpenAiEmbeddingBackend::from_env()` must succeed and produce a
+    /// backend whose `name()` is `"openai-embedding"`.
+    #[test]
+    fn embedding_backend_created_when_key_present() {
+        use phantom_embeddings::EmbeddingBackend;
+        with_env_var("OPENAI_API_KEY", Some("sk-test-fixture"), || {
+            let backend = phantom_embeddings::openai::OpenAiEmbeddingBackend::from_env()
+                .expect("from_env should succeed when key is set");
+            assert_eq!(backend.name(), "openai-embedding");
+        });
+    }
+
+    /// `embedding_backend_none_when_no_key`
+    ///
+    /// When `OPENAI_API_KEY` is absent, `OpenAiEmbeddingBackend::from_env()`
+    /// must return `Err(EmbedError::NotConfigured(_))` — the App then stores
+    /// `None` for `embedding_backend`.
+    #[test]
+    fn embedding_backend_none_when_no_key() {
+        with_env_var("OPENAI_API_KEY", None, || {
+            let result = phantom_embeddings::openai::OpenAiEmbeddingBackend::from_env();
+            assert!(
+                matches!(result, Err(phantom_embeddings::EmbedError::NotConfigured(_))),
+                "expected NotConfigured, got {result:?}"
+            );
+        });
+    }
+
+    // -- Bundle store env guard test -----------------------------------------
 
     /// Setting `PHANTOM_DISABLE_BUNDLE_STORE=1` must short-circuit
     /// `open_bundle_store()` and return `None` WITHOUT touching the

--- a/crates/phantom-app/src/capture.rs
+++ b/crates/phantom-app/src/capture.rs
@@ -39,6 +39,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use phantom_adapter::AppId;
 use phantom_bundle_store::{BundleEmbeddings, BundleStore};
 use phantom_bundles::{Bundle, FrameRef};
+use phantom_bundles::session::{CaptureFrame, CaptureSession};
 use phantom_embeddings::{
     EmbedItem, EmbedRequest, Embedding, EmbeddingBackend, Modality, openai::OpenAiEmbeddingBackend,
 };
@@ -73,7 +74,12 @@ const MAX_FRAMES_PER_BUNDLE: usize = 128;
 /// produced at least one capture. Tracks the last dhash (for dedup), how
 /// many consecutive identical captures we've seen (for adaptive cadence),
 /// when we last captured (for the cadence gate itself), and the in-flight
-/// bundle being assembled.
+/// [`CaptureSession`] being assembled.
+///
+/// The [`CaptureSession`] accumulates [`CaptureFrame`] values (phash, pixels,
+/// dimensions) and handles run-length duplicate suppression internally.
+/// When sealed via [`CaptureSession::finalize`] it produces a [`Bundle`] ready
+/// for the persistence job.
 #[derive(Default)]
 pub(crate) struct PaneCaptureState {
     /// dhash of the most recently *stored* frame for this pane.
@@ -83,19 +89,21 @@ pub(crate) struct PaneCaptureState {
     /// Wall-clock time when we last *attempted* a capture for this pane.
     /// `None` means no attempt yet — capture immediately on the next call.
     last_attempt: Option<Instant>,
-    /// Wall-clock when the open bundle started, in monotonic time.
-    /// Used to compute frame `t_offset_ns`.
+    /// Wall-clock when the open session started, in monotonic time.
+    /// Used to compute frame `t_offset_ns` when building the `Bundle`.
     bundle_start: Option<Instant>,
-    /// Wall-clock unix-ms when the open bundle started. Stored verbatim on
-    /// the `Bundle` at seal time.
+    /// Wall-clock unix-ms when the open session started. Stored verbatim on
+    /// the sealed `Bundle`.
     bundle_wall_ms: i64,
-    /// Bundle currently being assembled. `None` means no open bundle —
-    /// the next captured frame will start one.
-    open_bundle: Option<Bundle>,
-    /// Raw RGBA pixel buffers for each frame in `open_bundle`, in lock-step
-    /// with `Bundle::frames`. The persistence job consumes these to encode
-    /// PNG and seal them into the encrypted blob store. Cleared every
-    /// time `open_bundle` is taken.
+    /// Capture session currently being assembled.  `None` means no open
+    /// session — the next captured frame will start one.  Replaces the old
+    /// manual `open_bundle: Option<Bundle>` field.
+    open_session: Option<CaptureSession>,
+    /// Raw RGBA pixel buffers for each frame accepted into `open_session`,
+    /// in lock-step with the session's internal frame list.  The persistence
+    /// job consumes these to encode PNG blobs; they are not stored inside
+    /// [`CaptureSession`] because the blob layer is separate from the schema.
+    /// Cleared every time `open_session` is finalized/taken.
     pending_pixels: Vec<Vec<u8>>,
 }
 
@@ -133,14 +141,14 @@ impl CaptureState {
     }
 
     /// Total frames captured (across all panes) that are currently in open
-    /// (unsealed) bundles. Used by tests to assert dedup behavior without
+    /// (unsealed) sessions. Used by tests to assert dedup behavior without
     /// reaching into the bundle store.
     #[allow(dead_code)]
     #[must_use]
     pub fn open_frame_count(&self) -> usize {
         self.panes
             .values()
-            .map(|p| p.open_bundle.as_ref().map_or(0, |b| b.frames.len()))
+            .map(|p| p.open_session.as_ref().map_or(0, |s| s.frame_count()))
             .sum()
     }
 
@@ -559,52 +567,64 @@ impl crate::app::App {
                 });
             }
 
-            // Open a fresh bundle if we don't have one. Wall-clock is
-            // captured here so frame offsets are relative to bundle start.
-            if pane_state.open_bundle.is_none() {
-                let pane_id_u64 = u64::from(app_id);
-                let mut b = Bundle::new(pane_id_u64);
-                b.t_start_ns = 0;
-                b.t_wall_unix_ms = SystemTime::now()
+            // Validate frame dimensions before accumulating. A zero-dimension
+            // frame cannot be PNG-encoded and would produce an empty blob.
+            // Log and skip so the pipeline keeps running on the other panes.
+            if extent.0 == 0 || extent.1 == 0 {
+                log::warn!(
+                    "capture_panes: skipping zero-dimension frame for pane {app_id} \
+                     ({}x{})",
+                    extent.0,
+                    extent.1,
+                );
+                continue;
+            }
+
+            // Open a fresh CaptureSession if we don't have one. Wall-clock is
+            // captured here so frame offsets are relative to session start.
+            if pane_state.open_session.is_none() {
+                let session_id = uuid::Uuid::new_v4();
+                pane_state.bundle_start = Some(now);
+                pane_state.bundle_wall_ms = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
                     .map(|d| d.as_millis() as i64)
                     .unwrap_or(0);
-                pane_state.bundle_start = Some(now);
-                pane_state.bundle_wall_ms = b.t_wall_unix_ms;
-                pane_state.open_bundle = Some(b);
+                pane_state.open_session = Some(CaptureSession::new(session_id));
             }
 
-            let t_offset_ns = pane_state
-                .bundle_start
-                .map(|s| now.duration_since(s).as_nanos() as u64)
-                .unwrap_or(0);
-
-            // SHA-256-style hex of the raw RGBA — gives us a
-            // content-addressable identifier for the frame blob without
-            // pulling in another dep. The actual blob_path is filled in
-            // by the persist job once the store decides where it lives.
-            let sha_hex = simple_sha_hex(&pixels);
-            let bundle = pane_state.open_bundle.as_mut().expect("just inserted");
-            let frame = FrameRef {
-                t_offset_ns,
-                sha: sha_hex,
-                // Placeholder path. `PersistBundleJob::run` rewrites this
-                // to the relpath returned by `BundleStore::write_frame_blob`.
-                blob_path: format!("frames/{}-{}.png", bundle.id, bundle.frames.len()),
-                dhash: hash,
-                width: extent.0,
-                height: extent.1,
-            };
-            bundle.add_frame(frame);
+            // Push the captured frame into the CaptureSession.
+            // CaptureFrame carries the raw pixels so the session knows what
+            // to hand to finalize(); pending_pixels travels in lock-step for
+            // the PNG-encoding layer in the persistence job.
+            let session = pane_state.open_session.as_mut().expect("just opened");
+            let capture_frame = CaptureFrame::new(
+                frame_timestamp_ms,
+                hash,
+                pixels.clone(),
+                extent.0,
+                extent.1,
+            );
+            session.add_frame(capture_frame);
             pane_state.pending_pixels.push(pixels);
 
-            // Force-seal if the open bundle is at the cap.
-            if bundle.frames.len() >= MAX_FRAMES_PER_BUNDLE {
-                let mut taken = pane_state.open_bundle.take().expect("just had it");
-                taken.seal(Some("auto-cap".into()), vec!["auto".into()], 0.3);
+            // Force-seal if the session is at the cap.
+            if session.frame_count() >= MAX_FRAMES_PER_BUNDLE {
+                let taken_session = pane_state.open_session.take().expect("just had it");
                 let pixels_for_seal = std::mem::take(&mut pane_state.pending_pixels);
-                sealed_bundles.push((taken, pixels_for_seal));
                 pane_state.bundle_start = None;
+
+                match taken_session.finalize() {
+                    Ok(mut bundle) => {
+                        // Stamp wall-clock on the bundle so the store can order by time.
+                        // `finalize` already sealed the bundle via BundleAssembler::finish;
+                        // we only overwrite the wall-clock field.
+                        bundle.t_wall_unix_ms = pane_state.bundle_wall_ms;
+                        sealed_bundles.push((bundle, pixels_for_seal));
+                    }
+                    Err(e) => {
+                        log::warn!("CaptureSession::finalize failed at cap for pane {app_id}: {e}");
+                    }
+                }
             }
         }
 
@@ -615,26 +635,46 @@ impl crate::app::App {
         }
     }
 
-    /// Seal the open bundle for `pane` (if any) and queue it for persistence.
-    /// Called at command boundaries via [`Self::on_command_boundary`] and
-    /// from the bus-drain loop when an `Event::CommandComplete` is observed.
+    /// Seal the open session for `pane` (if any), finalize it into a
+    /// [`Bundle`], and queue it for persistence.  Called at command
+    /// boundaries via [`Self::on_command_boundary`] and from the bus-drain
+    /// loop when an `Event::CommandComplete` is observed.
     ///
     /// Returns `true` if a bundle was sealed and queued, `false` if there
-    /// was nothing to do (no open bundle for this pane).
+    /// was nothing to do (no open session for this pane, or the session had
+    /// no valid frames after zero-dimension filtering).
     pub(crate) fn seal_pane_bundle(&mut self, pane: AppId, intent: Option<String>) -> bool {
         let Some(state) = self.capture_state.panes.get_mut(&pane) else {
             return false;
         };
-        let Some(mut bundle) = state.open_bundle.take() else {
+        let Some(session) = state.open_session.take() else {
             return false;
         };
         let pixels = std::mem::take(&mut state.pending_pixels);
+        let wall_ms = state.bundle_wall_ms;
         state.bundle_start = None;
         state.last_dhash = None;
         state.consecutive_identical = 0;
-        bundle.seal(intent, vec!["pane-boundary".into()], 0.5);
-        self.persist_sealed_bundles(vec![(bundle, pixels)]);
-        true
+
+        match session.finalize() {
+            Ok(mut bundle) => {
+                // `finalize` already sealed the bundle via BundleAssembler::finish;
+                // we only overwrite the wall-clock field which was 0-initialized.
+                bundle.t_wall_unix_ms = wall_ms;
+                // Propagate the caller's intent into the already-sealed bundle.
+                if let Some(ref intent_str) = intent {
+                    bundle.intent = Some(intent_str.clone());
+                }
+                self.persist_sealed_bundles(vec![(bundle, pixels)]);
+                true
+            }
+            Err(e) => {
+                log::warn!(
+                    "seal_pane_bundle: CaptureSession::finalize failed for pane {pane}: {e}"
+                );
+                false
+            }
+        }
     }
 
     /// Explicit entry point for command-boundary sealing.
@@ -664,6 +704,10 @@ impl crate::app::App {
 
     /// Submit one or more sealed bundles to the job pool for off-thread
     /// persistence. The render thread never blocks on disk I/O.
+    ///
+    /// Uses the `embedding_backend` pre-wired at startup (from
+    /// [`App::with_config_scaled`]) to determine whether vector indexing is
+    /// available. Avoids re-reading the env var on every seal event.
     fn persist_sealed_bundles(&mut self, bundles: Vec<(Bundle, Vec<Vec<u8>>)>) {
         let Some(store) = self.bundle_store.clone() else {
             return;
@@ -674,13 +718,9 @@ impl crate::app::App {
             log::warn!("no job pool, dropping {} sealed bundles", bundles.len());
             return;
         };
-        // Decide once whether OpenAI embeddings are reachable from this
-        // process. If `OPENAI_API_KEY` is unset we never spin up a tokio
-        // runtime on the worker — bundles still persist with metadata.
-        let backend_kind = if std::env::var_os("OPENAI_API_KEY")
-            .filter(|v| !v.is_empty())
-            .is_some()
-        {
+        // Use the pre-constructed embedding backend stored on the App.
+        // `None` → bundles persist with metadata but no vector index.
+        let backend_kind = if self.embedding_backend.is_some() {
             EmbeddingBackendKind::OpenAi
         } else {
             EmbeddingBackendKind::None
@@ -704,6 +744,10 @@ impl crate::app::App {
 /// Instead we use FxHash-style 64-bit fold over the bytes and hex-encode
 /// it. Collisions are possible but the field is informational only; the
 /// dhash is what actually drives dedup.
+///
+/// Used by tests to verify determinism. The main pipeline delegates sha
+/// computation to [`CaptureSession`], which derives it from the phash.
+#[allow(dead_code)]
 fn simple_sha_hex(bytes: &[u8]) -> String {
     let mut h: u64 = 0xcbf2_9ce4_8422_2325; // FNV-1a 64-bit basis
     for &b in bytes {
@@ -729,7 +773,7 @@ mod tests {
             last_attempt: None,
             bundle_start: None,
             bundle_wall_ms: 0,
-            open_bundle: None,
+            open_session: None,
             pending_pixels: Vec::new(),
         }
     }
@@ -783,28 +827,22 @@ mod tests {
 
     /// `capture_pipeline_command_boundary_seals_bundle`
     ///
-    /// When a command boundary fires, the open bundle (if any) is sealed
+    /// When a command boundary fires, the open session (if any) is finalized
     /// and removed from the per-pane state. We exercise the seal path
-    /// directly on a synthetic bundle since the seal-and-persist branches
-    /// in `seal_pane_bundle` mirror this logic.
+    /// directly on a synthetic `CaptureSession` since the finalize-and-persist
+    /// branches in `seal_pane_bundle` mirror this logic.
     #[test]
     fn capture_pipeline_command_boundary_seals_bundle() {
+
         let mut state = CaptureState::new();
         let pane: AppId = 7;
 
-        // Open a bundle by hand and stuff a frame into it.
-        let mut bundle = Bundle::new(u64::from(pane));
-        bundle.t_wall_unix_ms = 1_700_000_000_000;
-        bundle.add_frame(FrameRef {
-            t_offset_ns: 0,
-            sha: "stub".into(),
-            blob_path: "frames/0.rgba".into(),
-            dhash: 0xAA,
-            width: 100,
-            height: 100,
-        });
+        // Open a CaptureSession and push one valid frame into it.
+        let mut session = CaptureSession::new(uuid::Uuid::new_v4());
+        session.add_frame(CaptureFrame::new(0, 0xAA, vec![0xAA, 0xBB, 0xCC, 0xDD], 100, 100));
         let ps = PaneCaptureState {
-            open_bundle: Some(bundle),
+            open_session: Some(session),
+            bundle_wall_ms: 1_700_000_000_000,
             pending_pixels: vec![vec![0xAA, 0xBB, 0xCC, 0xDD]],
             ..PaneCaptureState::default()
         };
@@ -812,32 +850,31 @@ mod tests {
 
         assert_eq!(state.open_frame_count(), 1, "1 frame open before seal");
 
-        // Pull the bundle out (mimics what `seal_pane_bundle` does).
-        let mut sealed = state
+        // Pull the session out and finalize it (mimics what `seal_pane_bundle` does).
+        let taken_session = state
             .panes
             .get_mut(&pane)
             .unwrap()
-            .open_bundle
+            .open_session
             .take()
             .unwrap();
-        sealed.seal(
-            Some("test-boundary".into()),
-            vec!["pane-boundary".into()],
-            0.5,
-        );
+        let mut sealed = taken_session.finalize().expect("one valid frame → Ok");
+        sealed.t_wall_unix_ms = 1_700_000_000_000;
+        sealed.intent = Some("test-boundary".into());
 
         assert_eq!(state.open_frame_count(), 0, "0 open frames after take");
-        assert!(sealed.sealed, "bundle sealed flag must be set");
+        assert!(sealed.sealed, "bundle must be sealed by finalize");
         assert_eq!(sealed.intent.as_deref(), Some("test-boundary"));
-        assert_eq!(sealed.frames.len(), 1, "frame count preserved by seal");
+        assert_eq!(sealed.frames.len(), 1, "frame count preserved by finalize");
     }
 
     /// `capture_state_advances_frame_counter_per_pane`
     ///
-    /// Each pane gets its own `consecutive_identical` and `open_bundle`
+    /// Each pane gets its own `consecutive_identical` and `open_session`
     /// frame counters — incrementing one must not touch the other.
     #[test]
     fn capture_state_advances_frame_counter_per_pane() {
+
         let mut state = CaptureState::new();
         let pane_a: AppId = 1;
         let pane_b: AppId = 2;
@@ -845,25 +882,11 @@ mod tests {
         state.panes.insert(pane_a, PaneCaptureState::default());
         state.panes.insert(pane_b, PaneCaptureState::default());
 
-        // Open a bundle in pane A only.
-        let mut a_bundle = Bundle::new(u64::from(pane_a));
-        a_bundle.add_frame(FrameRef {
-            t_offset_ns: 0,
-            sha: "a0".into(),
-            blob_path: "a/0.rgba".into(),
-            dhash: 1,
-            width: 10,
-            height: 10,
-        });
-        a_bundle.add_frame(FrameRef {
-            t_offset_ns: 1_000,
-            sha: "a1".into(),
-            blob_path: "a/1.rgba".into(),
-            dhash: 2,
-            width: 10,
-            height: 10,
-        });
-        state.panes.get_mut(&pane_a).unwrap().open_bundle = Some(a_bundle);
+        // Open a CaptureSession in pane A with 2 frames (distinct phashes).
+        let mut session_a = CaptureSession::new(uuid::Uuid::new_v4());
+        session_a.add_frame(CaptureFrame::new(0, 0x01, vec![0; 4], 10, 10));
+        session_a.add_frame(CaptureFrame::new(1_000, 0x02, vec![0; 4], 10, 10));
+        state.panes.get_mut(&pane_a).unwrap().open_session = Some(session_a);
 
         assert_eq!(state.open_frame_count(), 2, "pane A has 2 frames");
 
@@ -1147,35 +1170,28 @@ mod tests {
         assert_eq!(hits[0].bundle_id, a.id, "alpha must be the closest");
     }
 
-    /// `seal_pane_bundle_signature_takes_pixels_through`
+    /// `seal_pane_bundle_drains_pending_pixels_in_lockstep`
     ///
     /// Fix #1 unit-level check: when `seal_pane_bundle`-style logic runs
     /// (we call the underlying transitions directly since `App` requires
-    /// a full GPU context), the open bundle is taken, pending pixels
-    /// are drained in lock-step, and a sealed bundle + matching
+    /// a full GPU context), the open session is taken and finalized, pending
+    /// pixels are drained in lock-step, and a sealed bundle + matching
     /// `Vec<Vec<u8>>` is what would be queued.
     ///
     /// This mirrors the `App::seal_pane_bundle` body without going
     /// through GPU-bound `App::new`.
     #[test]
     fn seal_pane_bundle_drains_pending_pixels_in_lockstep() {
+
         let mut state = CaptureState::new();
         let pane: AppId = 11;
 
-        // Seed an open bundle with 2 frames + 2 pixel buffers.
-        let mut bundle = Bundle::new(u64::from(pane));
-        for i in 0..2_u64 {
-            bundle.add_frame(FrameRef {
-                t_offset_ns: i * 1_000_000,
-                sha: format!("sha-{i}"),
-                blob_path: "placeholder".into(),
-                dhash: i,
-                width: 2,
-                height: 2,
-            });
-        }
+        // Seed an open CaptureSession with 2 frames + 2 pixel buffers.
+        let mut session = CaptureSession::new(uuid::Uuid::new_v4());
+        session.add_frame(CaptureFrame::new(0, 0x01, vec![1; 16], 2, 2));
+        session.add_frame(CaptureFrame::new(1_000, 0x02, vec![2; 16], 2, 2));
         let ps = PaneCaptureState {
-            open_bundle: Some(bundle),
+            open_session: Some(session),
             pending_pixels: vec![vec![1; 16], vec![2; 16]],
             ..PaneCaptureState::default()
         };
@@ -1183,11 +1199,12 @@ mod tests {
 
         // Mirror the seal_pane_bundle body.
         let pane_state = state.panes.get_mut(&pane).expect("pane present");
-        let mut sealed = pane_state.open_bundle.take().expect("had open bundle");
+        let taken_session = pane_state.open_session.take().expect("had open session");
         let pixels = std::mem::take(&mut pane_state.pending_pixels);
-        sealed.seal(Some("test".into()), vec!["pane-boundary".into()], 0.5);
+        let mut sealed = taken_session.finalize().expect("two valid frames → Ok");
+        sealed.intent = Some("test".into());
 
-        assert!(sealed.sealed);
+        assert!(sealed.sealed, "finalize returns a sealed bundle");
         assert_eq!(sealed.frames.len(), 2);
         assert_eq!(pixels.len(), 2, "pixels must travel with the sealed bundle");
         assert_eq!(pixels[0].len(), 16);

--- a/crates/phantom-bundles/src/session.rs
+++ b/crates/phantom-bundles/src/session.rs
@@ -32,7 +32,8 @@ pub type SessionId = uuid::Uuid;
 
 // ─── CaptureFrame ────────────────────────────────────────────────────────────
 
-/// A raw captured frame: pixel data, wall-clock timestamp, and perceptual hash.
+/// A raw captured frame: pixel data, wall-clock timestamp, perceptual hash,
+/// and the pixel dimensions needed by the blob-encoding layer.
 ///
 /// All fields are private.  Use the accessor methods to read them.
 #[derive(Debug, Clone)]
@@ -41,8 +42,12 @@ pub struct CaptureFrame {
     timestamp_ms: u64,
     /// Perceptual hash (dHash) used for near-duplicate detection.
     phash: u64,
-    /// Raw pixel bytes (e.g. PNG-encoded).
+    /// Raw pixel bytes (RGBA, row-major).
     pixels: Vec<u8>,
+    /// Frame width in pixels. Zero means unknown / not set.
+    width: u32,
+    /// Frame height in pixels. Zero means unknown / not set.
+    height: u32,
 }
 
 impl CaptureFrame {
@@ -50,13 +55,17 @@ impl CaptureFrame {
     ///
     /// - `timestamp_ms` — wall-clock capture time in Unix milliseconds.
     /// - `phash`        — perceptual hash for deduplication.
-    /// - `pixels`       — raw pixel bytes (e.g. PNG-encoded image data).
+    /// - `pixels`       — raw RGBA pixel bytes (row-major).
+    /// - `width`        — frame width in pixels (`0` if unknown).
+    /// - `height`       — frame height in pixels (`0` if unknown).
     #[must_use]
-    pub fn new(timestamp_ms: u64, phash: u64, pixels: Vec<u8>) -> Self {
+    pub fn new(timestamp_ms: u64, phash: u64, pixels: Vec<u8>, width: u32, height: u32) -> Self {
         Self {
             timestamp_ms,
             phash,
             pixels,
+            width,
+            height,
         }
     }
 
@@ -76,6 +85,18 @@ impl CaptureFrame {
     #[must_use]
     pub fn pixels(&self) -> &[u8] {
         &self.pixels
+    }
+
+    /// Frame width in pixels. Returns `0` when not set.
+    #[must_use]
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    /// Frame height in pixels. Returns `0` when not set.
+    #[must_use]
+    pub fn height(&self) -> u32 {
+        self.height
     }
 }
 
@@ -224,6 +245,19 @@ impl CaptureSession {
         let mut assembler = BundleAssembler::new(pane_id);
 
         for frame in self.frames {
+            // Validate dimensions: a frame with zero width or height cannot be
+            // encoded as a PNG blob and would silently corrupt the bundle.
+            // Skip it with a warning rather than failing the whole finalize.
+            if frame.width == 0 || frame.height == 0 {
+                log::warn!(
+                    "CaptureSession::finalize: skipping frame at {}ms with zero dimensions ({}x{})",
+                    frame.timestamp_ms,
+                    frame.width,
+                    frame.height,
+                );
+                continue;
+            }
+
             // Convert CaptureFrame → FrameRef.  The pixel bytes are not stored
             // in the FrameRef schema (they belong to the blob layer); we embed a
             // minimal sha stub derived from the phash so round-trip tests remain
@@ -233,8 +267,8 @@ impl CaptureSession {
                 sha: format!("{:016x}", frame.phash),
                 blob_path: format!("frames/{:016x}.bin", frame.phash),
                 dhash: frame.phash,
-                width: 0,
-                height: 0,
+                width: frame.width,
+                height: frame.height,
             };
             assembler.push_frame(frame_ref);
         }
@@ -272,7 +306,7 @@ mod tests {
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     fn frame(timestamp_ms: u64, phash: u64) -> CaptureFrame {
-        CaptureFrame::new(timestamp_ms, phash, vec![0xDE, 0xAD, 0xBE, 0xEF])
+        CaptureFrame::new(timestamp_ms, phash, vec![0xDE, 0xAD, 0xBE, 0xEF], 1, 1)
     }
 
     fn segment(timestamp_ms: u64, text: &str) -> TranscriptSegment {
@@ -430,10 +464,12 @@ mod tests {
     #[test]
     fn capture_frame_accessors_return_correct_values() {
         let pixels = vec![1u8, 2, 3, 4];
-        let f = CaptureFrame::new(999, 0xCAFE, pixels.clone());
+        let f = CaptureFrame::new(999, 0xCAFE, pixels.clone(), 640, 480);
         assert_eq!(f.timestamp_ms(), 999);
         assert_eq!(f.phash(), 0xCAFE);
         assert_eq!(f.pixels(), pixels.as_slice());
+        assert_eq!(f.width(), 640);
+        assert_eq!(f.height(), 480);
     }
 
     #[test]
@@ -449,5 +485,78 @@ mod tests {
         let id = fresh_id();
         let session = CaptureSession::new(id);
         assert_eq!(session.session_id(), id);
+    }
+
+    // ── New tests for Problem 1 wiring ────────────────────────────────────────
+
+    /// `capture_session_push_frame_increments_count`
+    ///
+    /// Each call to `add_frame` with a distinct perceptual hash must increment
+    /// `frame_count()` by one.  This confirms that the accumulator is wired and
+    /// that non-duplicate frames are not silently dropped.
+    #[test]
+    fn capture_session_push_frame_increments_count() {
+        let mut session = CaptureSession::new(fresh_id());
+        assert_eq!(session.frame_count(), 0, "starts empty");
+        session.add_frame(CaptureFrame::new(10, 0x01, vec![0; 4], 2, 2));
+        assert_eq!(session.frame_count(), 1, "after first push");
+        session.add_frame(CaptureFrame::new(20, 0x02, vec![0; 4], 2, 2));
+        assert_eq!(session.frame_count(), 2, "after second push");
+        session.add_frame(CaptureFrame::new(30, 0x03, vec![0; 4], 2, 2));
+        assert_eq!(session.frame_count(), 3, "after third push");
+    }
+
+    /// `capture_session_skips_zero_dimension_frame`
+    ///
+    /// A frame whose width **or** height is zero must be silently excluded from
+    /// the sealed bundle (logged at `warn!`).  This guards the PNG encoder in
+    /// the persistence job against empty/invalid bitmaps.
+    ///
+    /// The session still accumulates the frame in memory (it has not yet called
+    /// `finalize`), but `finalize` must exclude all zero-dimension entries.
+    #[test]
+    fn capture_session_skips_zero_dimension_frame() {
+        let mut session = CaptureSession::new(fresh_id());
+
+        // One valid frame (2×2, phash=1).
+        session.add_frame(CaptureFrame::new(10, 0x01, vec![0; 16], 2, 2));
+        // Zero-width frame: should be excluded at finalize time.
+        session.add_frame(CaptureFrame::new(20, 0x02, vec![], 0, 4));
+        // Zero-height frame: same.
+        session.add_frame(CaptureFrame::new(30, 0x03, vec![], 2, 0));
+
+        // Three frames were accepted by the accumulator (dedup runs on phash,
+        // and all three phashes are distinct).
+        assert_eq!(session.frame_count(), 3, "accumulator holds all three before finalize");
+
+        // After finalize, only the valid frame survives.
+        let bundle = session.finalize().expect("at least one valid frame → Ok");
+        assert_eq!(
+            bundle.frames.len(),
+            1,
+            "zero-dimension frames must be excluded from sealed bundle"
+        );
+        assert_eq!(bundle.frames[0].dhash, 0x01, "only the valid frame remains");
+    }
+
+    /// `capture_session_seal_returns_bundle`
+    ///
+    /// A session with valid frames must produce a sealed `CaptureBundle` via
+    /// `finalize()`.  The returned bundle carries the `sealed` flag and
+    /// preserves all valid frames in push order.
+    #[test]
+    fn capture_session_seal_returns_bundle() {
+        let mut session = CaptureSession::new(fresh_id());
+        session.add_frame(CaptureFrame::new(100, 0xAA, vec![0; 4], 1, 1));
+        session.add_frame(CaptureFrame::new(200, 0xBB, vec![0; 4], 1, 1));
+
+        let bundle = session.finalize().expect("two valid frames must seal cleanly");
+        assert!(bundle.sealed, "finalize must return a sealed bundle");
+        assert_eq!(bundle.frames.len(), 2, "both valid frames in the sealed bundle");
+        assert_eq!(bundle.frames[0].dhash, 0xAA);
+        assert_eq!(bundle.frames[1].dhash, 0xBB);
+        // Timestamp-to-nanosecond conversion must be correct.
+        assert_eq!(bundle.frames[0].t_offset_ns, 100 * 1_000_000);
+        assert_eq!(bundle.frames[1].t_offset_ns, 200 * 1_000_000);
     }
 }

--- a/crates/phantom-embeddings/src/openai.rs
+++ b/crates/phantom-embeddings/src/openai.rs
@@ -25,11 +25,17 @@ const DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
 /// Construct via [`OpenAiEmbeddingBackend::from_env`] (reads `OPENAI_API_KEY`)
 /// or [`OpenAiEmbeddingBackend::new`]. Defaults to `text-embedding-3-large`;
 /// call [`OpenAiEmbeddingBackend::with_small`] to switch to the small model.
+///
+/// The [`reqwest::Client`] is created once at construction time and reused
+/// across all [`embed`](Self::embed) calls. This avoids spawning a new
+/// connection pool per request and keeps TLS handshake overhead to a minimum.
 pub struct OpenAiEmbeddingBackend {
     api_key: String,
     model: String,
     base_url: String,
     dim: usize,
+    /// Shared HTTP client — created once, reused for every embedding request.
+    client: std::sync::Arc<reqwest::Client>,
 }
 
 impl std::fmt::Debug for OpenAiEmbeddingBackend {
@@ -40,6 +46,7 @@ impl std::fmt::Debug for OpenAiEmbeddingBackend {
             .field("model", &self.model)
             .field("base_url", &self.base_url)
             .field("dim", &self.dim)
+            // client is intentionally omitted — not meaningful in debug output.
             .finish()
     }
 }
@@ -64,6 +71,9 @@ impl OpenAiEmbeddingBackend {
     }
 
     /// Build a backend with an explicit API key. Defaults to the large model.
+    ///
+    /// A [`reqwest::Client`] is created once here and stored for reuse across
+    /// all subsequent [`embed`](Self::embed) calls — no per-request allocation.
     #[must_use]
     pub fn new(api_key: String) -> Self {
         Self {
@@ -71,6 +81,7 @@ impl OpenAiEmbeddingBackend {
             model: MODEL_LARGE.to_string(),
             base_url: DEFAULT_BASE_URL.to_string(),
             dim: DIM_LARGE,
+            client: std::sync::Arc::new(reqwest::Client::new()),
         }
     }
 
@@ -158,8 +169,9 @@ impl EmbeddingBackend for OpenAiEmbeddingBackend {
         };
         let url = format!("{}/embeddings", self.base_url);
 
-        let client = reqwest::Client::new();
-        let resp = client
+        // Use the cached client — avoids TLS handshake setup on every call.
+        let resp = self
+            .client
             .post(&url)
             .bearer_auth(&self.api_key)
             .json(&body)


### PR DESCRIPTION
## Summary

- **phantom-bundles**: Extended `CaptureFrame` with `width`/`height` fields; `CaptureSession::finalize()` now skips zero-dimension frames with a `warn!` log and propagates real dimensions into `FrameRef`
- **phantom-app/capture**: Replaced manual `Bundle::new()` / `bundle.add_frame(FrameRef{...})` construction in `capture_panes()` and `seal_pane_bundle()` with `CaptureSession::new()` → `add_frame()` → `finalize()`; `PaneCaptureState.open_bundle` renamed to `open_session: Option<CaptureSession>`
- **phantom-app/app**: Added `embedding_backend: Option<Arc<dyn EmbeddingBackend>>` to `App`; initialized from `OpenAiEmbeddingBackend::from_env()` at startup; `persist_sealed_bundles()` now reads `self.embedding_backend.is_some()` instead of re-checking the env var
- **phantom-embeddings/openai**: Cached `reqwest::Client` inside `OpenAiEmbeddingBackend` (created once in `new()`, reused in every `embed()` call) to avoid per-request TLS handshake overhead

## New tests (5)

- `capture_session_push_frame_increments_count`
- `capture_session_skips_zero_dimension_frame`
- `capture_session_seal_returns_bundle`
- `embedding_backend_created_when_key_present`
- `embedding_backend_none_when_no_key`

## Pre-PR checks

```
./scripts/pre-pr-check.sh phantom-bundles      → PASS
./scripts/pre-pr-check.sh phantom-embeddings   → PASS
./scripts/pre-pr-check.sh phantom-app          → PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)