### PR TITLE
fix(phantom-skill-host): #[doc(hidden)] on tick_reaper_for_test

### DIFF
--- a/crates/phantom-skill-host/src/lib.rs
+++ b/crates/phantom-skill-host/src/lib.rs
@@ -57,6 +57,7 @@ pub mod swap_manager;
 pub mod watcher;
 
 pub use drain_reaper::all_swap_states;
+#[doc(hidden)]
 pub use drain_reaper::tick_reaper_for_test;
 pub use host::{SemanticSkill, SkillHost};
 pub use llm_host::{LlmHost, LlmSkill, LlmSkillAdapter};


### PR DESCRIPTION
Closes #521

## Summary
The test-only `tick_reaper_for_test` was re-exported from `lib.rs` without `#[doc(hidden)]`, so it appeared in public docs. Added the attribute.

## Verification
- cargo check -p phantom-skill-host passes
- cargo doc --no-deps -p phantom-skill-host: tick_reaper_for_test no longer appears in index.html