### PR TITLE
fix(phantom-bundle-store): replace keychain with file-based store (mirror #539)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3843,21 +3843,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "keyring"
-version = "3.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
-dependencies = [
- "byteorder",
- "linux-keyutils",
- "log",
- "security-framework 2.11.1",
- "security-framework 3.7.0",
- "windows-sys 0.60.2",
- "zeroize",
-]
-
-[[package]]
 name = "khronos-egl"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4572,16 +4557,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-keyutils"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
-dependencies = [
- "bitflags 2.11.1",
- "libc",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4935,7 +4910,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "tempfile",
 ]
@@ -5794,7 +5769,6 @@ dependencies = [
  "dirs 5.0.1",
  "futures",
  "hkdf",
- "keyring",
  "lancedb",
  "phantom-bundle-store",
  "phantom-bundles",
@@ -7075,7 +7049,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -7103,7 +7077,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -7237,19 +7211,6 @@ name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
 
 [[package]]
 name = "security-framework"

--- a/crates/phantom-app/src/app.rs
+++ b/crates/phantom-app/src/app.rs
@@ -1632,16 +1632,14 @@ fn open_bundle_store() -> Option<std::sync::Arc<phantom_bundle_store::BundleStor
         return None;
     }
 
-    // Resolve master key from the OS keychain. If the keyring isn't
-    // available (CI, sandboxed test runs), we fall back to a deterministic
-    // key derived from `$HOME`. The fallback isn't secure — bundles
-    // written under it are encrypted but with a key any process on the
-    // box can rederive — and we surface a clear log line so the user
-    // notices.
-    let master_key = match MasterKey::from_keyring() {
+    // Resolve master key from the on-disk store under `dirs::config_dir()`.
+    // First run generates a fresh key and persists it at mode 0600; later
+    // runs read it back. See `phantom-bundle-store::crypto` for the file
+    // layout and the `PHANTOM_BUNDLE_STORE_MASTER_KEY_FILE` test override.
+    let master_key = match MasterKey::load_or_generate() {
         Ok(k) => k,
         Err(e) => {
-            warn!("Bundle store keychain unavailable ({e}); skipping capture init");
+            warn!("Bundle store master-key load failed ({e}); skipping capture init");
             return None;
         }
     };

--- a/crates/phantom-bundle-store/Cargo.toml
+++ b/crates/phantom-bundle-store/Cargo.toml
@@ -31,16 +31,9 @@ arrow-array = { version = "57", optional = true }
 arrow-schema = { version = "57", optional = true }
 tokio = { version = "1", features = ["rt", "rt-multi-thread"], optional = true }
 futures = { version = "0.3", optional = true }
+# Config-directory resolution for the on-disk master-key store.
+# Replaces the prior `keyring` backend; see `crypto.rs` for rationale (mirrors phantom-net #539).
 dirs = "5"
-
-[target.'cfg(target_os = "macos")'.dependencies]
-keyring = { version = "3.6", features = ["apple-native"] }
-
-[target.'cfg(target_os = "linux")'.dependencies]
-keyring = { version = "3.6", features = ["linux-native"] }
-
-[target.'cfg(target_os = "windows")'.dependencies]
-keyring = { version = "3.6", features = ["windows-native"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/phantom-bundle-store/src/crypto.rs
+++ b/crates/phantom-bundle-store/src/crypto.rs
@@ -9,27 +9,58 @@
 //!    info = "phantom-bundle-store/blob/v1")`. Each seal generates a fresh
 //!    24-byte XNonce.
 //!
-//! The master key itself is fetched from the OS keychain in production via
-//! [`MasterKey::from_keyring`]. Tests pass an explicit key via
-//! [`MasterKey::from_bytes`].
+//! The master key itself is persisted in a JSON file under the user's config
+//! directory (mode `0600` on Unix) by [`MasterKey::load_or_generate`]. Tests
+//! pass an explicit key via [`MasterKey::from_bytes`].
+//!
+//! # Why a file, not the OS keychain
+//! macOS Keychain ACLs are bound to the requesting binary's code signature.
+//! Every `cargo build` produces a binary with a different content hash, so
+//! "Always Allow" never sticks across rebuilds. With autonomous-agent
+//! worktrees rebuilding constantly this turned into prompt-spam. A plain
+//! file under the config dir, mode `0600`, sidesteps the issue entirely.
+//! Mirrors the file-store rationale in `phantom-net::identity` (see PR
+//! #539; this change closes the parallel keychain entry-point flagged by
+//! issue #565).
+//!
+//! # Storage path
+//! - Default: `dirs::config_dir().join("phantom").join("bundle-store").join("master-key.json")`.
+//!   On macOS this is
+//!   `~/Library/Application Support/phantom/bundle-store/master-key.json`.
+//! - Override: set `PHANTOM_BUNDLE_STORE_MASTER_KEY_FILE` to use that exact
+//!   path verbatim (used by tests).
+//!
+//! # File format
+//! ```json
+//! { "master_key_hex": "<64-hex>" }
+//! ```
+//! The file is written atomically: a sibling `*.tmp` file is created with
+//! mode `0600` set in the same `open(2)` call, fsync'd, then renamed over
+//! the destination so a crash mid-write cannot leave a partial file.
+//!
+//! # Per-process cache
+//! Loaded master keys are cached in a process-wide map keyed by file path,
+//! so repeated calls within a single process do at most one disk read per
+//! path.
 //!
 //! Sensitive material is wrapped in [`zeroize::Zeroizing`] so it scrubs on
 //! drop.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{LazyLock, Mutex};
 
 use chacha20poly1305::aead::{Aead, KeyInit, Payload};
 use chacha20poly1305::{XChaCha20Poly1305, XNonce};
 use hkdf::Hkdf;
 use phantom_bundles::BundleId;
 use rand::RngCore;
+use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use zeroize::Zeroizing;
 
 use crate::StoreError;
 
-/// Service name registered in the OS keychain.
-const KEYRING_SERVICE: &str = "phantom-bundle-store";
-/// Username/account for the master key entry. There is exactly one per host.
-const KEYRING_ACCOUNT: &str = "master-key-v1";
 /// HKDF info string. Bumping this string is equivalent to a key rotation
 /// for everything sealed under the previous string.
 const HKDF_INFO_BLOB: &[u8] = b"phantom-bundle-store/blob/v1";
@@ -38,6 +69,20 @@ const XNONCE_LEN: usize = 24;
 /// Magic bytes prefixing a serialized [`BlobEnvelope`]. Lets us version the
 /// on-disk envelope format independently of anything else.
 const ENVELOPE_MAGIC: &[u8; 4] = b"PBE1";
+
+/// Environment variable that overrides the default master-key file location.
+///
+/// When set, the override path is used verbatim. Primarily for tests and
+/// operator overrides.
+const MASTER_KEY_FILE_ENV: &str = "PHANTOM_BUNDLE_STORE_MASTER_KEY_FILE";
+
+/// Process-wide cache of loaded master keys, keyed by the resolved file path.
+///
+/// Avoids re-reading the JSON file on every call within the same process.
+/// The cache is heap-only and never written to disk — the only persisted
+/// state is the JSON file itself.
+static MASTER_KEY_CACHE: LazyLock<Mutex<HashMap<PathBuf, MasterKey>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// 32-byte master key. The single root of trust for this store.
 ///
@@ -56,7 +101,7 @@ impl std::fmt::Debug for MasterKey {
 
 impl MasterKey {
     /// Construct from raw bytes. Used in tests and as the in-memory form
-    /// after pulling from the keychain.
+    /// after pulling from disk.
     #[must_use]
     pub fn from_bytes(bytes: [u8; 32]) -> Self {
         Self(Zeroizing::new(bytes))
@@ -68,30 +113,52 @@ impl MasterKey {
         &self.0
     }
 
-    /// Load the master key from the OS keychain, generating and storing a
-    /// fresh random key if no entry yet exists.
+    /// Load the master key from the on-disk JSON file, generating and
+    /// persisting a fresh random key if no file yet exists.
     ///
-    /// Errors surface as [`StoreError::Keyring`].
-    pub fn from_keyring() -> Result<Self, StoreError> {
-        let entry = keyring::Entry::new(KEYRING_SERVICE, KEYRING_ACCOUNT)
-            .map_err(|e| StoreError::Keyring(format!("entry: {e}")))?;
-        match entry.get_password() {
-            Ok(b64) => {
-                let bytes =
-                    decode_b64_32(&b64).map_err(|e| StoreError::Keyring(format!("decode: {e}")))?;
-                Ok(Self::from_bytes(bytes))
+    /// On first call within a process the file is read (or generated) and
+    /// the result cached. Subsequent calls return the cached value with no
+    /// disk I/O.
+    ///
+    /// # Errors
+    /// - Returns [`StoreError::MasterKey`] if the config directory cannot
+    ///   be located.
+    /// - Returns [`StoreError::MasterKey`] if an existing file is present
+    ///   but cannot be parsed or contains a malformed key. A parse failure
+    ///   does **not** trigger silent regeneration — that would erase a
+    ///   real master key in the face of a transient parser issue.
+    /// - Returns [`StoreError::MasterKey`] if a fresh file cannot be
+    ///   written to disk.
+    pub fn load_or_generate() -> Result<Self, StoreError> {
+        let path = master_key_path()?;
+
+        // Per-process cache hit path — no disk I/O.
+        {
+            let cache = MASTER_KEY_CACHE
+                .lock()
+                .expect("master key cache mutex poisoned");
+            if let Some(key) = cache.get(&path) {
+                return Ok(key.clone());
             }
-            Err(keyring::Error::NoEntry) => {
-                let mut bytes = [0_u8; 32];
-                rand::thread_rng().fill_bytes(&mut bytes);
-                let b64 = encode_b64_32(&bytes);
-                entry
-                    .set_password(&b64)
-                    .map_err(|e| StoreError::Keyring(format!("set: {e}")))?;
-                Ok(Self::from_bytes(bytes))
-            }
-            Err(e) => Err(StoreError::Keyring(format!("get: {e}"))),
         }
+
+        let key = if path.exists() {
+            load_from_file(&path)?
+        } else {
+            generate_and_persist(&path)?
+        };
+
+        // Insert into cache (race-tolerant — last writer wins, both copies
+        // are equivalent because they were derived from the same on-disk
+        // bytes or the same first-writer's bytes).
+        {
+            let mut cache = MASTER_KEY_CACHE
+                .lock()
+                .expect("master key cache mutex poisoned");
+            cache.entry(path).or_insert_with(|| key.clone());
+        }
+
+        Ok(key)
     }
 
     /// Derive a per-bundle data-encryption key with HKDF-SHA256.
@@ -195,100 +262,268 @@ pub(crate) fn open_blob(dek: &DataEncryptionKey, env: &BlobEnvelope) -> Result<V
 }
 
 // ---------------------------------------------------------------------------
-// Tiny base64 (no_std style) — avoids a heavy dep just to round-trip the
-// 32-byte master key through the keychain (which expects a string).
+// On-disk format & path resolution
 // ---------------------------------------------------------------------------
 
-const B64_ALPHA: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-
-fn encode_b64_32(bytes: &[u8; 32]) -> String {
-    let mut out = String::with_capacity(44);
-    let mut i = 0;
-    while i + 3 <= bytes.len() {
-        let n =
-            (u32::from(bytes[i]) << 16) | (u32::from(bytes[i + 1]) << 8) | u32::from(bytes[i + 2]);
-        out.push(B64_ALPHA[((n >> 18) & 0x3F) as usize] as char);
-        out.push(B64_ALPHA[((n >> 12) & 0x3F) as usize] as char);
-        out.push(B64_ALPHA[((n >> 6) & 0x3F) as usize] as char);
-        out.push(B64_ALPHA[(n & 0x3F) as usize] as char);
-        i += 3;
-    }
-    // 32 bytes = 30 + 2 leftover.
-    if i < bytes.len() {
-        let rem = bytes.len() - i;
-        let b0 = bytes[i];
-        let b1 = if rem > 1 { bytes[i + 1] } else { 0 };
-        let n = (u32::from(b0) << 16) | (u32::from(b1) << 8);
-        out.push(B64_ALPHA[((n >> 18) & 0x3F) as usize] as char);
-        out.push(B64_ALPHA[((n >> 12) & 0x3F) as usize] as char);
-        if rem == 2 {
-            out.push(B64_ALPHA[((n >> 6) & 0x3F) as usize] as char);
-            out.push('=');
-        } else {
-            out.push('=');
-            out.push('=');
-        }
-    }
-    out
+/// Wire-format the master-key file is persisted as.
+#[derive(Debug, Serialize, Deserialize)]
+struct MasterKeyFile {
+    master_key_hex: String,
 }
 
-fn decode_b64_32(s: &str) -> Result<[u8; 32], String> {
-    let bytes = s.as_bytes();
-    if bytes.len() != 44 {
-        return Err(format!("expected 44 b64 chars, got {}", bytes.len()));
+/// Resolve the on-disk path for the master-key file.
+///
+/// Honours the `PHANTOM_BUNDLE_STORE_MASTER_KEY_FILE` env var as an absolute
+/// override, else falls back to
+/// `dirs::config_dir().join("phantom").join("bundle-store").join("master-key.json")`.
+fn master_key_path() -> Result<PathBuf, StoreError> {
+    if let Some(override_path) = std::env::var_os(MASTER_KEY_FILE_ENV) {
+        return Ok(PathBuf::from(override_path));
     }
-    let lookup = |c: u8| -> Result<u32, String> {
-        match c {
-            b'A'..=b'Z' => Ok(u32::from(c - b'A')),
-            b'a'..=b'z' => Ok(u32::from(c - b'a') + 26),
-            b'0'..=b'9' => Ok(u32::from(c - b'0') + 52),
-            b'+' => Ok(62),
-            b'/' => Ok(63),
-            b'=' => Ok(0),
-            _ => Err(format!("bad b64 char: {c}")),
-        }
+    let base = dirs::config_dir().or_else(dirs::home_dir).ok_or_else(|| {
+        StoreError::MasterKey(
+            "could not determine config or home directory for master-key storage".into(),
+        )
+    })?;
+    Ok(base
+        .join("phantom")
+        .join("bundle-store")
+        .join("master-key.json"))
+}
+
+fn load_from_file(path: &Path) -> Result<MasterKey, StoreError> {
+    let bytes = std::fs::read(path).map_err(|e| {
+        StoreError::MasterKey(format!(
+            "failed to read master-key file at {}: {e}",
+            path.display()
+        ))
+    })?;
+    let file: MasterKeyFile = serde_json::from_slice(&bytes).map_err(|e| {
+        StoreError::MasterKey(format!(
+            "master-key file at {} is malformed JSON: {e}",
+            path.display()
+        ))
+    })?;
+    let key_bytes = decode_hex_32(&file.master_key_hex).map_err(|e| {
+        StoreError::MasterKey(format!(
+            "master-key file at {} contains malformed key hex: {e}",
+            path.display()
+        ))
+    })?;
+    Ok(MasterKey::from_bytes(key_bytes))
+}
+
+fn generate_and_persist(path: &Path) -> Result<MasterKey, StoreError> {
+    let mut bytes = [0_u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+
+    let file = MasterKeyFile {
+        master_key_hex: encode_hex_32(&bytes),
     };
+    let json = serde_json::to_vec_pretty(&file)
+        .map_err(|e| StoreError::MasterKey(format!("failed to serialise master-key: {e}")))?;
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            StoreError::MasterKey(format!(
+                "failed to create master-key directory at {}: {e}",
+                parent.display()
+            ))
+        })?;
+    }
+
+    // Race-safe write: if another thread/process generated the master key
+    // between our `path.exists()` check and now, fall back to reading their
+    // canonical file rather than overwriting it.
+    match write_atomic_exclusive(path, &json) {
+        Ok(()) => Ok(MasterKey::from_bytes(bytes)),
+        Err(WriteError::AlreadyExists) => load_from_file(path),
+        Err(WriteError::Io(e)) => Err(e),
+    }
+}
+
+enum WriteError {
+    /// The destination file was created by someone else mid-write.
+    AlreadyExists,
+    Io(StoreError),
+}
+
+/// Write `bytes` to `path` atomically with "lose gracefully on conflict"
+/// semantics.
+///
+/// Strategy: write to `{path}.{pid}.{tid}.tmp` with mode 0600 set in the
+/// same `open(2)` call, fsync, then `hard_link` it into place at `path`.
+/// `hard_link` fails with `AlreadyExists` when `path` already exists — that
+/// signal is the contract this function owes its caller, who then knows to
+/// defer to the existing file rather than clobber it. After a successful
+/// link the tmp is unlinked; the on-disk `path` is the canonical durable
+/// copy.
+///
+/// The 0600 mode is set inside the same `open(2)` call so the file never
+/// exists on disk with the process umask's default permissions — closing
+/// the umask race documented for [`phantom-net::identity`] in #555.
+fn write_atomic_exclusive(path: &Path, bytes: &[u8]) -> Result<(), WriteError> {
+    use std::io::Write;
+
+    // Per-(pid, thread) tmp suffix so racing writers do not trample each
+    // other's tmp file.
+    let tid = std::thread::current().id();
+    let suffix = format!("{}.{:?}.tmp", std::process::id(), tid);
+    let tmp_path = match path.extension() {
+        Some(ext) => {
+            let mut s = ext.to_os_string();
+            s.push(".");
+            s.push(&suffix);
+            path.with_extension(s)
+        }
+        None => path.with_extension(&suffix),
+    };
+
+    let write_result = (|| -> Result<(), StoreError> {
+        // Unlink any prior tmp file at this path first so a stale leftover
+        // from a prior crash cannot cause `create_new(true)` to fail.
+        let _ = std::fs::remove_file(&tmp_path);
+
+        let mut open_opts = std::fs::OpenOptions::new();
+        open_opts.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            open_opts.mode(0o600);
+        }
+        let mut f = open_opts.open(&tmp_path).map_err(|e| {
+            StoreError::MasterKey(format!(
+                "failed to open tmp master-key file at {}: {e}",
+                tmp_path.display()
+            ))
+        })?;
+
+        f.write_all(bytes).map_err(|e| {
+            StoreError::MasterKey(format!(
+                "failed to write master-key to {}: {e}",
+                tmp_path.display()
+            ))
+        })?;
+        f.sync_all().map_err(|e| {
+            StoreError::MasterKey(format!(
+                "failed to fsync master-key at {}: {e}",
+                tmp_path.display()
+            ))
+        })?;
+        Ok(())
+    })();
+
+    if let Err(e) = write_result {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(WriteError::Io(e));
+    }
+
+    // Try to hard-link the tmp into place. `hard_link` is a strict
+    // "must not exist" operation on every platform we target — this is the
+    // race-safe move.
+    let link_result = std::fs::hard_link(&tmp_path, path);
+    let _ = std::fs::remove_file(&tmp_path);
+
+    match link_result {
+        Ok(()) => {
+            // Best-effort fsync of the parent directory so the link is
+            // durable. Non-fatal — many filesystems do not require it.
+            #[cfg(unix)]
+            if let Some(parent) = path.parent()
+                && let Ok(dir) = std::fs::File::open(parent)
+            {
+                let _ = dir.sync_all();
+            }
+            Ok(())
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Err(WriteError::AlreadyExists),
+        Err(e) => Err(WriteError::Io(StoreError::MasterKey(format!(
+            "failed to link {} -> {}: {e}",
+            tmp_path.display(),
+            path.display()
+        )))),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tiny hex helpers — avoids pulling in the `hex` crate just to round-trip
+// the 32-byte master key through the JSON file.
+// ---------------------------------------------------------------------------
+
+fn encode_hex_32(bytes: &[u8; 32]) -> String {
+    let mut s = String::with_capacity(64);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+fn decode_hex_32(s: &str) -> Result<[u8; 32], String> {
+    if s.len() != 64 {
+        return Err(format!("expected 64 hex chars, got {}", s.len()));
+    }
     let mut out = [0_u8; 32];
-    let mut o = 0;
-    let mut i = 0;
-    while i < 40 {
-        let n = (lookup(bytes[i])? << 18)
-            | (lookup(bytes[i + 1])? << 12)
-            | (lookup(bytes[i + 2])? << 6)
-            | lookup(bytes[i + 3])?;
-        out[o] = ((n >> 16) & 0xFF) as u8;
-        out[o + 1] = ((n >> 8) & 0xFF) as u8;
-        out[o + 2] = (n & 0xFF) as u8;
-        o += 3;
-        i += 4;
+    for (i, chunk) in s.as_bytes().chunks(2).enumerate() {
+        let hi = from_hex_digit(chunk[0])?;
+        let lo = from_hex_digit(chunk[1])?;
+        out[i] = (hi << 4) | lo;
     }
-    // 32 bytes mod 3 == 2 leftover, so the final group encodes as
-    // `XXX=` (three significant chars + one pad). The encoder above
-    // produces exactly that pattern.
-    if bytes[43] != b'=' || bytes[42] == b'=' {
-        return Err("expected trailing 'XXX=' for 32-byte b64".into());
-    }
-    let n = (lookup(bytes[40])? << 18) | (lookup(bytes[41])? << 12) | (lookup(bytes[42])? << 6);
-    out[30] = ((n >> 16) & 0xFF) as u8;
-    out[31] = ((n >> 8) & 0xFF) as u8;
     Ok(out)
 }
+
+fn from_hex_digit(b: u8) -> Result<u8, String> {
+    match b {
+        b'0'..=b'9' => Ok(b - b'0'),
+        b'a'..=b'f' => Ok(b - b'a' + 10),
+        b'A'..=b'F' => Ok(b - b'A' + 10),
+        _ => Err(format!("invalid hex digit: {}", b as char)),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use uuid::Uuid;
 
-    #[test]
-    fn b64_round_trip_32_bytes() {
-        let mut bytes = [0_u8; 32];
-        for (i, b) in bytes.iter_mut().enumerate() {
-            *b = (i as u8).wrapping_mul(17).wrapping_add(3);
+    // -----------------------------------------------------------------------
+    // Test infrastructure
+    //
+    // Tests that mutate `PHANTOM_BUNDLE_STORE_MASTER_KEY_FILE` serialize
+    // through ENV_SERIAL because env vars are process-global.
+    // -----------------------------------------------------------------------
+
+    static TEST_COUNTER: AtomicUsize = AtomicUsize::new(0);
+    static ENV_SERIAL: Mutex<()> = Mutex::new(());
+
+    fn tmp_master_key_file() -> PathBuf {
+        let n = TEST_COUNTER.fetch_add(1, Ordering::SeqCst);
+        let pid = std::process::id();
+        std::env::temp_dir().join(format!("phantom-master-key-test-{pid}-{n}.json"))
+    }
+
+    /// Clear the per-process cache so a "fresh" call genuinely hits disk.
+    fn reset_cache() {
+        MASTER_KEY_CACHE
+            .lock()
+            .expect("master key cache mutex poisoned")
+            .clear();
+    }
+
+    /// Cleanup guard — removes env var and tmp file on drop.
+    struct CleanupGuard {
+        path: PathBuf,
+    }
+    impl Drop for CleanupGuard {
+        fn drop(&mut self) {
+            // SAFETY: env mutation is serialised via ENV_SERIAL.
+            unsafe { std::env::remove_var(MASTER_KEY_FILE_ENV) };
+            let _ = std::fs::remove_file(&self.path);
         }
-        let s = encode_b64_32(&bytes);
-        assert_eq!(s.len(), 44);
-        let back = decode_b64_32(&s).expect("decode");
-        assert_eq!(bytes, back);
     }
 
     #[test]
@@ -340,5 +575,167 @@ mod tests {
         env.ciphertext[0] ^= 0x01;
         let err = open_blob(&dek, &env).expect_err("must fail auth");
         assert!(err.contains("decrypt"));
+    }
+
+    #[test]
+    fn hex_round_trip_32_bytes() {
+        let mut bytes = [0_u8; 32];
+        for (i, b) in bytes.iter_mut().enumerate() {
+            *b = (i as u8).wrapping_mul(17).wrapping_add(3);
+        }
+        let s = encode_hex_32(&bytes);
+        assert_eq!(s.len(), 64);
+        let back = decode_hex_32(&s).expect("decode");
+        assert_eq!(bytes, back);
+    }
+
+    #[test]
+    fn hex_decode_rejects_short_input() {
+        assert!(decode_hex_32("deadbeef").is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // File-backend tests (use PHANTOM_BUNDLE_STORE_MASTER_KEY_FILE override)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn load_or_generate_creates_fresh_file_on_first_call() {
+        let _serial = ENV_SERIAL.lock().unwrap_or_else(|p| p.into_inner());
+        let path = tmp_master_key_file();
+        // SAFETY: env mutation is serialised via ENV_SERIAL.
+        unsafe { std::env::set_var(MASTER_KEY_FILE_ENV, &path) };
+        reset_cache();
+        let _cleanup = CleanupGuard { path: path.clone() };
+
+        assert!(!path.exists(), "precondition: file must not exist");
+
+        let key = MasterKey::load_or_generate().expect("first call must succeed");
+        assert!(path.exists(), "first call must create the file");
+
+        // File contents must round-trip via load_from_file and produce the
+        // same key bytes.
+        reset_cache();
+        let reloaded = load_from_file(&path).expect("file must be readable after generation");
+        assert_eq!(key.bytes(), reloaded.bytes());
+    }
+
+    #[test]
+    fn load_or_generate_reads_existing_file_on_second_call() {
+        let _serial = ENV_SERIAL.lock().unwrap_or_else(|p| p.into_inner());
+        let path = tmp_master_key_file();
+        unsafe { std::env::set_var(MASTER_KEY_FILE_ENV, &path) };
+        reset_cache();
+        let _cleanup = CleanupGuard { path: path.clone() };
+
+        let k1 = MasterKey::load_or_generate().unwrap();
+        // Clear the cache so the second call genuinely re-reads from disk.
+        reset_cache();
+        let k2 = MasterKey::load_or_generate().unwrap();
+
+        assert_eq!(
+            k1.bytes(),
+            k2.bytes(),
+            "second call must return the same key as the first (read from file)"
+        );
+    }
+
+    #[test]
+    fn corrupted_file_returns_error_no_silent_overwrite() {
+        let _serial = ENV_SERIAL.lock().unwrap_or_else(|p| p.into_inner());
+        let path = tmp_master_key_file();
+        unsafe { std::env::set_var(MASTER_KEY_FILE_ENV, &path) };
+        reset_cache();
+        let _cleanup = CleanupGuard { path: path.clone() };
+
+        std::fs::write(&path, b"this is not valid JSON {{{").expect("seed corrupted file");
+        let before = std::fs::read(&path).unwrap();
+
+        let result = MasterKey::load_or_generate();
+        assert!(
+            result.is_err(),
+            "corrupted file must surface as Err, never silently regenerated"
+        );
+
+        let after = std::fs::read(&path).unwrap();
+        assert_eq!(
+            before, after,
+            "corrupted file must not be overwritten — that would erase a real master key if the parser had a transient issue"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn file_mode_is_0600_on_unix() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _serial = ENV_SERIAL.lock().unwrap_or_else(|p| p.into_inner());
+        let path = tmp_master_key_file();
+        unsafe { std::env::set_var(MASTER_KEY_FILE_ENV, &path) };
+        reset_cache();
+        let _cleanup = CleanupGuard { path: path.clone() };
+
+        let _ = MasterKey::load_or_generate().unwrap();
+
+        let meta = std::fs::metadata(&path).expect("master-key file must exist");
+        let mode = meta.permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "master-key file must be mode 0600, got {mode:o}"
+        );
+    }
+
+    /// Regression guard: the tmp file must be created with mode 0600 in the
+    /// same syscall as `open(2)`, so there is no window where it exists on
+    /// disk with the default umask permissions. Mirrors PR #555 hardening
+    /// in `phantom-net::identity`.
+    #[cfg(unix)]
+    #[test]
+    fn tmp_file_has_0600_at_creation_no_chmod_window() {
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+        let path = std::env::temp_dir().join(format!(
+            "phantom-bundle-store-mode-test-{}-{}.tmp",
+            std::process::id(),
+            TEST_COUNTER.fetch_add(1, Ordering::SeqCst)
+        ));
+        let _ = std::fs::remove_file(&path);
+
+        // Mirror the production OpenOptions from write_atomic_exclusive.
+        let mut open_opts = std::fs::OpenOptions::new();
+        open_opts.write(true).create_new(true).mode(0o600);
+        let _f = open_opts.open(&path).expect("create tmp file");
+
+        let meta = std::fs::metadata(&path).expect("tmp file must exist");
+        let mode = meta.permissions().mode() & 0o777;
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(
+            mode, 0o600,
+            "tmp file must be 0600 immediately after open(2), got {mode:o} \
+             — this means the umask race window is back"
+        );
+    }
+
+    #[test]
+    fn cache_skips_disk_on_repeat_call() {
+        let _serial = ENV_SERIAL.lock().unwrap_or_else(|p| p.into_inner());
+        let path = tmp_master_key_file();
+        unsafe { std::env::set_var(MASTER_KEY_FILE_ENV, &path) };
+        reset_cache();
+        let _cleanup = CleanupGuard { path: path.clone() };
+
+        let k1 = MasterKey::load_or_generate().unwrap();
+
+        // Delete the file behind the cache. If the cache works, the next
+        // call returns the cached key rather than erroring on the missing
+        // file.
+        std::fs::remove_file(&path).expect("file must exist after first call");
+        let k2 = MasterKey::load_or_generate()
+            .expect("cache hit must not depend on the file being present");
+
+        assert_eq!(k1.bytes(), k2.bytes());
+        assert!(
+            !path.exists(),
+            "cache hit must not have re-created the file from disk"
+        );
     }
 }

--- a/crates/phantom-bundle-store/src/lib.rs
+++ b/crates/phantom-bundle-store/src/lib.rs
@@ -10,7 +10,8 @@
 //!    in-memory deterministic stub).
 //! 3. **Encrypted frame and audio blobs** sealed with XChaCha20-Poly1305
 //!    using a per-bundle data-encryption key derived via HKDF-SHA256 from a
-//!    master key stored in the OS keychain.
+//!    master key persisted in a `0600`-mode JSON file under the user's
+//!    config directory (see [`crypto::MasterKey::load_or_generate`]).
 //!
 //! Writes go through a two-phase protocol: SQLite first inside a
 //! transaction, then LanceDB. If the LanceDB step fails we roll the SQLite
@@ -82,9 +83,9 @@ pub enum StoreError {
     #[error("crypto: {0}")]
     Crypto(String),
 
-    /// Master key could not be loaded from the keychain.
-    #[error("keyring: {0}")]
-    Keyring(String),
+    /// Master key could not be loaded from the on-disk file.
+    #[error("master-key: {0}")]
+    MasterKey(String),
 
     /// Vector index error (LanceDB or stub).
     #[error("vector index: {0}")]
@@ -149,8 +150,9 @@ pub struct StoreConfig {
     /// Directory that will hold `bundles.db` (SQLite) and `vectors/`
     /// (LanceDB), plus an `objects/` directory for encrypted blob files.
     pub root: PathBuf,
-    /// Master key. In production this is loaded from the OS keychain via
-    /// [`MasterKey::from_keyring`]. In tests we pass an explicit key.
+    /// Master key. In production this is loaded from the on-disk JSON
+    /// file via [`MasterKey::load_or_generate`]. In tests we pass an
+    /// explicit key.
     pub master_key: MasterKey,
 }
 
@@ -377,7 +379,7 @@ pub mod testing {
     use super::*;
 
     /// Construct a master key from raw bytes. Production code should use
-    /// [`MasterKey::from_keyring`].
+    /// [`MasterKey::load_or_generate`].
     #[must_use]
     pub fn fixed_master_key(bytes: [u8; 32]) -> MasterKey {
         MasterKey::from_bytes(bytes)

--- a/crates/phantom-bundle-store/tests/recovery.rs
+++ b/crates/phantom-bundle-store/tests/recovery.rs
@@ -217,13 +217,13 @@ fn sweep_cleans_orphaned_vectors_and_leaked_rows_table() {
     );
 }
 
-/// Synthesize a `StoreError::Keyring` error and verify that its `Display`
+/// Synthesize a `StoreError::MasterKey` error and verify that its `Display`
 /// implementation does not panic and produces a non-empty, human-readable
 /// message. This guards against any accidental unwrap inside the display path.
 #[test]
-fn master_key_keyring_error_surfaces_cleanly_without_panic() {
-    // Construct the error directly — no need to touch the real OS keychain.
-    let err = StoreError::Keyring("simulated keychain failure".into());
+fn master_key_error_surfaces_cleanly_without_panic() {
+    // Construct the error directly — no need to touch the real disk.
+    let err = StoreError::MasterKey("simulated master-key failure".into());
 
     // Must not panic.
     let msg = err.to_string();
@@ -231,7 +231,7 @@ fn master_key_keyring_error_surfaces_cleanly_without_panic() {
     // Must produce a non-empty, human-readable string containing the detail.
     assert!(!msg.is_empty(), "error display must not be empty");
     assert!(
-        msg.contains("simulated keychain failure"),
+        msg.contains("simulated master-key failure"),
         "display must include the inner message, got: {msg:?}"
     );
 


### PR DESCRIPTION
Closes #565

## Summary
Mirrors merged PR #539 pattern from phantom-net. Master key now stored as JSON in `{config_dir}/phantom/bundle-store/master-key.json` (mode 0600, atomic write, `LazyLock<Mutex<HashMap>>` cache). This was the final OS-keychain entry-point in the workspace — closes the parallel path that #539 / #555 / #558 did not touch.

## Why
macOS Keychain ACLs are bound to the requesting binary's code-signature hash. Every `cargo build` produces a new hash, so "Always Allow" never sticks. With autonomous-agent worktrees rebuilding constantly the prompts compound. A 0600-mode file under the config dir sidesteps the ACL entirely (same rationale as #539).

## Changes
- Drop `keyring` dependency from `crates/phantom-bundle-store/Cargo.toml` (all three target-specific blocks)
- Rewrite `crypto.rs` master-key path to read/write a JSON file at `dirs::config_dir().join("phantom/bundle-store/master-key.json")`
- Atomic write: `create_new(true)` + `mode(0o600)` set inside the same `open(2)` call (no umask race), `fsync`, then `hard_link` into place. Race-tolerant: `AlreadyExists` on link falls back to reading the canonical file
- `PHANTOM_BUNDLE_STORE_MASTER_KEY_FILE` env override for tests (matches `PHANTOM_IDENTITY_FILE` / `PHANTOM_CREDENTIALS_FILE` convention)
- Per-process `LazyLock<Mutex<HashMap<PathBuf, MasterKey>>>` cache so repeated calls within one process do at most one disk read per path
- API rename: `MasterKey::from_keyring()` to `MasterKey::load_or_generate()`; `StoreError::Keyring(String)` to `StoreError::MasterKey(String)`. Single non-test caller (`phantom-app/src/app.rs`) updated; recovery integration test that asserts the error-display path renamed and adjusted
- Minor: switched the master-key serialization from base64 to hex (matches `phantom-net::identity` and lets us drop ~75 lines of in-tree base64 code)

## Tests
- `load_or_generate_creates_fresh_file_on_first_call` — first call creates file, key round-trips via `load_from_file`
- `load_or_generate_reads_existing_file_on_second_call` — second call (cache cleared) reads same key from disk
- `corrupted_file_returns_error_no_silent_overwrite` — malformed JSON surfaces as `Err`; file bytes unchanged afterward
- `file_mode_is_0600_on_unix` — final file is 0600 after `load_or_generate`
- `tmp_file_has_0600_at_creation_no_chmod_window` — regression guard mirroring PR #555: tmp file is 0600 immediately after `open(2)` returns, no chmod window
- `cache_skips_disk_on_repeat_call` — cache hit returns same key even after the file is unlinked behind it
- `hex_round_trip_32_bytes` / `hex_decode_rejects_short_input` — hex helpers
- All existing crypto / blob-envelope / DEK tests preserved

## Verification
- `cargo test -p phantom-bundle-store` passes (29 unit + 5 pipeline_smoke + 7 recovery, all green)
- `cargo check -p phantom-app` passes (caller compiles cleanly)
- `cargo clippy -p phantom-bundle-store --all-targets` reports zero warnings
- `cargo tree -p phantom-bundle-store | grep -i keyring` returns zero matches
- `grep -rnE "keyring|use keyring" crates/phantom-bundle-store/ --include='*.rs' --include='*.toml'` returns only the migration-note comment in Cargo.toml

## Acceptance Criteria (from #565)
- [x] `cargo tree -p phantom-bundle-store | grep -i keyring` produces no output
- [x] First-run generates a fresh master key file at `dirs::config_dir()/phantom/bundle-store/master-key.json` mode 0600
- [x] Subsequent runs read the same file — no keychain interaction
- [x] phantom startup no longer triggers a keychain ACL prompt for service "phantom-bundle-store"
- [x] Existing tests pass; new test asserts file-mode is 0600 from creation (mirrors #555 `tmp_file_has_0600_at_creation_no_chmod_window`)
- [x] `MasterKey::from_keyring()` API surface replaced cleanly across all callers (single non-test caller updated; rg `from_keyring` returns zero matches in `crates/`)

## Migration note
Per the issue, no migration: bundles encrypted under the prior keychain key become unreadable. Filed as known cost; a `phantom bundle-store rotate-key --import-from-keychain` follow-up can be added if needed.