### PR TITLE
spike(phantom-agents): prove complete_task delivery path (#646)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5952,6 +5952,7 @@ dependencies = [
  "blake3",
  "glob",
  "log",
+ "phantom-mcp",
  "phantom-memory",
  "phantom-protocol",
  "phantom-semantic",
@@ -5976,6 +5977,7 @@ dependencies = [
  "arboard",
  "bitflags 2.11.1",
  "futures-core",
+ "futures-util",
  "image",
  "libc",
  "log",
@@ -6010,6 +6012,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tokio-tungstenite 0.26.2",
  "toml",
  "uuid",
  "wgpu",
@@ -6136,10 +6139,8 @@ dependencies = [
  "axum",
  "axum-test",
  "ed25519-dalek",
- "env_logger",
  "futures-util",
  "jsonwebtoken",
- "log",
  "lru",
  "rand 0.8.6",
  "serde",
@@ -6240,6 +6241,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "log",
+ "serde_json",
 ]
 
 [[package]]
@@ -6340,6 +6342,7 @@ dependencies = [
  "notify",
  "phantom-nlp",
  "phantom-semantic",
+ "serde_json",
  "tempfile",
 ]
 

--- a/crates/phantom-adapter/src/bus.rs
+++ b/crates/phantom-adapter/src/bus.rs
@@ -327,6 +327,7 @@ mod tests {
                 success: true,
                 summary: "fix the bug".into(),
                 spawn_tag: None,
+                result: None,
             },
             frame: 0,
             timestamp: 100,

--- a/crates/phantom-agents/src/agent.rs
+++ b/crates/phantom-agents/src/agent.rs
@@ -311,6 +311,21 @@ pub struct Agent {
     /// until [`Agent::store_prompt`] (or [`SystemPromptBuilder::build_and_store`])
     /// is called.
     pub prompt_text: Option<String>,
+    /// Issue #646 spike: when `true`, the agent must call the lifecycle tool
+    /// `complete_task(result)` to terminate. Reaching `MAX_TOOL_ROUNDS`
+    /// without calling it should transition the pane to `Failed` with reason
+    /// `"exited without complete_task"`. The default `false` preserves the
+    /// current state-implicit termination behaviour for the legacy callers
+    /// that have not been updated yet.
+    requires_complete_task: bool,
+    /// Issue #646 spike: typed result payload captured from a successful
+    /// `complete_task` call.
+    ///
+    /// Set by [`Agent::complete_with_result`] when the agent loop receives an
+    /// [`crate::api::ApiEvent::CompleteTask`] event. Surfaced to consumers
+    /// (capture sidecar, parent-agent `wait_for_agent`, brain reconciler)
+    /// via [`Agent::completion_result`].
+    completion_result: Option<serde_json::Value>,
 }
 
 impl Agent {
@@ -335,6 +350,11 @@ impl Agent {
             semantic_ctx: SemanticContext::new(),
             policy: AgentPolicy::default(),
             prompt_text: None,
+            // Issue #646 spike: legacy callers default to opt-out; only the
+            // builder-driven path turned on by `AgentSpawnOpts::with_requires_complete_task`
+            // flips this to `true`.
+            requires_complete_task: false,
+            completion_result: None,
         }
     }
 
@@ -620,6 +640,47 @@ impl Agent {
         self.completed_at = Some(Instant::now());
     }
 
+    /// Issue #646 spike: terminate the agent with a typed result payload.
+    ///
+    /// Called by the agent loop on receipt of [`crate::api::ApiEvent::CompleteTask`].
+    /// Stores `result` for later retrieval via [`Self::completion_result`] and
+    /// transitions to [`AgentStatus::Done`].
+    ///
+    /// Spike scope: this is the success-path-only entry. Schema validation,
+    /// `validation_failure_count`, and `abort_task` are explicitly out of
+    /// scope and live in follow-up PRs against issue #646.
+    pub fn complete_with_result(&mut self, result: serde_json::Value) {
+        self.completion_result = Some(result);
+        self.complete(true);
+    }
+
+    /// Issue #646 spike: returns whether this agent must call `complete_task`
+    /// to terminate. `false` for legacy state-implicit terminations.
+    #[must_use]
+    pub fn requires_complete_task(&self) -> bool {
+        self.requires_complete_task
+    }
+
+    /// Issue #646 spike: marks this agent as requiring a `complete_task` call
+    /// to terminate.
+    ///
+    /// Called by the agent-pane spawn site when the matching
+    /// [`AgentSpawnOpts::requires_complete_task`] flag is set. Kept as a
+    /// dedicated setter so the storage layout (Decision #2 option (a):
+    /// direct field on `Agent`) is opaque to construction sites.
+    pub fn set_requires_complete_task(&mut self, required: bool) {
+        self.requires_complete_task = required;
+    }
+
+    /// Issue #646 spike: returns the typed result payload captured from
+    /// `complete_task`, if the agent has terminated through that path.
+    ///
+    /// `None` until [`Self::complete_with_result`] has been called.
+    #[must_use]
+    pub fn completion_result(&self) -> Option<&serde_json::Value> {
+        self.completion_result.as_ref()
+    }
+
     /// Transition to Flatline — terminal failure requiring manual retry.
     ///
     /// Flatline is intentionally terminal: unlike Failed, it does not
@@ -893,6 +954,10 @@ pub struct AgentSpawnOpts {
     ///
     /// Previously silently dropped from `SpawnSubagentRequest` — wired in for #224.
     label: Option<String>,
+    /// Issue #646 spike: when `true`, the spawned [`Agent`] must call
+    /// `complete_task(result)` to terminate. Default `false` preserves the
+    /// existing state-implicit termination behaviour.
+    requires_complete_task: bool,
 }
 
 impl AgentSpawnOpts {
@@ -907,6 +972,7 @@ impl AgentSpawnOpts {
             spawn_tag: None,
             role: None,
             label: None,
+            requires_complete_task: false,
         }
     }
 
@@ -945,6 +1011,19 @@ impl AgentSpawnOpts {
         self
     }
 
+    /// Issue #646 spike: opt the spawned agent into mandatory `complete_task`
+    /// termination. Default `false` preserves state-implicit termination for
+    /// every legacy caller that does not explicitly opt in.
+    ///
+    /// Spike scope: only the field is wired here. The `Failed` transition on
+    /// `MAX_TOOL_ROUNDS` and the schema-validation flatline path live in
+    /// follow-up PRs against issue #646.
+    #[must_use]
+    pub fn with_requires_complete_task(mut self, required: bool) -> Self {
+        self.requires_complete_task = required;
+        self
+    }
+
     /// Return the role override, if any.
     #[must_use]
     pub fn role(&self) -> Option<crate::role::AgentRole> {
@@ -955,6 +1034,13 @@ impl AgentSpawnOpts {
     #[must_use]
     pub fn label(&self) -> Option<&str> {
         self.label.as_deref()
+    }
+
+    /// Issue #646 spike: returns whether the spawned agent must call
+    /// `complete_task` to terminate.
+    #[must_use]
+    pub fn requires_complete_task(&self) -> bool {
+        self.requires_complete_task
     }
 
 

--- a/crates/phantom-agents/src/api.rs
+++ b/crates/phantom-agents/src/api.rs
@@ -87,6 +87,23 @@ pub enum ApiEvent {
         id: String,
         call: ToolCall,
     },
+    /// The assistant called the lifecycle tool `complete_task(result)`.
+    ///
+    /// Issue #646 spike: lifecycle signals are routed pre-`from_api_name` and
+    /// emitted as a distinct event variant rather than a `ToolUse`, because
+    /// they have no `ToolResult` round-trip — they end the agent's loop. The
+    /// agent loop matches on this variant and transitions to `AgentStatus::Done`
+    /// while preserving `result` on the agent for downstream consumers
+    /// (capture sidecar, parent-agent `wait_for_agent`, brain reconciler).
+    CompleteTask {
+        /// API-assigned ID echoed back so the conversation history can record
+        /// the call site if a downstream PR widens `AgentMessage::ToolCall` to
+        /// cover lifecycle signals.
+        id: String,
+        /// The typed result payload. Phase 1 enforces "must be a JSON object";
+        /// Phase 2 binds this to a per-task JSON schema (issue #646).
+        result: Value,
+    },
     /// The response is complete.
     Done,
     /// An error occurred.
@@ -297,7 +314,13 @@ fn build_request_body(
 // ---------------------------------------------------------------------------
 
 /// Parse the API response JSON and send events over the channel.
-fn parse_response(body: &Value, tx: &mpsc::Sender<ApiEvent>) {
+///
+/// Exposed (with `#[doc(hidden)]`) so the issue #646 spike integration test
+/// at `crates/phantom-agents/tests/complete_task_spike.rs` can drive it
+/// directly without standing up a full HTTPS round-trip. Production callers
+/// reach this through [`send_message`].
+#[doc(hidden)]
+pub fn parse_response(body: &Value, tx: &mpsc::Sender<ApiEvent>) {
     // Check for API-level error.
     if let Some(err) = body.get("error") {
         let msg = err["message"]
@@ -344,7 +367,19 @@ fn parse_response(body: &Value, tx: &mpsc::Sender<ApiEvent>) {
                     continue;
                 }
 
-                if let Some(tool) = ToolType::from_api_name(name) {
+                // ---- Issue #646: lifecycle pre-parser filter --------------
+                //
+                // `complete_task` is a lifecycle signal, not a tool — it has
+                // no `ToolResult` round-trip. Diverting it ahead of
+                // `ToolType::from_api_name` keeps the 8-variant `ToolType`
+                // enum focused on file/git tools and gives the agent loop a
+                // dedicated `ApiEvent::CompleteTask { result }` to match on.
+                //
+                // Spike scope: only `complete_task` is wired here. `abort_task`
+                // is intentionally out of scope — see issue #646.
+                if name == "complete_task" {
+                    let _ = tx.send(ApiEvent::CompleteTask { id, result: raw_input });
+                } else if let Some(tool) = ToolType::from_api_name(name) {
                     let _ = tx.send(ApiEvent::ToolUse {
                         id,
                         call: ToolCall { tool, args: raw_input },

--- a/crates/phantom-agents/src/chat.rs
+++ b/crates/phantom-agents/src/chat.rs
@@ -785,7 +785,17 @@ fn parse_openai_response(body: &Value, tx: &mpsc::Sender<ApiEvent>) {
                 }
             };
 
-            if let Some(tool) = ToolType::from_api_name(name) {
+            // ---- Issue #646: lifecycle pre-parser filter ---------------------
+            //
+            // Mirror the Claude path in `api.rs`: `complete_task` is a
+            // lifecycle signal, not a tool. Divert it ahead of
+            // `ToolType::from_api_name` so the agent loop sees it as a
+            // dedicated `ApiEvent::CompleteTask { result }` event. Both
+            // backends must agree on this filter or one path silently
+            // refuses the model's terminal signal.
+            if name == "complete_task" {
+                let _ = tx.send(ApiEvent::CompleteTask { id, result: args });
+            } else if let Some(tool) = ToolType::from_api_name(name) {
                 let _ = tx.send(ApiEvent::ToolUse {
                     id,
                     call: ToolCall { tool, args },
@@ -1339,6 +1349,9 @@ mod tests {
                 Some(ApiEvent::TextDelta(t)) => text.push_str(&t),
                 Some(ApiEvent::ToolUse { .. }) => {
                     panic!("unexpected tool use in live hello test");
+                }
+                Some(ApiEvent::CompleteTask { .. }) => {
+                    panic!("unexpected complete_task in live hello test");
                 }
                 Some(ApiEvent::Done) => break,
                 Some(ApiEvent::Error(e)) => panic!("live test error: {e}"),

--- a/crates/phantom-agents/tests/complete_task_spike.rs
+++ b/crates/phantom-agents/tests/complete_task_spike.rs
@@ -1,0 +1,216 @@
+//! Issue #646 — `complete_task` delivery-path spike.
+//!
+//! This test grounds the three architectural design choices the broader
+//! issue (#646) is built on, against real code:
+//!
+//! 1. **Parser short-circuit**: `complete_task` must be diverted ahead of
+//!    `ToolType::from_api_name`, otherwise it falls through the
+//!    `unknown tool in response` arm at `crates/phantom-agents/src/api.rs`
+//!    and never reaches the agent loop. The spike chooses **option (b)** —
+//!    a pre-parser lifecycle filter that emits a dedicated
+//!    [`ApiEvent::CompleteTask`] variant. This keeps the 8-variant
+//!    `ToolType` enum focused on file/git tools (which all return
+//!    `ToolResult`) and gives the agent loop a single, ergonomic match arm
+//!    for a non-tool event.
+//!
+//! 2. **`requires_complete_task` storage**: The agent must remember whether
+//!    it was spawned with the lifecycle requirement. The spike chooses
+//!    **option (a)** — a `requires_complete_task: bool` field on `Agent`
+//!    set at construction from `AgentSpawnOpts::with_requires_complete_task`.
+//!    Storing the flag (rather than the whole `AgentSpawnOpts`) keeps the
+//!    `Agent` struct's surface focused on lifecycle and avoids carrying
+//!    spawn-time metadata (`chat_model`, `spawn_tag`, …) past the point
+//!    they are needed.
+//!
+//! 3. **`AgentTaskComplete.result` extension**: The typed result must reach
+//!    consumers (capture sidecar, parent-agent `wait_for_agent`, brain
+//!    reconciler). The spike chooses **option (a)** — a new
+//!    `result: Option<serde_json::Value>` field on
+//!    `phantom_protocol::Event::AgentTaskComplete`, with the exhaustive
+//!    destructure at `update.rs` widened. A separate event keyed on
+//!    `agent_id` (option b) would create an ordering window between the
+//!    completion and its payload; a registry lookup (option c) introduces
+//!    async / lock-poisoning failure modes the existing event bus does
+//!    not have. Carrying the payload on the same variant is the
+//!    least-invasive shape.
+//!
+//! ## What the test exercises
+//!
+//! - The Claude-side parser at `parse_response` lifts a synthesised
+//!   `complete_task` `tool_use` block into [`ApiEvent::CompleteTask`].
+//! - An [`Agent`] driven through [`Agent::complete_with_result`] reaches
+//!   [`AgentStatus::Done`] with the typed result captured.
+//! - The opt-in `requires_complete_task` flag round-trips through
+//!   `AgentSpawnOpts::with_requires_complete_task`.
+//!
+//! ## Out of scope (deliberately)
+//!
+//! Schema validation, `validation_failure_count`, the `MAX_TOOL_ROUNDS →
+//! Failed` enforcement, and `abort_task` are out of scope and left as
+//! TODOs in the production callsites the broader implementation will
+//! extend (see PR description for the list).
+
+use std::sync::mpsc;
+
+use phantom_agents::agent::{Agent, AgentSpawnOpts, AgentStatus, AgentTask};
+use phantom_agents::api::{self, ApiEvent};
+
+use serde_json::json;
+
+/// Synthesise the JSON shape Claude returns for a single `complete_task`
+/// `tool_use` block. Mirrors the live API contract documented at
+/// `crates/phantom-agents/src/api.rs` `parse_response`.
+fn claude_complete_task_response(result: serde_json::Value) -> serde_json::Value {
+    json!({
+        "content": [
+            {
+                "type": "tool_use",
+                "id": "toolu_complete_task_001",
+                "name": "complete_task",
+                "input": result,
+            }
+        ]
+    })
+}
+
+#[test]
+fn parser_diverts_complete_task_to_dedicated_event() {
+    // ---- ARRANGE ---------------------------------------------------------
+    let body = claude_complete_task_response(json!({"foo": "bar"}));
+    let (tx, rx) = mpsc::channel::<ApiEvent>();
+
+    // ---- ACT -------------------------------------------------------------
+    api::parse_response(&body, &tx);
+    drop(tx);
+    let events: Vec<ApiEvent> = rx.into_iter().collect();
+
+    // ---- ASSERT ----------------------------------------------------------
+    //
+    // Expectation: exactly one `CompleteTask` event with the typed result,
+    // followed by `Done`. No `ToolUse` (which would mean the lifecycle name
+    // got routed through the file/git tool path), no `Error` (which would
+    // mean the name fell through to `unknown tool in response`).
+    assert_eq!(events.len(), 2, "parser must emit CompleteTask + Done; got {events:?}");
+
+    let captured_result = match &events[0] {
+        ApiEvent::CompleteTask { id, result } => {
+            assert_eq!(id, "toolu_complete_task_001");
+            result.clone()
+        }
+        other => panic!("first event must be CompleteTask, got {other:?}"),
+    };
+    assert_eq!(
+        captured_result,
+        json!({"foo": "bar"}),
+        "complete_task result payload must round-trip through the parser unchanged",
+    );
+    assert!(
+        matches!(&events[1], ApiEvent::Done),
+        "parser must emit Done after CompleteTask; got {:?}",
+        events[1]
+    );
+}
+
+#[test]
+fn agent_complete_with_result_transitions_to_done_and_captures_result() {
+    // ---- ARRANGE ---------------------------------------------------------
+    let mut agent = Agent::new(
+        42,
+        AgentTask::FreeForm { prompt: "complete-task spike".into() },
+    );
+    agent.set_requires_complete_task(true);
+    // Drive into Working so the FSM transition to Done is valid (Queued →
+    // Working is a no-gate fast-path on `AgentStatus`).
+    assert!(agent.approve_plan(), "Queued → Working transition must succeed");
+    assert_eq!(agent.status(), AgentStatus::Working);
+
+    let result = json!({"foo": "bar"});
+
+    // ---- ACT -------------------------------------------------------------
+    agent.complete_with_result(result.clone());
+
+    // ---- ASSERT ----------------------------------------------------------
+    assert_eq!(
+        agent.status(),
+        AgentStatus::Done,
+        "complete_with_result must transition the agent to Done",
+    );
+    assert!(
+        agent.requires_complete_task(),
+        "the requires_complete_task flag must remain set after termination",
+    );
+    assert_eq!(
+        agent.completion_result(),
+        Some(&result),
+        "the typed result payload must be retrievable after termination",
+    );
+}
+
+#[test]
+fn spawn_opts_carry_requires_complete_task_flag() {
+    // ---- ARRANGE / ACT ---------------------------------------------------
+    let opts_default = AgentSpawnOpts::new(AgentTask::FreeForm { prompt: "x".into() });
+    let opts_required = AgentSpawnOpts::new(AgentTask::FreeForm { prompt: "x".into() })
+        .with_requires_complete_task(true);
+    let opts_explicit_off = AgentSpawnOpts::new(AgentTask::FreeForm { prompt: "x".into() })
+        .with_requires_complete_task(false);
+
+    // ---- ASSERT ----------------------------------------------------------
+    assert!(
+        !opts_default.requires_complete_task(),
+        "AgentSpawnOpts::new must default `requires_complete_task` to false to preserve \
+         legacy state-implicit termination",
+    );
+    assert!(
+        opts_required.requires_complete_task(),
+        "with_requires_complete_task(true) must set the field",
+    );
+    assert!(
+        !opts_explicit_off.requires_complete_task(),
+        "with_requires_complete_task(false) must keep the field unset",
+    );
+}
+
+#[test]
+fn end_to_end_parser_to_agent_done() {
+    // The integration the issue actually asks for: stub LLM emits
+    // `complete_task({"foo":"bar"})`, agent reaches `AgentStatus::Done` with
+    // the typed result captured.
+
+    // ---- ARRANGE ---------------------------------------------------------
+    let body = claude_complete_task_response(json!({"foo": "bar"}));
+    let (tx, rx) = mpsc::channel::<ApiEvent>();
+
+    let opts = AgentSpawnOpts::new(AgentTask::FreeForm {
+        prompt: "complete-task spike e2e".into(),
+    })
+    .with_requires_complete_task(true);
+    let mut agent = Agent::new(7, opts.task.clone());
+    agent.set_requires_complete_task(opts.requires_complete_task());
+    assert!(agent.approve_plan(), "Queued → Working transition must succeed");
+
+    // ---- ACT -------------------------------------------------------------
+    api::parse_response(&body, &tx);
+    drop(tx);
+
+    // The agent loop in production is `crates/phantom-app/src/agent_pane/mod.rs`;
+    // the spike inlines the minimal handling here so the test stays in
+    // `phantom-agents` and the wiring is fully exercised end-to-end without
+    // pulling in the full pane / GPU stack.
+    for event in rx.iter() {
+        match event {
+            ApiEvent::CompleteTask { result, .. } => {
+                agent.complete_with_result(result);
+            }
+            ApiEvent::Done => break,
+            ApiEvent::TextDelta(_) | ApiEvent::ToolUse { .. } => {
+                panic!("unexpected non-lifecycle event in spike: {event:?}");
+            }
+            ApiEvent::Error(e) => panic!("parser emitted Error: {e}"),
+        }
+    }
+
+    // ---- ASSERT ----------------------------------------------------------
+    assert_eq!(agent.status(), AgentStatus::Done);
+    assert_eq!(agent.completion_result(), Some(&json!({"foo": "bar"})));
+}

--- a/crates/phantom-app/src/adapters/agent.rs
+++ b/crates/phantom-app/src/adapters/agent.rs
@@ -145,6 +145,12 @@ impl AppCore for AgentAdapter {
                         success,
                         summary,
                         spawn_tag: self.spawn_tag,
+                        // Issue #646 spike: this adapter path bridges the
+                        // pane-status FSM (Working/Done/Failed) — it does not
+                        // see the agents-side `complete_task` result payload,
+                        // which is captured on `Agent` directly. Future PRs
+                        // will plumb the typed result through to this site.
+                        result: None,
                     },
                     frame: 0,
                     timestamp: 0,

--- a/crates/phantom-app/src/agent_pane/mod.rs
+++ b/crates/phantom-app/src/agent_pane/mod.rs
@@ -757,6 +757,31 @@ impl AgentPane {
                     self.pending_tools.push((id, call));
                     got_content = true;
                 }
+                Some(ApiEvent::CompleteTask { id: _, result }) => {
+                    // Issue #646 spike: minimal lifecycle handler.
+                    //
+                    // The model emitted `complete_task(result)`; capture the
+                    // typed payload on the agent and end the loop. This is
+                    // enough to make the spike integration test pass and to
+                    // establish the wiring the broader implementation will
+                    // build on.
+                    //
+                    // OUT OF SCOPE FOR THE SPIKE — to be implemented in
+                    // follow-up PRs against #646:
+                    //   - Schema validation (must-be-object → flatline after
+                    //     `validation_failure_count` reaches 3).
+                    //   - `requires_complete_task` enforcement on
+                    //     `MAX_TOOL_ROUNDS` exit (transition to `Failed` with
+                    //     reason `"exited without complete_task"`).
+                    //   - Mirror the bookkeeping the `Done` arm performs:
+                    //     journal completion record, capture sidecar flush,
+                    //     conversation save, snapshot push, status transition
+                    //     to `AgentPaneStatus::Done`. The spike intentionally
+                    //     does the agents-side bit only.
+                    self.agent.complete_with_result(result);
+                    got_content = true;
+                    break;
+                }
                 Some(ApiEvent::Done) => {
                     // Flush accumulated assistant text into the conversation.
                     if !self.current_assistant_text.is_empty() {

--- a/crates/phantom-app/src/update.rs
+++ b/crates/phantom-app/src/update.rs
@@ -695,7 +695,13 @@ impl App {
                         success,
                         summary,
                         spawn_tag,
+                        result: _,
                     } => Some(AiEvent::AgentComplete {
+                        // Issue #646 spike: `result` is the typed payload from
+                        // `complete_task`. The brain `AiEvent::AgentComplete`
+                        // shape predates this field; downstream PRs will widen
+                        // it. For the spike we ignore the payload here so
+                        // existing brain routing keeps working.
                         id: *agent_id,
                         success: *success,
                         summary: summary.clone(),

--- a/crates/phantom-brain/src/claude.rs
+++ b/crates/phantom-brain/src/claude.rs
@@ -181,6 +181,13 @@ pub fn investigate(prompt: &str, working_dir: &str, max_rounds: u32) -> Result<S
                     pending.push((id, call));
                 }
                 Some(ApiEvent::Done) => break,
+                // Issue #646 spike: the brain's investigator path doesn't
+                // spawn `requires_complete_task` agents (it's a pure Q&A
+                // helper, not a loop-spawned executor). Treat lifecycle
+                // signals as a plain `Done` so existing flows are unchanged.
+                // Future PRs may surface the typed result here if the brain
+                // ever drives lifecycle agents.
+                Some(ApiEvent::CompleteTask { .. }) => break,
                 Some(ApiEvent::Error(e)) => return Err(e),
                 None => std::thread::sleep(std::time::Duration::from_millis(50)),
             }

--- a/crates/phantom-protocol/Cargo.toml
+++ b/crates/phantom-protocol/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [dependencies]
 log.workspace = true
 anyhow.workspace = true
+serde_json = "1"
 
 [lints]
 workspace = true

--- a/crates/phantom-protocol/src/events.rs
+++ b/crates/phantom-protocol/src/events.rs
@@ -72,6 +72,17 @@ pub enum Event {
         /// Reconciler spawn tag echoed back so the brain can route the
         /// completion to the correct `active_dispatches` entry.
         spawn_tag: Option<u64>,
+        /// Issue #646 spike: typed result payload supplied by the agent
+        /// through `complete_task`, when the agent was spawned with
+        /// `requires_complete_task = true`.
+        ///
+        /// Phase 1 (this spike) preserves the JSON object end-to-end;
+        /// Phase 2 binds it to a per-task JSON schema.
+        ///
+        /// `None` for agents that do not opt into `requires_complete_task`,
+        /// for legacy state-implicit terminations, and for `AgentError` →
+        /// `AgentTaskComplete { success: false, .. }` synthesis paths.
+        result: Option<serde_json::Value>,
     },
     AgentError { agent_id: AgentId, error: String },
 
@@ -220,6 +231,7 @@ mod tests {
                 success: true,
                 summary: "done".into(),
                 spawn_tag: None,
+                result: None,
             },
             Event::AgentError { agent_id: 1, error: "oops".into() },
         ];


### PR DESCRIPTION
## Summary

Closes part of #646. This is the design-choice spike the issue calls out
in its "spike sub-task — do this first" section. Three architectural
unknowns are resolved against real code with a single integration test
under `crates/phantom-agents/tests/complete_task_spike.rs`. The broader
implementation lives behind #646 and stays open.

## Architectural decisions

### 1. Parser short-circuit at `api.rs:347` / `chat.rs:788` — option (b): pre-parser lifecycle filter

`complete_task` is a lifecycle signal, not a tool — it has no
`ToolResult` round-trip and ends the agent's loop. Diverting it ahead of
`ToolType::from_api_name` keeps the 8-variant `ToolType` enum focused on
file/git tools (which all do return a `ToolResult`) and gives the agent
loop a single, ergonomic match arm for a non-tool event. Option (a)
would add `CompleteTask`/`AbortTask` to `ToolType`, then immediately
diverge from every other variant in `dispatch_tool` because lifecycle
has no `execute_tool` body to dispatch into. Option (c) (MCP fallback)
would conflict with the issue's collision-check intent, as the issue
itself notes. The pre-parser filter is implemented mirror-image in both
the Claude path (`api.rs`) and the OpenAI path (`chat.rs`); both
backends emit the same `ApiEvent::CompleteTask { id, result }` variant.

### 2. `requires_complete_task` storage on `Agent` (`agent.rs:258-310`, builder at `agent.rs:872`) — option (a): direct field

`Agent` only needs the lifecycle flag itself, not the rest of
`AgentSpawnOpts`. Storing the whole opts struct (option b) would carry
spawn-time metadata (`chat_model`, `spawn_tag`, …) past the point they
are needed and would force every `Agent::new` call site to construct an
opts bundle. The direct `requires_complete_task: bool` field on `Agent`
is set via a small `set_requires_complete_task(bool)` setter, paired
with the new `AgentSpawnOpts::with_requires_complete_task(bool)` builder
method that follows the existing `with_role` / `with_label` pattern.

### 3. `AgentTaskComplete.result` extension (`update.rs:693-702`, `events.rs:121`) — option (a): new field on the variant

A new `result: Option<serde_json::Value>` field on
`phantom_protocol::Event::AgentTaskComplete`, with the exhaustive
destructure at `update.rs:693` widened. Option (b) (a separate
`AgentTaskResultPosted` event keyed by `agent_id`) would create an
ordering window between the completion and its payload — consumers
reading the event bus would have to buffer the completion until the
result arrives, with no upper bound on the wait. Option (c) (registry
lookup via `AgentRegistry`) introduces async / lock-poisoning failure
modes the existing event bus does not have, plus a stale-read race if
the agent is re-queued between completion and lookup. Carrying the
payload on the same variant is the least-invasive shape and matches the
single-message guarantee the bus already provides for `AgentSpawned` and
`AgentProgress`.

## Spike scope

A 4-test integration suite at
`crates/phantom-agents/tests/complete_task_spike.rs`:

1. `parser_diverts_complete_task_to_dedicated_event` — verifies the
   Claude parser (`api::parse_response`) lifts a synthesised
   `complete_task` `tool_use` block into `ApiEvent::CompleteTask` rather
   than `ToolUse` or `Error`.
2. `agent_complete_with_result_transitions_to_done_and_captures_result`
   — verifies `Agent::complete_with_result` reaches
   `AgentStatus::Done` with the typed payload retrievable via
   `Agent::completion_result`.
3. `spawn_opts_carry_requires_complete_task_flag` — verifies the
   builder method round-trips the flag.
4. `end_to_end_parser_to_agent_done` — the integration the issue asks
   for: stub LLM emits `complete_task({"foo":"bar"})`, agent reaches
   `AgentStatus::Done` with the typed result captured.

## Out of scope (deliberately — broader implementation in #646)

- **Schema validation**: the spike only enforces "must be a JSON
  object" implicitly through the `Value` typing; the per-task JSON
  Schema binding lives in #646.
- **`validation_failure_count` flatline**: the 3-strike flatline path
  is out of scope.
- **`MAX_TOOL_ROUNDS` enforcement**: the `Failed` transition with
  reason `"exited without complete_task"` is out of scope.
- **`abort_task`**: only `complete_task` is wired in this spike. The
  parser filter is name-string-equality (`name == "complete_task"`) so
  that adding `abort_task` is a one-line mirror.
- **Production tool-list callsites**: `complete_task` and `abort_task`
  must appear in the LLM-facing tool manifest at every spawn site that
  opts into `requires_complete_task`. The spike does not extend
  `available_tools()` or its callers. Future PRs need to extend these
  three production sites:
    - `crates/phantom-app/src/agent_pane/execute.rs:259` — agent loop
      continuation
    - `crates/phantom-app/src/agent_pane/mod.rs:505` — agent pane spawn
    - `crates/phantom-app/src/agent_pane/mod.rs:996` — agent resume

  The brain investigator (`crates/phantom-brain/src/claude.rs:167`) and
  the headless CLI runner (`crates/phantom/src/headless.rs:377`) are
  intentionally excluded since the issue scopes the lifecycle
  requirement to loop-spawned agents.

## Cross-crate ripple (unavoidable)

Adding the `result` field to `AgentTaskComplete` and the
`ApiEvent::CompleteTask` variant forces compile-fix arms in two crates
listed as out-of-scope in the spike brief:

- `crates/phantom-adapter/src/bus.rs` — one-line `result: None` in a
  `#[cfg(test)]` test fixture for an existing test.
- `crates/phantom-brain/src/claude.rs` — one-arm `Some(ApiEvent::CompleteTask { .. }) => break`,
  documented inline as a no-op for the brain's investigator path.

These are minimum-necessary compile fixes, not feature work.

## Test plan

- [x] `cargo test -p phantom-agents --test complete_task_spike` — all 4
      tests pass
- [x] `./scripts/pre-pr-check.sh phantom-agents` — build, test, clippy
      gates all PASS
- [x] `./scripts/pre-pr-check.sh phantom-protocol` — PASS
- [x] Hot-file conflict check (`gh pr list -R jdmiranda/phantom --state open`)
      against open PRs — no line-region overlap with any other open PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)