### PR TITLE
fix(phantom-hub): remove unused log + env_logger deps

### DIFF
--- a/crates/phantom-hub/Cargo.toml
+++ b/crates/phantom-hub/Cargo.toml
@@ -14,8 +14,6 @@ name = "phantom-hub"
 path = "src/main.rs"
 
 [dependencies]
-log.workspace = true
-env_logger.workspace = true
 anyhow.workspace = true
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/phantom-hub/src/router.rs
+++ b/crates/phantom-hub/src/router.rs
@@ -278,7 +278,7 @@ pub async fn deliver_response(registry: &SharedRegistry, phantom_id: &PhantomId,
             if let Some(u) = n.as_u64() {
                 HubId(u)
             } else {
-                log::warn!(
+                tracing::warn!(
                     "deliver_response: non-u64 response id from {}: {:?}",
                     phantom_id,
                     n
@@ -287,7 +287,7 @@ pub async fn deliver_response(registry: &SharedRegistry, phantom_id: &PhantomId,
             }
         }
         other => {
-            log::warn!(
+            tracing::warn!(
                 "deliver_response: unexpected response id from {}: {:?}",
                 phantom_id,
                 other
@@ -302,7 +302,7 @@ pub async fn deliver_response(registry: &SharedRegistry, phantom_id: &PhantomId,
         if let Some(tx) = state.pending.remove(&hub_id) {
             let _ = tx.send(resp);
         } else {
-            log::warn!(
+            tracing::warn!(
                 "deliver_response: hub_id {} not in pending table for {}",
                 hub_id.0,
                 phantom_id


### PR DESCRIPTION
Closes #436

## Summary
- phantom-hub declared `log` and `env_logger` as workspace deps but used neither in production code
- Found 3 `log::warn!` calls in `router.rs`; migrated them to `tracing::warn!`
- Removed both `log.workspace = true` and `env_logger.workspace = true` from Cargo.toml
- phantom-hub now uses `tracing` exclusively throughout

## Verification
- All `log::` and `env_logger::` references removed from crates/phantom-hub/src/
- `cargo check -p phantom-hub` passes