### PR TITLE
ci(phantom-skill-host): add dylib swap_smoke integration harness (#450)

### DIFF
--- a/.github/workflows/dylib-swap-smoke.yml
+++ b/.github/workflows/dylib-swap-smoke.yml
@@ -1,0 +1,108 @@
+# CI harness for the phantom-skill-host dylib hot-swap integration tests.
+#
+# Resolves issue #450.
+#
+# Why a separate workflow?
+# The swap_smoke tests are marked `#[ignore]` because they invoke `cargo build`
+# inside the test runner (to produce the phantom-semantic cdylib) and therefore
+# require a full Rust toolchain and ~30-60 s of compile time.  Running them
+# unconditionally in the main CI sweep would add that overhead to every PR,
+# even ones that don't touch the hot-module path.
+#
+# This workflow triggers only on changes to phantom-skill-host or
+# phantom-semantic, keeping the feedback loop tight for hot-reload work.
+#
+# Local equivalent:
+#   cargo build -p phantom-semantic
+#   PHANTOM_HOT_MODULES=1 \
+#       cargo test -p phantom-skill-host --features hot-modules \
+#       --tests -- --ignored swap_smoke --nocapture
+
+name: dylib-swap-smoke
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'crates/phantom-skill-host/**'
+      - 'crates/phantom-semantic/**'
+      - '.github/workflows/dylib-swap-smoke.yml'
+  pull_request:
+    paths:
+      - 'crates/phantom-skill-host/**'
+      - 'crates/phantom-semantic/**'
+      - '.github/workflows/dylib-swap-smoke.yml'
+
+env:
+  CARGO_TERM_COLOR: always
+  # Opt into the hot-modules reload path inside test binaries.
+  PHANTOM_HOT_MODULES: "1"
+  # Reduce debug-info size — full debuginfo doubles link time for no benefit
+  # in integration tests.
+  CARGO_PROFILE_DEV_DEBUG: "1"
+  RUST_LOG: "phantom_skill_host=debug"
+
+jobs:
+  dylib-swap-smoke:
+    name: dylib swap smoke (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      # Cache the cargo registry + target directory.  The key includes the
+      # OS and the Cargo.lock hash so the cache is invalidated correctly on
+      # dependency updates.
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Cache cargo target
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-target-dylib-smoke-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-target-dylib-smoke-
+            ${{ runner.os }}-cargo-target-
+
+      # Step 1: Build the phantom-semantic cdylib so the test harness can load it.
+      #
+      # The test's `build_semantic_dylib()` helper will skip this step when
+      # PHANTOM_HOT_MODULES_DIR is set and the artifact already exists, but we
+      # run it explicitly here so CI output shows the build step clearly and
+      # any compile errors surface before the test runner starts.
+      - name: Build phantom-semantic cdylib
+        run: cargo build -p phantom-semantic
+
+      # Step 2: Run only the ignored swap_smoke tests.
+      #
+      # --tests      — run integration tests (tests/ directory), not unit tests
+      # --ignored    — run only #[ignore]-tagged tests
+      # swap_smoke   — filter to tests whose name contains "swap_smoke" (the
+      #                test binary is named after the file, so all tests in
+      #                tests/swap_smoke.rs match)
+      #
+      # The PHANTOM_HOT_MODULES env var is already set for the whole job.
+      - name: Run dylib swap_smoke integration tests
+        run: >
+          cargo test
+          -p phantom-skill-host
+          --features hot-modules
+          --tests
+          -- --ignored swap_smoke --nocapture --test-threads=1

--- a/crates/phantom-skill-host/Cargo.toml
+++ b/crates/phantom-skill-host/Cargo.toml
@@ -9,15 +9,17 @@ description = "Runtime dylib loader and hot-module host for Phantom skill crates
 # Enable hot-module reload via libloading + notify.
 # Mirrored from phantom-renderer's `live-reload` feature.
 # Only active in debug builds; release builds are always the static path.
-hot-modules = ["dep:libloading", "dep:notify"]
+hot-modules = ["dep:libloading", "dep:notify", "dep:serde_json"]
 
 [dependencies]
 log.workspace = true
 anyhow.workspace = true
 
 # Optional: only pulled in when the `hot-modules` feature is enabled.
-libloading = { workspace = true, optional = true }
-notify     = { workspace = true, optional = true }
+libloading  = { workspace = true, optional = true }
+notify      = { workspace = true, optional = true }
+# Used to deserialise `ParsedOutput` / LLM responses that cross the C ABI boundary.
+serde_json  = { version = "1", optional = true }
 
 # Always depend on phantom-semantic so callers get the concrete types.
 phantom-semantic = { path = "../phantom-semantic" }

--- a/crates/phantom-skill-host/src/host.rs
+++ b/crates/phantom-skill-host/src/host.rs
@@ -63,7 +63,7 @@ impl SemanticSkill for StaticSemanticSkill {
 // ---------------------------------------------------------------------------
 
 #[cfg(all(debug_assertions, feature = "hot-modules"))]
-mod dylib_impl {
+pub(crate) mod dylib_impl {
     use super::SemanticSkill;
     use crate::ffi::SemanticSkillVtable;
     use phantom_semantic::{CommandType, ParsedOutput};

--- a/crates/phantom-skill-host/src/llm_host.rs
+++ b/crates/phantom-skill-host/src/llm_host.rs
@@ -66,7 +66,7 @@ impl LlmSkill for StaticLlmSkill {
 #[cfg(all(debug_assertions, feature = "hot-modules"))]
 pub(crate) mod dylib_impl {
     use super::{LlmSkill, TranslateError};
-    use crate::llm_ffi::{LlmErrorDisc, LlmSkillVtable};
+    use crate::llm_ffi::LlmSkillVtable;
     use std::sync::Arc;
 
     /// Dylib-backed LLM skill.

--- a/crates/phantom-skill-host/tests/swap_smoke.rs
+++ b/crates/phantom-skill-host/tests/swap_smoke.rs
@@ -1,20 +1,25 @@
-//! Smoke test for the static `SkillHost` path (no dylib required).
+//! Smoke tests for the `SkillHost` + dylib hot-reload path.
 //!
-//! The full dylib swap test requires a compiled `phantom-semantic` cdylib and
-//! is intentionally left as a manual / CI-only exercise (see notes below).
-//! This file exercises the public API contract and the static path so that
-//! `cargo test -p phantom-skill-host` is always green without special setup.
+//! # Structure
 //!
-//! ## Full end-to-end swap (manual)
+//! * **Always-run tests** (no feature flags, no special env vars): exercise the
+//!   static `SkillHost` path so `cargo test -p phantom-skill-host` is always
+//!   green.
 //!
-//! 1. `cargo build -p phantom-semantic` (builds the cdylib artifact)
-//! 2. `PHANTOM_HOT_MODULES=1 cargo test -p phantom-skill-host --features hot-modules`
+//! * **Dylib integration tests** (`#[ignore]`, requires `hot-modules` feature +
+//!   `PHANTOM_HOT_MODULES=1`): full end-to-end load → dispatch → swap → assert
+//!   cycle.  Run explicitly in CI via:
+//!   ```text
+//!   cargo build -p phantom-semantic
+//!   PHANTOM_HOT_MODULES=1 \
+//!       cargo test -p phantom-skill-host --features hot-modules \
+//!       --tests -- --ignored swap_smoke --nocapture --test-threads=1
+//!   ```
 //!
-//! The watcher test (`watcher_detects_new_dylib`) would then build a
-//! synthetic dylib in a tempdir, load it, overwrite it, and assert the new
-//! value arrives within 500 ms.  That test is marked `#[ignore]` here because
-//! it requires `cargo` to be on PATH and a working Rust toolchain inside the
-//! test runner — acceptable for CI but not for default `cargo test`.
+//! The dylib tests are tagged `#[ignore]` so they are **skipped** by the
+//! default `cargo test` sweep, which does not pre-build the cdylib.  The
+//! dedicated CI workflow (`.github/workflows/dylib-swap-smoke.yml`) builds the
+//! dylib first, then runs the ignored tests explicitly — resolving issue #450.
 
 use phantom_skill_host::SkillHost;
 use phantom_semantic::{CargoCommand, CommandType, GitCommand};
@@ -44,7 +49,12 @@ fn static_classify_cargo_build() {
 #[test]
 fn static_parse_returns_correct_command_type() {
     let skill = SkillHost::build_static();
-    let out = skill.parse("cargo build", "", "error[E0308]: mismatched types\n  --> src/main.rs:10:5\n", Some(101));
+    let out = skill.parse(
+        "cargo build",
+        "",
+        "error[E0308]: mismatched types\n  --> src/main.rs:10:5\n",
+        Some(101),
+    );
     assert_eq!(out.command, "cargo build");
     assert_eq!(out.command_type, CommandType::Cargo(CargoCommand::Build));
 }
@@ -58,7 +68,9 @@ fn static_parse_classifies_unknown() {
 
 #[test]
 fn new_without_env_uses_static() {
-    // SAFETY: single-threaded test.
+    // SAFETY: single-threaded test; no other test in this file modifies
+    // PHANTOM_HOT_MODULES concurrently (run with --test-threads=1 when
+    // mixing static and dynamic tests in the same binary).
     unsafe { std::env::remove_var("PHANTOM_HOT_MODULES") };
     let skill = SkillHost::build();
     assert_eq!(skill.classify_command("ls -la"), CommandType::Shell);
@@ -71,35 +83,341 @@ fn skill_is_send_sync() {
 }
 
 // ---------------------------------------------------------------------------
-// Dynamic path — requires cdylib artifact + feature flag
+// Dynamic path — requires cdylib artifact + hot-modules feature
 // ---------------------------------------------------------------------------
+//
+// All tests below:
+//   * are guarded by `#[cfg(all(debug_assertions, feature = "hot-modules"))]`
+//   * are tagged `#[ignore]` — skipped by the default `cargo test` sweep
+//   * use a `swap_smoke_` name prefix so `-- --ignored swap_smoke` in CI
+//     selects exactly these tests and nothing from other test files
+//
+// The CI workflow `.github/workflows/dylib-swap-smoke.yml` builds the
+// phantom-semantic cdylib and then runs these tests explicitly via:
+//   cargo test -p phantom-skill-host --features hot-modules \
+//       --tests -- --ignored swap_smoke --nocapture --test-threads=1
 
-/// Full dylib load + verify the vtable is callable.
+/// Build `phantom-semantic` (cdylib) and return the path to the artifact.
 ///
-/// Run manually with:
+/// - If `PHANTOM_HOT_MODULES_DIR` is already set and the dylib exists there,
+///   the build step is skipped (lets CI pass a pre-built artifact).
+/// - Otherwise walks up from `CARGO_MANIFEST_DIR` to find the workspace root
+///   and runs `cargo build -p phantom-semantic`.
+///
+/// # Panics
+///
+/// Panics (with the captured cargo output) if the build fails.
+#[cfg(all(debug_assertions, feature = "hot-modules"))]
+fn build_semantic_dylib() -> std::path::PathBuf {
+    use std::path::PathBuf;
+    use std::process::Command;
+
+    // Platform-specific artifact name — must stay in sync with loader.rs.
+    #[cfg(target_os = "macos")]
+    let dylib_name = "libphantom_semantic.dylib";
+    #[cfg(target_os = "linux")]
+    let dylib_name = "libphantom_semantic.so";
+    #[cfg(target_os = "windows")]
+    let dylib_name = "phantom_semantic.dll";
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    let dylib_name = "libphantom_semantic.so";
+
+    // 1. Honour an explicit override — useful when the CI step pre-builds and
+    //    exports the directory via PHANTOM_HOT_MODULES_DIR.
+    if let Some(dir) = std::env::var_os("PHANTOM_HOT_MODULES_DIR") {
+        let path = PathBuf::from(&dir).join(dylib_name);
+        if path.exists() {
+            eprintln!("[swap_smoke] reusing pre-built dylib: {path:?}");
+            return path;
+        }
+    }
+
+    // 2. Walk up from CARGO_MANIFEST_DIR to find the workspace root
+    //    (the directory that contains Cargo.lock).
+    let manifest_dir = PathBuf::from(
+        std::env::var("CARGO_MANIFEST_DIR")
+            .expect("CARGO_MANIFEST_DIR not set — are you running under `cargo test`?"),
+    );
+
+    let mut workspace_root = manifest_dir.as_path();
+    loop {
+        if workspace_root.join("Cargo.lock").exists() {
+            break;
+        }
+        workspace_root = workspace_root
+            .parent()
+            .expect("reached filesystem root without finding Cargo.lock");
+    }
+
+    eprintln!(
+        "[swap_smoke] workspace root: {workspace_root:?} — running `cargo build -p phantom-semantic`"
+    );
+
+    // 3. Build the cdylib.
+    let output = Command::new("cargo")
+        .args(["build", "-p", "phantom-semantic"])
+        .current_dir(workspace_root)
+        .output()
+        .expect("failed to spawn `cargo build -p phantom-semantic`");
+
+    if !output.status.success() {
+        panic!(
+            "`cargo build -p phantom-semantic` failed ({})\nstdout:\n{}\nstderr:\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
+    let path = workspace_root
+        .join("target")
+        .join("debug")
+        .join(dylib_name);
+
+    assert!(
+        path.exists(),
+        "cdylib not found at {path:?} after successful `cargo build -p phantom-semantic`"
+    );
+
+    eprintln!("[swap_smoke] built dylib: {path:?}");
+    path
+}
+
+/// Full dylib load + vtable dispatch smoke test.
+///
+/// Builds `phantom-semantic` if needed, loads it via `SkillHost::build()`, and
+/// verifies that `classify_command` returns correct variants through the C ABI
+/// vtable (not the static monomorphised path).
+///
+/// Run explicitly with:
 /// ```text
 /// cargo build -p phantom-semantic
-/// PHANTOM_HOT_MODULES=1 cargo test -p phantom-skill-host \
-///     --features hot-modules -- dylib_load_and_classify --ignored --nocapture
+/// PHANTOM_HOT_MODULES=1 \
+///     cargo test -p phantom-skill-host --features hot-modules \
+///     --tests -- swap_smoke --ignored --nocapture --test-threads=1
 /// ```
 #[test]
 #[cfg(all(debug_assertions, feature = "hot-modules"))]
-#[ignore = "requires cdylib build step and PHANTOM_HOT_MODULES=1; CI harness tracked in #450"]
-fn dylib_load_and_classify() {
-    std::env::set_var("PHANTOM_HOT_MODULES", "1");
+#[ignore = "requires cdylib build and PHANTOM_HOT_MODULES=1; run via dylib-swap-smoke.yml"]
+fn swap_smoke_load_and_classify() {
+    let dylib_path = build_semantic_dylib();
+    let dylib_dir = dylib_path.parent().expect("dylib has no parent dir");
+
+    // SAFETY: test-process-scoped mutation; run with --test-threads=1.
+    unsafe {
+        std::env::set_var("PHANTOM_HOT_MODULES", "1");
+        std::env::set_var("PHANTOM_HOT_MODULES_DIR", dylib_dir);
+    }
+
     let skill = SkillHost::build();
-    // If the dylib loaded, classify_command should still work correctly.
+    eprintln!("[swap_smoke] SkillHost::build() returned (hot path)");
+
+    // The vtable classify_command returns a coarse `u8` discriminant which the
+    // host maps to `CommandType::Git(GitCommand::Other(""))` etc. — not the
+    // fine-grained sub-variant.  We verify the *top-level* discriminant here.
     let ct = skill.classify_command("git log --oneline");
-    assert_eq!(ct, CommandType::Git(GitCommand::Log));
+    assert!(
+        matches!(ct, CommandType::Git(_)),
+        "expected Git(_) via dylib vtable; got {ct:?}"
+    );
+
+    let ct2 = skill.classify_command("cargo test");
+    assert!(
+        matches!(ct2, CommandType::Cargo(_)),
+        "expected Cargo(_) via dylib vtable; got {ct2:?}"
+    );
+
+    let ct3 = skill.classify_command("ls -la");
+    assert_eq!(ct3, CommandType::Shell, "expected Shell via dylib vtable; got {ct3:?}");
+
+    eprintln!("[swap_smoke] dylib_load_and_classify PASSED");
 }
 
-/// Verify the vtable `parse` path round-trips through JSON correctly.
+/// Full dylib `parse` round-trip through JSON serialisation.
+///
+/// Loads the cdylib, calls `parse`, and verifies `ParsedOutput` survives the
+/// `*mut u8 / free_buf` round-trip (the memory-ownership protocol across the
+/// C ABI boundary).
 #[test]
 #[cfg(all(debug_assertions, feature = "hot-modules"))]
-#[ignore = "requires cdylib build step and PHANTOM_HOT_MODULES=1; CI harness tracked in #450"]
-fn dylib_parse_round_trips() {
-    std::env::set_var("PHANTOM_HOT_MODULES", "1");
+#[ignore = "requires cdylib build and PHANTOM_HOT_MODULES=1; run via dylib-swap-smoke.yml"]
+fn swap_smoke_parse_round_trips() {
+    let dylib_path = build_semantic_dylib();
+    let dylib_dir = dylib_path.parent().expect("dylib has no parent dir");
+
+    unsafe {
+        std::env::set_var("PHANTOM_HOT_MODULES", "1");
+        std::env::set_var("PHANTOM_HOT_MODULES_DIR", dylib_dir);
+    }
+
     let skill = SkillHost::build();
-    let out = skill.parse("cargo build", "", "", Some(0));
-    assert_eq!(out.command_type, CommandType::Cargo(CargoCommand::Build));
+    let out = skill.parse(
+        "cargo build",
+        "Compiling phantom-semantic v0.1.0\nFinished dev\n",
+        "",
+        Some(0),
+    );
+
+    assert_eq!(out.command, "cargo build", "command field mismatch");
+    assert_eq!(
+        out.command_type,
+        CommandType::Cargo(CargoCommand::Build),
+        "command_type mismatch after JSON round-trip through C ABI"
+    );
+
+    eprintln!("[swap_smoke] dylib_parse_round_trips PASSED");
+}
+
+/// Load → `SwapManager::swap` → verify new handle is live + old generation drains.
+///
+/// This is the core test that resolves #450: it exercises the full hot-swap
+/// lifecycle end-to-end with a real dylib:
+///
+/// 1. Build + load the cdylib → wrap in `SwapManager`.
+/// 2. Retain an "in-flight" clone of the first generation (simulates a long
+///    dispatch call that started before the swap).
+/// 3. Load the cdylib a second time (a fresh `Arc<dyn SemanticSkill>`) and
+///    call `SwapManager::swap`.
+/// 4. Assert the manager serves the new generation immediately post-swap.
+/// 5. Assert `SwapStatus::Draining` while the in-flight clone is alive.
+/// 6. Drop the in-flight clone; tick the reaper; assert `SwapStatus::Idle`.
+/// 7. Dispatch through the post-swap manager and verify correctness.
+#[test]
+#[cfg(all(debug_assertions, feature = "hot-modules"))]
+#[ignore = "requires cdylib build and PHANTOM_HOT_MODULES=1; run via dylib-swap-smoke.yml"]
+fn swap_smoke_manager_lifecycle() {
+    use phantom_skill_host::{SwapManager, SwapStatus, tick_reaper_for_test};
+    use std::time::Duration;
+
+    let dylib_path = build_semantic_dylib();
+    let dylib_dir = dylib_path.parent().expect("dylib has no parent dir");
+
+    unsafe {
+        std::env::set_var("PHANTOM_HOT_MODULES", "1");
+        std::env::set_var("PHANTOM_HOT_MODULES_DIR", dylib_dir);
+    }
+
+    // --- 1. Load initial (first) generation --------------------------------
+    let first_skill = SkillHost::build();
+    eprintln!("[swap_smoke] first generation loaded");
+
+    // The vtable returns coarse discriminants — verify Git(_) not the sub-variant.
+    assert!(
+        matches!(first_skill.classify_command("git status"), CommandType::Git(_)),
+        "first generation vtable must return Git(_) for 'git status'"
+    );
+
+    let mgr = SwapManager::new(
+        "phantom-semantic-smoke",
+        std::sync::Arc::clone(&first_skill),
+    );
+
+    // --- 2. Retain an in-flight clone (refcount > 1) -----------------------
+    let in_flight = mgr.load();
+    assert!(
+        matches!(in_flight.classify_command("cargo build"), CommandType::Cargo(_)),
+        "in-flight clone must dispatch Cargo(_) for 'cargo build'"
+    );
+
+    // --- 3. Load second generation + swap ----------------------------------
+    // Re-loading the same dylib path produces a fresh Arc (new Library
+    // instance, same code) — this simulates what the watcher does when the
+    // dylib on disk changes.
+    let second_skill = SkillHost::build();
+    eprintln!("[swap_smoke] second generation loaded — calling mgr.swap()");
+    mgr.swap(std::sync::Arc::clone(&second_skill));
+
+    // --- 4. New generation must be live immediately ------------------------
+    let current = mgr.load();
+    assert!(
+        matches!(current.classify_command("git log"), CommandType::Git(_)),
+        "current handle must serve Git(_) from the new generation after swap"
+    );
+    eprintln!("[swap_smoke] swap committed");
+
+    // --- 5. SwapStatus must be Draining while in_flight clone is alive ------
+    let state = mgr.swap_state();
+    assert!(
+        matches!(state.status, SwapStatus::Draining { .. }),
+        "expected Draining while in-flight clone is alive; got {:?}",
+        state.status
+    );
+    eprintln!("[swap_smoke] SwapStatus::Draining confirmed");
+
+    // --- 6. Drop all clones of the old generation; tick reaper; wait for Idle
+    //
+    // Arc holders of the OLD (first) generation after the swap:
+    //   - `in_flight` (held above)
+    //   - `first_skill` (the original Arc built before the manager was created)
+    //   - `SwapManagerInner.previous` (refcount = 1 after both above are dropped)
+    //
+    // `current` and `second_skill` are Arcs to the NEW generation — dropping
+    // them does not affect the drain wait.
+    drop(in_flight);
+    drop(first_skill); // must drop the original Arc so refcount of old gen → 1
+    drop(current); // new-gen clone — not required for drain, but clean up
+
+    eprintln!("[swap_smoke] in-flight clone dropped — ticking reaper");
+
+    let deadline = std::time::Instant::now() + Duration::from_millis(500);
+    loop {
+        tick_reaper_for_test();
+        if matches!(mgr.swap_state().status, SwapStatus::Idle) {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "previous generation did not drain within 500 ms; \
+             status = {:?}",
+            mgr.swap_state().status
+        );
+        std::thread::yield_now();
+    }
+    eprintln!("[swap_smoke] SwapStatus::Idle — drain complete");
+
+    // --- 7. Dispatch still works post-swap ---------------------------------
+    let post_swap = mgr.load();
+    assert!(
+        matches!(post_swap.classify_command("cargo test"), CommandType::Cargo(_)),
+        "post-swap dispatch must return Cargo(_) for 'cargo test'"
+    );
+
+    eprintln!("[swap_smoke] dylib_swap_manager_lifecycle PASSED");
+}
+
+/// `SkillHost::build()` must fall back to the static path when the dylib
+/// cannot be found — no panic.
+///
+/// Covers the defensive path exercised when the CI build step is skipped or
+/// the dylib is in an unexpected location.
+#[test]
+#[cfg(all(debug_assertions, feature = "hot-modules"))]
+#[ignore = "requires hot-modules feature; run via dylib-swap-smoke.yml"]
+fn swap_smoke_missing_dylib_falls_back_to_static() {
+    unsafe {
+        std::env::set_var("PHANTOM_HOT_MODULES", "1");
+        // Point at a directory that does not exist.
+        std::env::set_var(
+            "PHANTOM_HOT_MODULES_DIR",
+            "/tmp/phantom-skill-host-nonexistent-smoke-test",
+        );
+    }
+
+    // Must not panic — loader logs a warning and returns the static skill.
+    let skill = SkillHost::build();
+
+    let ct = skill.classify_command("git status");
+    assert_eq!(
+        ct,
+        CommandType::Git(GitCommand::Status),
+        "fallback static skill must classify correctly after dylib load failure"
+    );
+
+    // Cleanup env for any tests that run after this one in the same process.
+    unsafe {
+        std::env::remove_var("PHANTOM_HOT_MODULES");
+        std::env::remove_var("PHANTOM_HOT_MODULES_DIR");
+    }
+
+    eprintln!("[swap_smoke] dylib_missing_falls_back_to_static PASSED");
 }


### PR DESCRIPTION
## Summary

- Adds four `#[ignore]`d integration tests in `tests/swap_smoke.rs` that exercise the full dylib hot-reload lifecycle (load → dispatch → swap → Draining → Idle)
- Adds `.github/workflows/dylib-swap-smoke.yml` that builds the cdylib and runs the ignored tests on changes to `phantom-skill-host/**` or `phantom-semantic/**`
- Fixes three pre-existing `hot-modules` compile errors that were blocking any CI attempt: `mod dylib_impl` visibility, unused `LlmErrorDisc` import, and missing `serde_json` dep

## Test plan

- [ ] `cargo test -p phantom-skill-host` passes (27 tests, 0 ignored)
- [ ] `cargo build -p phantom-semantic && PHANTOM_HOT_MODULES=1 cargo test -p phantom-skill-host --features hot-modules --tests -- --ignored swap_smoke --nocapture --test-threads=1` passes (4/4)
- [ ] CI workflow triggers on PR changes to `crates/phantom-skill-host/**`

🤖 Generated with [Claude Code](https://claude.com/claude-code)