### PR TITLE
fix(phantom-brain): runtime-enforce PlanStep.depends_on (closes #647)

### DIFF
--- a/crates/phantom-brain/src/orchestrator.rs
+++ b/crates/phantom-brain/src/orchestrator.rs
@@ -16,7 +16,7 @@
 //! | Task ledger            | `TaskLedger` struct                    |
 //! | Progress ledger        | `ProgressAssessment` (5-question eval) |
 
-use std::collections::{HashSet, VecDeque};
+use std::collections::VecDeque;
 use std::time::Instant;
 
 use phantom_agents::AgentTask;
@@ -436,6 +436,95 @@ impl TaskLedger {
         }
     }
 
+    /// Returns `None` when the step at `idx` has every entry in its
+    /// `depends_on` list either out-of-bounds or already at
+    /// [`StepStatus::Done`]; returns `Some(open)` listing the in-bounds
+    /// dependency indices that are not yet `Done`.
+    ///
+    /// Out-of-bounds dependency indices are treated as satisfied, matching
+    /// the [`TaskLedger::eligible_next`] and [`TaskLedger::has_cycle`]
+    /// semantics. The returned `Vec` preserves the original order from
+    /// `depends_on` and contains only indices that are in range for the
+    /// current `plan`.
+    ///
+    /// This is the private helper that backs [`TaskLedger::eligible_next`]'s
+    /// dependency filter and [`TaskLedger::try_dispatch`]'s guard. Returns
+    /// `Some(vec![])` (empty `open` list) is never produced: an empty open
+    /// list always collapses to `None`.
+    ///
+    /// Panics if `idx` is out of bounds; callers must validate the index
+    /// before invoking this helper.
+    fn deps_satisfied(&self, idx: usize) -> Option<Vec<usize>> {
+        let plan_len = self.plan.len();
+        let open: Vec<usize> = self.plan[idx]
+            .depends_on
+            .iter()
+            .copied()
+            .filter(|dep| {
+                // Out-of-bounds indices are treated as satisfied.
+                *dep < plan_len && self.plan[*dep].status != StepStatus::Done
+            })
+            .collect();
+
+        if open.is_empty() { None } else { Some(open) }
+    }
+
+    /// Transition the step at `idx` from [`StepStatus::Pending`] to
+    /// [`StepStatus::Active`], enforcing every gating invariant in one
+    /// guarded mutator.
+    ///
+    /// This is the **only** path that production code may use to set a step
+    /// to `Active`. The reconciler calls it from `dispatch_pending`; direct
+    /// `plan[idx].status = StepStatus::Active` writes are reserved for
+    /// `#[cfg(test)]` fixtures only.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DispatchBlocked`] when:
+    /// - `idx >= plan.len()` — [`DispatchBlocked::OutOfBounds`].
+    /// - The step is not [`StepStatus::Pending`] —
+    ///   [`DispatchBlocked::NotPending`] carries the current status so the
+    ///   caller can distinguish "already running" from "completed" without
+    ///   a second lookup.
+    /// - Any in-bounds entry in `depends_on` is not yet `Done` —
+    ///   [`DispatchBlocked::UnmetDeps`] carries the open indices.
+    ///
+    /// On success the step's `status` is set to `Active` and a reference
+    /// to the now-active step is returned so the caller can read its
+    /// description, task, and disposition without a second lookup.
+    /// Fields other than `status` (notably `agent_id` and `attempts`) are
+    /// **not** mutated by this method — the reconciler stamps those after
+    /// a successful dispatch.
+    pub fn try_dispatch(&mut self, idx: usize) -> Result<&PlanStep, DispatchBlocked> {
+        let plan_len = self.plan.len();
+        let Some(step) = self.plan.get(idx) else {
+            return Err(DispatchBlocked::OutOfBounds {
+                idx,
+                len: plan_len,
+            });
+        };
+
+        if step.status != StepStatus::Pending {
+            return Err(DispatchBlocked::NotPending {
+                idx,
+                current: step.status,
+            });
+        }
+
+        if let Some(open) = self.deps_satisfied(idx) {
+            return Err(DispatchBlocked::UnmetDeps { idx, open });
+        }
+
+        // All invariants hold — perform the single mutation. Unwrap is safe:
+        // we already validated `idx` is in bounds above.
+        let step = self
+            .plan
+            .get_mut(idx)
+            .expect("plan idx validated above");
+        step.status = StepStatus::Active;
+        Ok(&*step)
+    }
+
     /// Returns all `Pending` steps whose dependency constraints are satisfied.
     ///
     /// A step is *eligible* when:
@@ -455,28 +544,16 @@ impl TaskLedger {
     ///
     /// O(n × d) where n = number of plan steps and d = average dependency
     /// fan-in. For typical plans (n < 20, d < 5) this is negligible.
-    #[must_use] 
+    #[must_use]
     pub fn eligible_next(&self) -> Vec<(usize, &PlanStep)> {
-        // Collect the index set of all completed steps.
-        let done: HashSet<usize> = self
-            .plan
-            .iter()
-            .enumerate()
-            .filter(|(_, s)| s.status == StepStatus::Done)
-            .map(|(i, _)| i)
-            .collect();
-
+        // NeedsApproval steps are explicitly excluded: they require a
+        // human to call approve_checkpoint before they become Pending.
+        // Dependency satisfaction is delegated to `deps_satisfied` so the
+        // same predicate backs both `eligible_next` and `try_dispatch`.
         self.plan
             .iter()
             .enumerate()
-            .filter(|(_, s)| {
-                // NeedsApproval steps are explicitly excluded: they require a
-                // human to call approve_checkpoint before they become Pending.
-                s.status == StepStatus::Pending
-                    && s.depends_on
-                        .iter()
-                        .all(|dep| *dep >= self.plan.len() || done.contains(dep))
-            })
+            .filter(|(idx, s)| s.status == StepStatus::Pending && self.deps_satisfied(*idx).is_none())
             .collect()
     }
 
@@ -1151,21 +1228,67 @@ impl Orchestrator {
         }
     }
 
-    /// Pull the next pending step from the task ledger without dispatching it.
+    /// Locate the first eligible pending step and atomically transition it
+    /// to [`StepStatus::Active`] via [`TaskLedger::try_dispatch`].
     ///
     /// Returns `None` when:
     /// - The plan is empty.
-    /// - All steps are `Active`, `Done`, `Failed`, or `Skipped` (no pending work).
+    /// - No step is eligible (all dependencies open, or every step is
+    ///   `Active`, `Done`, `Failed`, `Skipped`, or `NeedsApproval`).
+    /// - The guarded `try_dispatch` rejects the candidate (e.g. an
+    ///   intervening race left a dependency unmet).
     ///
-    /// The returned [`PlanStep`] is a **clone** of the ledger entry — the
-    /// caller is responsible for advancing the step's status to `Active` via
-    /// [`TaskLedger::plan`] after successfully dispatching the returned step.
-    #[must_use] 
-    pub fn dispatch_next_step(&self) -> Option<PlanStep> {
-        self.ledger
-            .next_pending_step()
-            .map(|(_, step)| step.clone())
+    /// The returned [`PlanStep`] is a **clone** of the ledger entry taken
+    /// **after** the dispatch transition, so its `status` is already
+    /// `Active`. This method had no production callers prior to runtime
+    /// dep enforcement; the reconciler calls [`TaskLedger::try_dispatch`]
+    /// directly. The signature is `&mut self` because the transition is
+    /// the very thing we wanted to make guarded.
+    pub fn dispatch_next_step(&mut self) -> Option<PlanStep> {
+        let idx = self.ledger.eligible_next().first().map(|(i, _)| *i)?;
+        match self.ledger.try_dispatch(idx) {
+            Ok(step) => Some(step.clone()),
+            Err(blocked) => {
+                log::warn!(
+                    "Orchestrator::dispatch_next_step: try_dispatch rejected step {idx}: {blocked:?}"
+                );
+                None
+            }
+        }
     }
+}
+
+// ---------------------------------------------------------------------------
+// DispatchBlocked
+// ---------------------------------------------------------------------------
+
+/// Why a [`TaskLedger::try_dispatch`] call refused to transition a step to
+/// [`StepStatus::Active`].
+///
+/// Each variant pins down exactly which invariant the guarded mutator
+/// enforced. Callers (the reconciler, today) match on the variant to log
+/// open dependency indices and skip the step for the current tick rather
+/// than rolling back partial state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DispatchBlocked {
+    /// `idx` was out of bounds for the current plan (`len` reflects the
+    /// plan length at the time of the call).
+    OutOfBounds { idx: usize, len: usize },
+    /// The step exists but its current status is not
+    /// [`StepStatus::Pending`]. Includes the current status so callers can
+    /// distinguish "already running" (`Active`) from "completed" (`Done`)
+    /// without a second lookup.
+    NotPending { idx: usize, current: StepStatus },
+    /// One or more in-bounds dependency indices in `step.depends_on` are
+    /// not yet at [`StepStatus::Done`]. `open` lists those indices in the
+    /// order they appear in `depends_on`. Out-of-bounds dependency
+    /// indices are silently filtered out and never reported here.
+    UnmetDeps { idx: usize, open: Vec<usize> },
+    /// Reserved for the per-step quarantine flag tracked in issue #649.
+    /// `try_dispatch` does **not** emit this variant in the current
+    /// implementation; it exists so downstream callers can already
+    /// pattern-match exhaustively without an `_` arm.
+    Quarantined,
 }
 
 // ---------------------------------------------------------------------------
@@ -1650,11 +1773,12 @@ mod tests {
     /// Returns None when the plan is empty.
     #[test]
     fn dispatch_next_step_none_on_empty_plan() {
-        let orch = Orchestrator::new("goal with no plan");
+        let mut orch = Orchestrator::new("goal with no plan");
         assert!(orch.dispatch_next_step().is_none());
     }
 
-    /// Returns the first Pending step.
+    /// Returns the first Pending step and transitions it to `Active` in
+    /// the ledger (the guarded mutator semantics).
     #[test]
     fn dispatch_next_step_returns_first_pending() {
         let mut orch = Orchestrator::new("test");
@@ -1664,6 +1788,9 @@ mod tests {
         ]);
         let step = orch.dispatch_next_step().expect("should return step A");
         assert_eq!(step.description, "step A");
+        // The dispatcher is the *only* path to Active in production.
+        assert_eq!(orch.ledger().plan[0].status, StepStatus::Active);
+        assert_eq!(orch.ledger().plan[1].status, StepStatus::Pending);
     }
 
     /// Skips Done steps and returns the next Pending one.
@@ -1703,42 +1830,47 @@ mod tests {
         assert!(orch.dispatch_next_step().is_none());
     }
 
-    /// Dispatch is idempotent: calling it twice returns the same pending step
-    /// because it does not mutate ledger state.
+    /// Dispatch is the guarded mutator: a second call after a successful
+    /// dispatch returns `None` because the just-dispatched step is now
+    /// `Active` and no other step is eligible.
     #[test]
-    fn dispatch_next_step_is_idempotent() {
+    fn dispatch_next_step_is_not_idempotent() {
         let mut orch = Orchestrator::new("test");
         orch.set_plan(vec![PlanStep::new("s1", free_task("s1"))]);
 
-        let first = orch.dispatch_next_step();
+        let first = orch
+            .dispatch_next_step()
+            .expect("first dispatch returns the pending step");
+        assert_eq!(first.description, "s1");
+        assert_eq!(orch.ledger().plan[0].status, StepStatus::Active);
+
         let second = orch.dispatch_next_step();
-        assert!(first.is_some());
-        assert!(second.is_some());
-        assert_eq!(
-            first.unwrap().description,
-            second.unwrap().description,
-            "dispatch_next_step must not mutate ledger"
+        assert!(
+            second.is_none(),
+            "second dispatch must return None — step is already Active"
         );
     }
 
-    /// After the caller manually marks a step Active, dispatch_next_step moves
-    /// to the following Pending step — correct sequencing in the outer loop.
+    /// After step 1 is dispatched (marked Active by the guarded mutator),
+    /// `dispatch_next_step` advances to step 2 — correct sequencing in
+    /// the outer loop with no manual status manipulation required.
     #[test]
-    fn dispatch_next_step_sequences_correctly_after_activation() {
+    fn dispatch_next_step_advances_after_activation() {
         let mut orch = Orchestrator::new("test");
         orch.set_plan(vec![
             PlanStep::new("step 1", free_task("s1")),
             PlanStep::new("step 2", free_task("s2")),
         ]);
 
-        // Caller takes step 1 and marks it Active.
+        // First call dispatches step 1 — `try_dispatch` flips it to Active.
         let step1 = orch.dispatch_next_step().expect("step 1");
         assert_eq!(step1.description, "step 1");
-        orch.ledger_mut().plan[0].status = StepStatus::Active;
+        assert_eq!(orch.ledger().plan[0].status, StepStatus::Active);
 
-        // Now dispatch should return step 2.
+        // Now the only eligible Pending step is step 2.
         let step2 = orch.dispatch_next_step().expect("step 2");
         assert_eq!(step2.description, "step 2");
+        assert_eq!(orch.ledger().plan[1].status, StepStatus::Active);
     }
 
     // -- Issue #60: Task DAG + cycle detection --------------------------------

--- a/crates/phantom-brain/src/reconciler.rs
+++ b/crates/phantom-brain/src/reconciler.rs
@@ -41,7 +41,11 @@ use phantom_agents::policy::AgentPolicy;
 use phantom_agents::{AgentId, AgentTask};
 
 use crate::events::{AiAction, ConnectionState};
-use crate::orchestrator::{ReplanDecision, StepStatus, TaskLedger};
+use crate::orchestrator::{DispatchBlocked, ReplanDecision, TaskLedger};
+// `StepStatus` is only referenced from the test module below; bring it in
+// there via a separate `use` to keep the production import surface minimal.
+#[cfg(test)]
+use crate::orchestrator::StepStatus;
 
 /// How often the reconciler checks whether a paused agent's backend has
 /// become available again.
@@ -371,6 +375,28 @@ impl ReconcilerState {
             .collect();
 
         for (idx, task, disposition, description) in eligible {
+            // Route the Pending → Active transition through the guarded
+            // mutator so `PlanStep.depends_on` is enforced at the dispatch
+            // boundary (issue #647). Reaching `UnmetDeps` here indicates a
+            // race between `eligible_next()` and `try_dispatch()` — e.g. a
+            // dependency reverted from `Done` between the two calls — since
+            // `eligible_next()` already pre-filters by satisfied deps.
+            match ledger.try_dispatch(idx) {
+                Ok(_) => {}
+                Err(DispatchBlocked::UnmetDeps { open, .. }) => {
+                    log::warn!(
+                        "Reconciler: try_dispatch rejected step {idx}; unmet deps {open:?} — skipping this tick"
+                    );
+                    continue;
+                }
+                Err(blocked) => {
+                    log::warn!(
+                        "Reconciler: try_dispatch rejected step {idx}: {blocked:?} — skipping this tick"
+                    );
+                    continue;
+                }
+            }
+
             let agent_id: AgentId = self.next_agent_id;
             self.next_agent_id = self
                 .next_agent_id
@@ -382,10 +408,9 @@ impl ReconcilerState {
             let stall_timeout =
                 Duration::from_secs(self.agent_policy.timeout_seconds);
 
-            // Advance step to Active before emitting SpawnAgent so that a
-            // synchronous ledger inspection sees the correct state.
+            // The guarded mutator already flipped status to Active; the
+            // reconciler still owns `agent_id` and `attempts` stamping.
             if let Some(s) = ledger.plan.get_mut(idx) {
-                s.status = StepStatus::Active;
                 s.agent_id = Some(agent_id);
                 s.attempts += 1;
             }

--- a/crates/phantom-brain/tests/dispatch_guard.rs
+++ b/crates/phantom-brain/tests/dispatch_guard.rs
@@ -1,0 +1,194 @@
+//! Integration tests for the `try_dispatch` guarded mutator (issue #647).
+//!
+//! These tests exercise the runtime enforcement of `PlanStep.depends_on`
+//! at the orchestrator dispatch boundary. Before this guard existed, the
+//! reconciler set `s.status = StepStatus::Active` directly, bypassing the
+//! dependency check that `eligible_next()` advertised at the read API.
+//!
+//! Coverage:
+//! 1. Out-of-bounds index is rejected with `DispatchBlocked::OutOfBounds`.
+//! 2. A step with unmet deps is rejected with `DispatchBlocked::UnmetDeps`;
+//!    the `open` set shrinks as dependencies complete.
+//! 3. A step with satisfied deps transitions to `Active`; a second call
+//!    on the same step is rejected with `DispatchBlocked::NotPending`.
+//! 4. End-to-end through `ReconcilerState::tick`: step 1 depends on step 0,
+//!    and is dispatched only after step 0 reaches `Done`.
+
+use std::sync::mpsc;
+
+use phantom_agents::AgentTask;
+use phantom_brain::events::AiAction;
+use phantom_brain::orchestrator::{DispatchBlocked, PlanStep, StepStatus, TaskLedger};
+use phantom_brain::reconciler::ReconcilerState;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn free_task(prompt: &str) -> AgentTask {
+    AgentTask::FreeForm {
+        prompt: prompt.into(),
+    }
+}
+
+fn step(description: &str, depends_on: Vec<usize>) -> PlanStep {
+    PlanStep::with_deps(description, free_task(description), depends_on)
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: Out-of-bounds index
+// ---------------------------------------------------------------------------
+
+#[test]
+fn try_dispatch_rejects_out_of_bounds_index() {
+    let mut ledger = TaskLedger::new("oob test");
+    ledger.set_plan(vec![step("only step", vec![])]);
+
+    let err = ledger
+        .try_dispatch(7)
+        .expect_err("try_dispatch must refuse an OOB index");
+
+    assert_eq!(
+        err,
+        DispatchBlocked::OutOfBounds { idx: 7, len: 1 },
+        "OOB rejection must carry both the requested idx and the plan length",
+    );
+
+    // No state mutation: the in-range step is still Pending.
+    assert_eq!(ledger.plan[0].status, StepStatus::Pending);
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: Unmet dependencies
+// ---------------------------------------------------------------------------
+
+#[test]
+fn try_dispatch_rejects_step_with_unmet_deps() {
+    let mut ledger = TaskLedger::new("deps test");
+    // Step 2 depends on both steps 0 and 1.
+    ledger.set_plan(vec![
+        step("s0", vec![]),
+        step("s1", vec![]),
+        step("s2", vec![0, 1]),
+    ]);
+
+    // Initially both deps are open.
+    let err = ledger.try_dispatch(2).expect_err("deps unmet");
+    let DispatchBlocked::UnmetDeps { idx, open } = err else {
+        panic!("expected UnmetDeps, got {err:?}");
+    };
+    assert_eq!(idx, 2);
+    assert_eq!(open, vec![0, 1], "both deps must be reported open");
+    assert_eq!(ledger.plan[2].status, StepStatus::Pending);
+
+    // Complete step 0 — the open set shrinks to just [1].
+    ledger.plan[0].status = StepStatus::Done;
+    let err = ledger.try_dispatch(2).expect_err("dep 1 still open");
+    let DispatchBlocked::UnmetDeps { open, .. } = err else {
+        panic!("expected UnmetDeps after one dep done");
+    };
+    assert_eq!(open, vec![1], "only the still-open dep should be reported");
+
+    // Complete step 1 — now `try_dispatch` succeeds and flips status.
+    ledger.plan[1].status = StepStatus::Done;
+    ledger
+        .try_dispatch(2)
+        .expect("all deps satisfied, dispatch must succeed");
+    assert_eq!(ledger.plan[2].status, StepStatus::Active);
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: Successful dispatch is single-shot
+// ---------------------------------------------------------------------------
+
+#[test]
+fn try_dispatch_succeeds_when_deps_satisfied() {
+    let mut ledger = TaskLedger::new("happy path");
+    ledger.set_plan(vec![step("solo", vec![])]);
+
+    let returned = ledger
+        .try_dispatch(0)
+        .expect("step with no deps must dispatch");
+    assert_eq!(returned.description, "solo");
+    assert_eq!(returned.status, StepStatus::Active);
+    // The mutation is observable on the ledger itself.
+    assert_eq!(ledger.plan[0].status, StepStatus::Active);
+
+    // A second dispatch on the same index must be rejected — the step
+    // is no longer `Pending`, it is `Active`.
+    let err = ledger
+        .try_dispatch(0)
+        .expect_err("second dispatch must be rejected");
+    assert_eq!(
+        err,
+        DispatchBlocked::NotPending {
+            idx: 0,
+            current: StepStatus::Active,
+        },
+        "the rejection must carry the actual current status",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: End-to-end through the reconciler
+// ---------------------------------------------------------------------------
+
+#[test]
+fn reconciler_dispatches_dependent_step_via_try_dispatch() {
+    let (tx, rx) = mpsc::channel();
+    let mut state = ReconcilerState::new();
+    let mut ledger = TaskLedger::new("e2e");
+    ledger.set_plan(vec![
+        step("step 0", vec![]),
+        step("step 1", vec![0]),
+    ]);
+
+    // First tick — step 0 is dispatched, step 1 is blocked by deps.
+    state.tick(&mut ledger, &tx);
+    let first = rx
+        .try_recv()
+        .expect("first SpawnAgent must be emitted for step 0");
+    assert!(matches!(first, AiAction::SpawnAgent { .. }));
+    assert!(
+        rx.try_recv().is_err(),
+        "only step 0 should dispatch while step 1's dep is unmet",
+    );
+    assert_eq!(ledger.plan[0].status, StepStatus::Active);
+    assert_eq!(ledger.plan[1].status, StepStatus::Pending);
+    let step0_agent = ledger.plan[0]
+        .agent_id
+        .expect("agent_id must be stamped on dispatch");
+    assert_eq!(ledger.plan[0].attempts, 1, "attempts must be incremented");
+
+    // Complete step 0 through the standard reconciler path so the active
+    // dispatch is cleared and step 0 transitions to Done. After this,
+    // step 1 is the only eligible step and its dep is satisfied.
+    state.on_agent_complete(&mut ledger, 1, true, "ok", Some(step0_agent));
+    assert_eq!(ledger.plan[0].status, StepStatus::Done);
+    // Drain any pending notifications from the completion path so the
+    // next assertion is unambiguous.
+    while rx.try_recv().is_ok() {}
+
+    state.tick(&mut ledger, &tx);
+    let second = rx
+        .try_recv()
+        .expect("second SpawnAgent must be emitted for step 1");
+    assert!(matches!(second, AiAction::SpawnAgent { .. }));
+    assert!(
+        rx.try_recv().is_err(),
+        "exactly one SpawnAgent per dispatched step",
+    );
+    assert_eq!(
+        ledger.plan[1].status,
+        StepStatus::Active,
+        "step 1 must be Active after its dep is satisfied",
+    );
+    assert!(
+        ledger.plan[1].agent_id.is_some(),
+        "reconciler must stamp agent_id on the dependent step",
+    );
+    assert_eq!(
+        ledger.plan[1].attempts, 1,
+        "attempts must be incremented exactly once on dispatch",
+    );
+}


### PR DESCRIPTION
## Summary

Adds a guarded mutator at the orchestrator dispatch boundary so the `PlanStep.depends_on` contract is enforced before any step transitions to `StepStatus::Active`. Fresh redo of the closed PR #651 after that branch was contaminated by leftover commits from another worktree.

- New `TaskLedger::try_dispatch(idx) -> Result<&PlanStep, DispatchBlocked>` is the only path that sets `StepStatus::Active` in production.
- New `DispatchBlocked` enum: `OutOfBounds { idx, len }`, `NotPending { idx, current }`, `UnmetDeps { idx, open: Vec<usize> }`, `Quarantined`. The `Quarantined` variant is reserved for issue #649 and is not emitted by this PR.
- Private `TaskLedger::deps_satisfied(idx)` helper factored from the `eligible_next()` filter; returns `None` when satisfied, `Some(open)` listing in-bounds dep indices that are not yet `Done`. Out-of-bounds dep indices are treated as satisfied (matching the existing `eligible_next` and `has_cycle` semantics).
- `Orchestrator::dispatch_next_step` becomes a thin `&mut self` shim that locates the first eligible step via `eligible_next()` and routes through `try_dispatch`. Returns `None` on any `DispatchBlocked` variant. This method had no production callers prior to this work — only the two in-file tests, which are updated below.

## Migrated production site

The single migrated production direct mutation is in `crates/phantom-brain/src/reconciler.rs`, inside `dispatch_pending` (the block that previously set `s.status = StepStatus::Active` directly). The migration:

- Calls `ledger.try_dispatch(idx)` first.
- On `Err(DispatchBlocked::UnmetDeps { open, .. })`, logs the open dep indices and skips the step for the current tick (it will be re-evaluated next tick). Reaching this branch indicates a race between `eligible_next()` and `try_dispatch` (e.g. a dependency that was reverted), since `eligible_next()` already pre-filters by deps.
- On any other `Err(_)`, logs the variant and skips the step.
- On `Ok(_)`, the reconciler stamps `agent_id` and increments `attempts` (these fields remain reconciler-owned; `try_dispatch` only mutates `status`).

## Preserved main-state context

This PR integrates with — does not replace — the new reconciler state that landed on `main` since PR #651 was written:

- `PauseReason` (re-exported from `phantom_agents::agent`).
- `AgentPolicy` (re-exported from `phantom_agents::policy`) and its `agent_policy` field on `ReconcilerState`.
- `PausedAgentEntry` struct and the `paused_agents` Vec.
- `BACKEND_POLL_INTERVAL` constant.
- The per-step `stall_timeout = Duration::from_secs(self.agent_policy.timeout_seconds)` derivation (closes #35).

None of these are deleted or modified.

## Why goal.rs was NOT migrated

`crates/phantom-brain/src/goal.rs` contains a `StepStatus::Active` reference at line 688, which lives inside `#[cfg(test)] mod tests` (the test module attribute is at line 407). It is a test assertion verifying that the reconciler dispatches step 0 to `Active` after a tick. It is not a production mutation and is intentionally left untouched.

## Tests

- New integration tests in `crates/phantom-brain/tests/dispatch_guard.rs`:
  1. `try_dispatch_rejects_out_of_bounds_index` — OOB idx returns `OutOfBounds { idx, len }`.
  2. `try_dispatch_rejects_step_with_unmet_deps` — Returns `UnmetDeps { idx, open }`; verifies `open` shrinks as deps complete.
  3. `try_dispatch_succeeds_when_deps_satisfied` — Transitions step to Active; second call on same idx is rejected with `NotPending`.
  4. `reconciler_dispatches_dependent_step_via_try_dispatch` — End-to-end: step 0 marked Done via `on_agent_complete`, step 1 has `depends_on = [0]`, reconciler tick dispatches step 1 via `try_dispatch` (verifies `agent_id` set, `attempts == 1`, exactly one `SpawnAgent` emitted).
- Two existing in-file orchestrator tests are updated to reflect the new mutating semantics of `dispatch_next_step`. `dispatch_next_step_is_idempotent` is renamed to `dispatch_next_step_is_not_idempotent` and now verifies single-shot behaviour. `dispatch_next_step_sequences_correctly_after_activation` is renamed `dispatch_next_step_advances_after_activation` and no longer manually mutates `status`.

## Pre-PR check

Pre-existing failures on `origin/main` are preserved unchanged (Rule 2 override in operating policy).

| | Gates failed | E0063 `brain_handle` errors (`lib test`) | Clippy errors (`lib`) |
|---|---|---|---|
| Baseline (`origin/main`, my changes stashed) | 2 | 3 | 2 |
| With my changes | 2 | 3 | 2 |

The 3 `E0063` errors live in `crates/phantom-brain/src/lib.rs` tests (`brain_handle_send_recv`, `brain_handle_try_recv_none_when_empty`, `brain_handle_event_sender_clone`); they reference an old `BrainHandle` initializer that predates this branch. The 2 clippy errors live in `crates/phantom-brain/src/brain.rs:123` and `crates/phantom-brain/src/ooda.rs:363`. None of these files are touched by this PR.

- `cargo build -p phantom-brain` — clean, zero warnings.
- `cargo test -p phantom-brain --test dispatch_guard` — 4/4 pass.
- `cargo test -p phantom-brain --test privacy_gate_e2e` — 5/5 pass (regression coverage).
- `cargo test -p phantom-brain --doc` — 10/10 doctests pass.
- `cargo build --workspace` — same 8 pre-existing `phantom-app` errors as baseline, zero new failures introduced.

## Out of scope

- Quarantine semantics (issue #649) — `DispatchBlocked::Quarantined` exists in the enum but is not emitted.
- `complete_task` integration (issue #646 — landed via spike #652).
- Pre-existing clippy hygiene across the workspace.
- Any crate outside `phantom-brain`.

Closes #647.

## Test plan

- [ ] Reviewer: confirm `crates/phantom-brain/tests/dispatch_guard.rs` covers the four acceptance-criteria cases.
- [ ] Reviewer: confirm `goal.rs` remains untouched and the `#[cfg(test)]` boundary verification holds.
- [ ] CI: `cargo test -p phantom-brain --test dispatch_guard` green.
- [ ] CI: `cargo test -p phantom-brain --test privacy_gate_e2e` still green (regression coverage).

Generated with [Claude Code](https://claude.com/claude-code)