### PR TITLE
feat(phantom-app): wire complete_task tool manifest + 3-strike flatline (closes #646)

### DIFF
--- a/crates/phantom-agents/src/api.rs
+++ b/crates/phantom-agents/src/api.rs
@@ -358,8 +358,29 @@ pub fn parse_response(body: &Value, tx: &mpsc::Sender<ApiEvent>) {
                     .cloned()
                     .unwrap_or(Value::Object(serde_json::Map::new()));
 
+                // ---- Issue #646: lifecycle pre-parser filter --------------
+                //
+                // `complete_task` is a lifecycle signal, not a tool — it has
+                // no `ToolResult` round-trip. Diverting it ahead of both the
+                // non-object input guard AND `ToolType::from_api_name` keeps
+                // the 8-variant `ToolType` enum focused on file/git tools and
+                // gives the agent loop a dedicated
+                // `ApiEvent::CompleteTask { result }` to match on.
+                //
+                // The non-object guard is intentionally NOT applied here so
+                // the consumer-side validation gate in `phantom-app`
+                // (`agent_pane::poll`) can count schema-invalid calls toward
+                // the 3-strike `validation_failure_count` flatline. The
+                // file/git path below keeps the strict guard.
+                if name == "complete_task" {
+                    let _ = tx.send(ApiEvent::CompleteTask { id, result: raw_input });
+                    continue;
+                }
+
                 // Reject non-object `input` fields — the Claude API always
-                // sends an object here; a bare string or null is malformed.
+                // sends an object here for tool calls; a bare string or null
+                // is malformed. Lifecycle signals (`complete_task`) bypass
+                // this guard above so the consumer can validate.
                 if raw_input.as_object().is_none() {
                     let _ = tx.send(ApiEvent::Error(format!(
                         "tool_use block for '{name}' has non-object input: {raw_input}"
@@ -367,19 +388,7 @@ pub fn parse_response(body: &Value, tx: &mpsc::Sender<ApiEvent>) {
                     continue;
                 }
 
-                // ---- Issue #646: lifecycle pre-parser filter --------------
-                //
-                // `complete_task` is a lifecycle signal, not a tool — it has
-                // no `ToolResult` round-trip. Diverting it ahead of
-                // `ToolType::from_api_name` keeps the 8-variant `ToolType`
-                // enum focused on file/git tools and gives the agent loop a
-                // dedicated `ApiEvent::CompleteTask { result }` to match on.
-                //
-                // Spike scope: only `complete_task` is wired here. `abort_task`
-                // is intentionally out of scope — see issue #646.
-                if name == "complete_task" {
-                    let _ = tx.send(ApiEvent::CompleteTask { id, result: raw_input });
-                } else if let Some(tool) = ToolType::from_api_name(name) {
+                if let Some(tool) = ToolType::from_api_name(name) {
                     let _ = tx.send(ApiEvent::ToolUse {
                         id,
                         call: ToolCall { tool, args: raw_input },

--- a/crates/phantom-agents/src/tools.rs
+++ b/crates/phantom-agents/src/tools.rs
@@ -481,6 +481,67 @@ pub fn available_tools() -> Vec<ToolDefinition> {
     ]
 }
 
+/// Return the lifecycle tool definitions (`complete_task`, `abort_task`).
+///
+/// Issue #646 broader implementation: when an [`crate::agent::Agent`] is spawned
+/// with [`crate::agent::AgentSpawnOpts::with_requires_complete_task`] set to
+/// `true`, the agent-pane dispatch loop must extend its LLM tool manifest with
+/// these definitions so the model can emit the terminal signal. Both Claude
+/// (`api.rs`) and OpenAI (`chat.rs`) parsers divert tool-name matches for
+/// `complete_task` ahead of [`ToolType::from_api_name`] into a dedicated
+/// [`crate::api::ApiEvent::CompleteTask`] event (decision #1 from the spike
+/// PR — option (b)).
+///
+/// `result` is required and must be a JSON object — the consumer-side
+/// validation gate in `phantom-app::agent_pane` enforces this and flatlines
+/// the pane after three consecutive schema-invalid calls.
+///
+/// Out of scope: full `abort_task` consumer wiring lives behind future work.
+/// The definition is exposed here so the model can call it; the consumer side
+/// is currently a no-op that lets the existing iteration-limit / error arms
+/// terminate the agent.
+#[must_use]
+pub fn lifecycle_tools() -> Vec<ToolDefinition> {
+    vec![
+        ToolDefinition {
+            name: "complete_task".into(),
+            description: "Signal that the task is complete. Call this once when you have finished \
+                          the work — the call ends the agent loop. `result` must be a JSON object \
+                          summarising the outcome (e.g. `{\"summary\": \"...\", \"artifacts\": [...]}`).".into(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "summary": {
+                        "type": "string",
+                        "description": "Short human-readable description of what was accomplished."
+                    },
+                    "artifacts": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Optional list of files, identifiers, or outputs produced."
+                    }
+                }
+            }),
+        },
+        ToolDefinition {
+            name: "abort_task".into(),
+            description: "Signal that the task cannot be completed. Call this once when you have \
+                          determined the work is infeasible or blocked — the call ends the agent \
+                          loop. `reason` must be a short string explaining why.".into(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "reason": {
+                        "type": "string",
+                        "description": "Short human-readable explanation of why the task was aborted."
+                    }
+                },
+                "required": ["reason"]
+            }),
+        },
+    ]
+}
+
 // ---------------------------------------------------------------------------
 // Path sandboxing
 // ---------------------------------------------------------------------------

--- a/crates/phantom-agents/tests/complete_task_broader.rs
+++ b/crates/phantom-agents/tests/complete_task_broader.rs
@@ -1,0 +1,183 @@
+//! Issue #646 — broader `complete_task` wiring.
+//!
+//! Builds on the spike (`complete_task_spike.rs`) which proved the parser
+//! short-circuit, the `Agent::complete_with_result` lifecycle path, and the
+//! `AgentSpawnOpts::with_requires_complete_task` builder. This file exercises
+//! the broader-implementation surface the spike was explicit about deferring:
+//!
+//! - `tools::lifecycle_tools()` exposes the LLM-facing `complete_task` /
+//!   `abort_task` `ToolDefinition`s so the agent pane can extend its manifest
+//!   when the agent opted in.
+//! - The Claude parser (`api::parse_response`) lets non-object
+//!   `complete_task` inputs through to `ApiEvent::CompleteTask` so the
+//!   consumer-side validation gate (in `phantom-app`) can count them toward
+//!   the 3-strike `validation_failure_count` flatline. The file/git tool
+//!   path keeps the strict non-object guard.
+//!
+//! Agent-pane-side behaviour (the 3-strike flatline itself and the
+//! `MAX_TOOL_ROUNDS → "exited without complete_task"` reason rewrite) is
+//! covered by unit tests in `crates/phantom-app/src/agent_pane/tests.rs`
+//! because those depend on `AgentPane`, which is `pub(crate)` and not
+//! reachable across crate boundaries.
+
+use std::sync::mpsc;
+
+use phantom_agents::api::{self, ApiEvent};
+use phantom_agents::tools::lifecycle_tools;
+
+use serde_json::json;
+
+fn claude_tool_response(name: &str, input: serde_json::Value) -> serde_json::Value {
+    json!({
+        "content": [
+            {
+                "type": "tool_use",
+                "id": "toolu_broader_test_001",
+                "name": name,
+                "input": input,
+            }
+        ]
+    })
+}
+
+#[test]
+fn lifecycle_tools_returns_complete_task_and_abort_task() {
+    let tools = lifecycle_tools();
+
+    // Exactly two lifecycle definitions: complete_task + abort_task.
+    assert_eq!(
+        tools.len(),
+        2,
+        "lifecycle_tools() must return exactly [complete_task, abort_task]; got {tools:?}"
+    );
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_str()).collect();
+    assert!(
+        names.contains(&"complete_task"),
+        "lifecycle_tools() must include complete_task; got {names:?}"
+    );
+    assert!(
+        names.contains(&"abort_task"),
+        "lifecycle_tools() must include abort_task; got {names:?}"
+    );
+
+    // Each definition must carry an `object`-typed JSON schema.
+    for tool in &tools {
+        let schema_type = tool
+            .parameters
+            .get("type")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        assert_eq!(
+            schema_type, "object",
+            "tool {} must declare an object schema; got {}",
+            tool.name, tool.parameters
+        );
+    }
+}
+
+#[test]
+fn lifecycle_tools_disjoint_from_available_tools() {
+    use phantom_agents::tools::available_tools;
+
+    let file_tool_names: Vec<String> = available_tools()
+        .iter()
+        .map(|t| t.name.clone())
+        .collect();
+    let lifecycle_names: Vec<String> = lifecycle_tools()
+        .iter()
+        .map(|t| t.name.clone())
+        .collect();
+
+    for ln in &lifecycle_names {
+        assert!(
+            !file_tool_names.contains(ln),
+            "lifecycle tool {ln:?} must NOT collide with a file/git tool name in available_tools(); \
+             collision would cause the parser to misroute the lifecycle signal through \
+             ToolType::from_api_name. file_tool_names = {file_tool_names:?}",
+        );
+    }
+}
+
+#[test]
+fn parser_passes_non_object_complete_task_input_through_as_completetask() {
+    // The broader implementation relaxes the strict non-object guard
+    // specifically for `complete_task` so the consumer-side validation gate
+    // can count schema-invalid calls. A string, null, or array `input` must
+    // emit `ApiEvent::CompleteTask` (with the malformed payload preserved
+    // for the consumer to inspect) rather than `ApiEvent::Error`.
+    let bad_inputs = vec![
+        json!("not an object"),
+        json!(null),
+        json!([1, 2, 3]),
+        json!(42),
+    ];
+
+    for input in bad_inputs {
+        let body = claude_tool_response("complete_task", input.clone());
+        let (tx, rx) = mpsc::channel::<ApiEvent>();
+        api::parse_response(&body, &tx);
+        drop(tx);
+        let events: Vec<ApiEvent> = rx.into_iter().collect();
+
+        assert_eq!(
+            events.len(),
+            2,
+            "non-object complete_task must still emit CompleteTask + Done; got {events:?} for input {input}",
+        );
+        assert!(
+            matches!(&events[0], ApiEvent::CompleteTask { result, .. } if result == &input),
+            "non-object input must round-trip through CompleteTask unchanged; got {:?} for input {input}",
+            events[0],
+        );
+        assert!(
+            matches!(&events[1], ApiEvent::Done),
+            "second event must be Done; got {:?}",
+            events[1]
+        );
+    }
+}
+
+#[test]
+fn parser_preserves_strict_non_object_guard_for_file_tools() {
+    // The relaxation must ONLY apply to `complete_task`. File/git tools that
+    // emit a non-object input must still produce an Error event, because they
+    // have no consumer-side validation gate and the runtime expects an
+    // `Object` shape downstream.
+    let body = claude_tool_response("read_file", json!("just a string"));
+    let (tx, rx) = mpsc::channel::<ApiEvent>();
+    api::parse_response(&body, &tx);
+    drop(tx);
+    let events: Vec<ApiEvent> = rx.into_iter().collect();
+
+    assert!(
+        events.iter().any(|e| matches!(e, ApiEvent::Error(_))),
+        "non-object read_file input must still produce an Error event; got {events:?}",
+    );
+    assert!(
+        !events.iter().any(|e| matches!(e, ApiEvent::ToolUse { .. })),
+        "non-object read_file input must NOT produce a ToolUse event; got {events:?}",
+    );
+}
+
+#[test]
+fn parser_routes_valid_complete_task_through_as_completetask() {
+    // The relaxation must not regress the spike's valid-object path. An
+    // object `complete_task` input must still emit `CompleteTask + Done`.
+    let body = claude_tool_response(
+        "complete_task",
+        json!({"summary": "did the thing", "artifacts": ["a.rs"]}),
+    );
+    let (tx, rx) = mpsc::channel::<ApiEvent>();
+    api::parse_response(&body, &tx);
+    drop(tx);
+    let events: Vec<ApiEvent> = rx.into_iter().collect();
+
+    assert_eq!(events.len(), 2, "expected CompleteTask + Done; got {events:?}");
+    match &events[0] {
+        ApiEvent::CompleteTask { result, .. } => {
+            assert_eq!(result.get("summary").and_then(|v| v.as_str()), Some("did the thing"));
+        }
+        other => panic!("first event must be CompleteTask; got {other:?}"),
+    }
+    assert!(matches!(&events[1], ApiEvent::Done));
+}

--- a/crates/phantom-app/src/agent_pane/execute.rs
+++ b/crates/phantom-app/src/agent_pane/execute.rs
@@ -3,7 +3,7 @@
 use phantom_agents::agent::AgentMessage;
 use phantom_agents::api::{ApiEvent, ApiHandle, ClaudeConfig, send_message};
 use phantom_agents::chat::{ChatBackend, ChatRequest};
-use phantom_agents::tools::{ToolCall, ToolDefinition, ToolResult, ToolType, available_tools};
+use phantom_agents::tools::{ToolCall, ToolDefinition, ToolResult, ToolType, available_tools, lifecycle_tools};
 use phantom_agents::agent::Agent;
 
 use super::{AgentPane, AgentPaneStatus, MAX_TOOL_ROUNDS};
@@ -84,16 +84,38 @@ impl AgentPane {
         use log::warn;
 
         if self.turn_count >= MAX_TOOL_ROUNDS {
+            // Issue #646: when the agent opted into the `complete_task`
+            // termination contract but exhausted its tool-round budget
+            // without ever emitting the terminal signal, the failure
+            // reason is rewritten so downstream consumers (capture
+            // sidecar, journal, supervisor) can distinguish a budget
+            // overrun from a generic iteration limit. The
+            // `completion_result` is checked instead of the agent's
+            // `AgentStatus::Done` state because the agent-loop break on
+            // `CompleteTask` may not have run yet when this branch fires
+            // — `completion_result()` is set inside
+            // `Agent::complete_with_result` and is the ground truth for
+            // "did the model ever signal completion".
+            let exited_without_complete_task =
+                self.agent.requires_complete_task()
+                    && self.agent.completion_result().is_none();
+            let reason = if exited_without_complete_task {
+                "exited without complete_task".to_string()
+            } else {
+                format!("iteration limit reached ({MAX_TOOL_ROUNDS} tool rounds)")
+            };
             if let Some(ref mut j) = self.journal
-                && let Err(e) = j.record_flatline(
-                    self.agent.id(),
-                    format!("iteration limit reached ({MAX_TOOL_ROUNDS} tool rounds)"),
-                ) {
+                && let Err(e) = j.record_flatline(self.agent.id(), reason.clone()) {
                     warn!("AgentJournal::record_flatline (limit) failed: {e}");
                 }
-            self.output.push_str(&format!(
-                "\n\n✗ Agent hit iteration limit ({MAX_TOOL_ROUNDS} tool rounds).\n"
-            ));
+            if exited_without_complete_task {
+                self.output
+                    .push_str("\n\n✗ Agent exited without complete_task.\n");
+            } else {
+                self.output.push_str(&format!(
+                    "\n\n✗ Agent hit iteration limit ({MAX_TOOL_ROUNDS} tool rounds).\n"
+                ));
+            }
             self.rollback_if_dirty();
             self.status = AgentPaneStatus::Failed;
             self.api_handle = None;
@@ -256,7 +278,13 @@ impl AgentPane {
         self.maybe_emit_blocked_event();
 
         // Re-invoke the chat backend with the updated conversation.
-        let tools = available_tools();
+        // Issue #646: extend the tool manifest with lifecycle tools when the
+        // agent opted into the `complete_task` contract so the model keeps
+        // seeing the termination affordance on every turn after the first.
+        let mut tools = available_tools();
+        if self.agent.requires_complete_task() {
+            tools.extend(lifecycle_tools());
+        }
         let handle = Self::dispatch(
             self.chat_backend.as_deref(),
             &self.claude_config,

--- a/crates/phantom-app/src/agent_pane/mod.rs
+++ b/crates/phantom-app/src/agent_pane/mod.rs
@@ -23,7 +23,7 @@ use phantom_agents::chat::{ChatBackend, ChatError, ChatModel, build_backend_with
 use phantom_agents::permissions::PermissionSet;
 use phantom_agents::role::{AgentRole, CapabilityClass};
 use phantom_agents::spawn_rules::SubstrateEvent;
-use phantom_agents::tools::{ToolCall, available_tools};
+use phantom_agents::tools::{ToolCall, available_tools, lifecycle_tools};
 use phantom_agents::{AgentSpawnOpts, AgentTask};
 use phantom_history::{AgentOutputCapture, ToolCall as HistoryToolCall};
 use phantom_session::AgentSnapshot;
@@ -44,7 +44,14 @@ pub(crate) use events::{new_blocked_event_sink, new_denied_event_sink};
 const DEFAULT_AGENT_PANE_ROLE: AgentRole = AgentRole::Conversational;
 
 /// Maximum number of tool-use rounds before the agent is force-stopped.
-const MAX_TOOL_ROUNDS: u32 = 25;
+pub(super) const MAX_TOOL_ROUNDS: u32 = 25;
+
+/// Issue #646: consecutive `complete_task` schema validation failures that
+/// trigger an [`AgentPaneStatus::Failed`] transition with the canonical
+/// `"complete_task: schema validation failed 3x"` reason. Per the issue's
+/// acceptance criteria this is a hard 3-strike — there is no exponential
+/// back-off or recovery window beyond the consecutive-failure reset.
+pub(super) const COMPLETE_TASK_VALIDATION_FLATLINE: u8 = 3;
 
 /// Number of consecutive tool-call failures before the pane emits a substrate
 /// `AgentBlocked` event.
@@ -311,6 +318,21 @@ pub(crate) struct AgentPane {
     /// the agent pane's render loop.
     pub(super) tts_tx: Option<tokio::sync::mpsc::Sender<String>>,
 
+    /// Issue #646: consecutive `complete_task` schema validation failures.
+    ///
+    /// Incremented every time the agent emits a `complete_task` lifecycle
+    /// signal whose `result` payload fails the must-be-an-object gate.
+    /// Reset to 0 on either a successful `complete_task` call OR any
+    /// non-`complete_task` tool call — consecutive-failure semantics so a
+    /// single bad call followed by recovery does not flatline.
+    ///
+    /// When the counter reaches [`COMPLETE_TASK_VALIDATION_FLATLINE`], the
+    /// pane transitions to [`AgentPaneStatus::Failed`] with the reason
+    /// `"complete_task: schema validation failed 3x"`. Per-loop `exit_schema`
+    /// binding (beyond the must-be-object gate) is out of scope here and
+    /// deferred to the loop overseer.
+    pub(super) validation_failure_count: u8,
+
     /// Shared MCP tool registry for external tool fallback.
     ///
     /// Set at spawn time by [`App::spawn_agent_pane_with_opts`] via
@@ -383,6 +405,7 @@ impl AgentPane {
             pane_messages: Vec::new(),
             tts_tx: None,
             mcp_registry: None,
+            validation_failure_count: 0,
         }
     }
 
@@ -469,6 +492,9 @@ impl AgentPane {
         // Allocate from the process-global counter so the id is distinct from
         // any id produced via AgentManager::spawn on another path (fixes #513).
         let mut agent = Agent::new(allocate_agent_id(), task.clone());
+        // Issue #646: forward the spawn-opt opt-in to the agent so the loop
+        // can enforce the `complete_task` termination contract end-to-end.
+        agent.set_requires_complete_task(opts.requires_complete_task());
         let sys_prompt = agent.system_prompt();
         agent.push_message(AgentMessage::System(sys_prompt));
 
@@ -502,7 +528,14 @@ impl AgentPane {
         };
         agent.push_message(AgentMessage::User(user_prompt));
 
-        let tools = available_tools();
+        // Issue #646: agents that opt in to the lifecycle contract see
+        // `complete_task` and `abort_task` in their LLM tool manifest so the
+        // model can emit the terminal signal. The parser diverts these names
+        // ahead of `ToolType::from_api_name` into `ApiEvent::CompleteTask`.
+        let mut tools = available_tools();
+        if agent.requires_complete_task() {
+            tools.extend(lifecycle_tools());
+        }
 
         info!(
             "Agent pane spawning: {} messages (system={}, user={}, backend={})",
@@ -572,6 +605,7 @@ impl AgentPane {
             )],
             tts_tx: None,
             mcp_registry: None,
+            validation_failure_count: 0,
         }
     }
 
@@ -755,30 +789,94 @@ impl AgentPane {
                     ));
                     self.tool_use_ids.push(id.clone());
                     self.pending_tools.push((id, call));
+                    // Issue #646: any non-`complete_task` tool call resets the
+                    // consecutive validation-failure streak. The counter only
+                    // tracks back-to-back invalid `complete_task` calls; a
+                    // single bad call followed by recovery should not
+                    // flatline the pane.
+                    self.validation_failure_count = 0;
                     got_content = true;
                 }
                 Some(ApiEvent::CompleteTask { id: _, result }) => {
-                    // Issue #646 spike: minimal lifecycle handler.
+                    // Issue #646 broader implementation: schema-validate the
+                    // payload, count consecutive failures, and flatline after
+                    // three back-to-back invalid calls.
                     //
-                    // The model emitted `complete_task(result)`; capture the
-                    // typed payload on the agent and end the loop. This is
-                    // enough to make the spike integration test pass and to
-                    // establish the wiring the broader implementation will
-                    // build on.
-                    //
-                    // OUT OF SCOPE FOR THE SPIKE — to be implemented in
-                    // follow-up PRs against #646:
-                    //   - Schema validation (must-be-object → flatline after
-                    //     `validation_failure_count` reaches 3).
-                    //   - `requires_complete_task` enforcement on
-                    //     `MAX_TOOL_ROUNDS` exit (transition to `Failed` with
-                    //     reason `"exited without complete_task"`).
-                    //   - Mirror the bookkeeping the `Done` arm performs:
-                    //     journal completion record, capture sidecar flush,
-                    //     conversation save, snapshot push, status transition
-                    //     to `AgentPaneStatus::Done`. The spike intentionally
-                    //     does the agents-side bit only.
+                    // Validation gate: `result` must be a JSON Object. The
+                    // parser at `phantom_agents::api::parse_response` lets
+                    // non-object inputs through specifically for
+                    // `complete_task` so this consumer-side gate can count
+                    // them. Per-loop `exit_schema` binding (beyond
+                    // must-be-object) is out of scope.
+                    if !result.is_object() {
+                        self.validation_failure_count =
+                            self.validation_failure_count.saturating_add(1);
+                        warn!(
+                            "AgentPane #{}: complete_task schema validation failed (count={}/{}, got {result})",
+                            self.agent.id(),
+                            self.validation_failure_count,
+                            COMPLETE_TASK_VALIDATION_FLATLINE
+                        );
+                        self.output.push_str(&format!(
+                            "\n⚠ complete_task: result must be a JSON object (failure {}/{})\n",
+                            self.validation_failure_count,
+                            COMPLETE_TASK_VALIDATION_FLATLINE
+                        ));
+
+                        if self.validation_failure_count >= COMPLETE_TASK_VALIDATION_FLATLINE {
+                            let reason = "complete_task: schema validation failed 3x".to_string();
+                            if let Some(ref mut j) = self.journal
+                                && let Err(e) = j.record_flatline(self.agent.id(), reason.clone()) {
+                                    warn!("AgentJournal::record_flatline (validation) failed: {e}");
+                                }
+                            self.output.push_str(&format!("\n\n✗ {reason}\n"));
+                            self.rollback_if_dirty();
+                            self.flush_capture_record();
+                            self.status = AgentPaneStatus::Failed;
+                            self.api_handle = None;
+                            self.push_snapshot();
+                            self.save_conversation();
+                            got_content = true;
+                            break;
+                        }
+
+                        // Sub-threshold failure: do NOT end the loop. The
+                        // model may emit a valid `complete_task` next turn.
+                        // Surface the validation error back to the model via
+                        // the conversation so it can self-correct.
+                        self.agent.push_message(AgentMessage::User(format!(
+                            "Your last complete_task call's result was not a JSON object \
+                             (got {result}). Try again — `result` must be an object."
+                        )));
+                        got_content = true;
+                        continue;
+                    }
+
+                    // Valid schema. Reset the counter, capture the payload
+                    // on the agent, and end the loop. The pane transitions
+                    // to `Done` to mirror the bookkeeping the `ApiEvent::Done`
+                    // arm performs for state-implicit termination.
+                    self.validation_failure_count = 0;
                     self.agent.complete_with_result(result);
+
+                    if let Some(ref mut j) = self.journal {
+                        let summary = format!(
+                            "complete_task; ~{}in/~{}out tokens, {} tool calls",
+                            self.input_tokens, self.output_tokens, self.tool_call_count
+                        );
+                        if let Err(e) = j.record_completion(self.agent.id(), true, summary) {
+                            warn!("AgentJournal::record_completion failed: {e}");
+                        }
+                    }
+                    self.output.push_str(&format!(
+                        "\n\n✓ Agent completed (complete_task) | ~{}in / ~{}out tokens | {} tool calls\n",
+                        self.input_tokens, self.output_tokens, self.tool_call_count,
+                    ));
+                    self.status = AgentPaneStatus::Done;
+                    self.api_handle = None;
+                    self.push_snapshot();
+                    self.flush_capture_record();
+                    self.save_conversation();
                     got_content = true;
                     break;
                 }
@@ -993,7 +1091,12 @@ impl AgentPane {
         self.agent.push_message(AgentMessage::User(message));
 
         // Re-invoke the chat backend with the updated conversation.
-        let tools = available_tools();
+        // Issue #646: extend the tool manifest with lifecycle tools when the
+        // agent opted into the `complete_task` contract.
+        let mut tools = available_tools();
+        if self.agent.requires_complete_task() {
+            tools.extend(lifecycle_tools());
+        }
         let handle = Self::dispatch(
             self.chat_backend.as_deref(),
             &self.claude_config,

--- a/crates/phantom-app/src/agent_pane/tests.rs
+++ b/crates/phantom-app/src/agent_pane/tests.rs
@@ -72,6 +72,8 @@ fn agent_with_handle() -> (AgentPane, mpsc::Sender<ApiEvent>) {
         dag_explorer: None,
         pane_messages: Vec::new(),
         tts_tx: None,
+        mcp_registry: None,
+        validation_failure_count: 0,
     };
     (pane, tx)
 }
@@ -176,6 +178,8 @@ fn poll_returns_false_when_no_handle() {
         dag_explorer: None,
         pane_messages: Vec::new(),
         tts_tx: None,
+        mcp_registry: None,
+        validation_failure_count: 0,
     };
     assert!(!pane.poll());
 }
@@ -1053,6 +1057,8 @@ fn spawn_agent_pane_task_matches_prompt() {
         dag_explorer: None,
         pane_messages: Vec::new(),
         tts_tx: None,
+        mcp_registry: None,
+        validation_failure_count: 0,
     };
     let _ = tx; // keep sender alive so handle stays live
     assert_eq!(pane.task, "fix the failing tests");
@@ -1849,4 +1855,289 @@ fn working_status_shows_indicator_in_render() {
             .map(|s| s.text.as_str())
             .collect::<Vec<_>>()
     );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #646 — broader complete_task wiring
+// ---------------------------------------------------------------------------
+
+#[test]
+fn agent_pane_defaults_validation_failure_count_to_zero() {
+    // The 3-strike consumer-side validation gate is a stateful counter on
+    // `AgentPane`. Every fresh pane must start at 0 so the very first
+    // schema-invalid call counts as failure #1, not #N.
+    let (pane, _tx) = agent_with_handle();
+    assert_eq!(pane.validation_failure_count, 0);
+}
+
+#[test]
+fn max_tool_rounds_reason_rewritten_when_requires_complete_task_and_no_completion() {
+    // Agent opted in to the lifecycle contract but never emitted
+    // `complete_task` before the tool-round budget ran out. The reason text
+    // displayed in the pane and recorded in the journal must rewrite to
+    // `"exited without complete_task"` instead of the generic iteration
+    // limit message.
+    let (mut pane, tx) = agent_with_handle();
+    pane.agent.set_requires_complete_task(true);
+    pane.turn_count = MAX_TOOL_ROUNDS;
+
+    // Drive one tool round so the limit branch fires.
+    tx.send(ApiEvent::ToolUse {
+        id: "toolu_no_complete".into(),
+        call: phantom_agents::tools::ToolCall {
+            tool: phantom_agents::tools::ToolType::GitStatus,
+            args: serde_json::json!({}),
+        },
+    })
+    .unwrap();
+    tx.send(ApiEvent::Done).unwrap();
+
+    pane.poll();
+
+    assert_eq!(pane.status, AgentPaneStatus::Failed);
+    assert!(
+        pane.output.contains("exited without complete_task"),
+        "pane output must surface the new failure reason; got:\n{}",
+        pane.output
+    );
+    // The generic iteration-limit reason must NOT appear when the
+    // requires_complete_task path is the actual root cause.
+    assert!(
+        !pane.output.contains("iteration limit"),
+        "generic iteration-limit reason must not appear when requires_complete_task is set; \
+         got:\n{}",
+        pane.output
+    );
+    assert!(pane.api_handle.is_none());
+}
+
+#[test]
+fn max_tool_rounds_keeps_generic_reason_when_requires_complete_task_unset() {
+    // Legacy state-implicit termination path: `requires_complete_task` is
+    // false, so hitting MAX_TOOL_ROUNDS keeps the original iteration-limit
+    // reason byte-for-byte. This is the regression-guard around the rewrite.
+    let (mut pane, tx) = agent_with_handle();
+    assert!(!pane.agent.requires_complete_task(), "default is false");
+    pane.turn_count = MAX_TOOL_ROUNDS;
+
+    tx.send(ApiEvent::ToolUse {
+        id: "toolu_legacy".into(),
+        call: phantom_agents::tools::ToolCall {
+            tool: phantom_agents::tools::ToolType::GitStatus,
+            args: serde_json::json!({}),
+        },
+    })
+    .unwrap();
+    tx.send(ApiEvent::Done).unwrap();
+
+    pane.poll();
+
+    assert_eq!(pane.status, AgentPaneStatus::Failed);
+    assert!(
+        pane.output.contains("iteration limit"),
+        "legacy path must keep the iteration-limit reason; got:\n{}",
+        pane.output
+    );
+    assert!(
+        !pane.output.contains("exited without complete_task"),
+        "legacy path must NOT surface the requires_complete_task-only reason; got:\n{}",
+        pane.output
+    );
+}
+
+#[test]
+fn max_tool_rounds_keeps_generic_reason_when_completion_already_set() {
+    // Defensive guard: if the agent has already captured a completion result
+    // (e.g. via a successful `complete_task` earlier in the loop), hitting
+    // MAX_TOOL_ROUNDS should not retroactively label the failure as "exited
+    // without complete_task" — the model DID call it. The generic
+    // iteration-limit reason is correct in this edge case.
+    let (mut pane, tx) = agent_with_handle();
+    pane.agent.set_requires_complete_task(true);
+    pane.agent.complete_with_result(serde_json::json!({"summary": "earlier success"}));
+    pane.turn_count = MAX_TOOL_ROUNDS;
+
+    tx.send(ApiEvent::ToolUse {
+        id: "toolu_after_complete".into(),
+        call: phantom_agents::tools::ToolCall {
+            tool: phantom_agents::tools::ToolType::GitStatus,
+            args: serde_json::json!({}),
+        },
+    })
+    .unwrap();
+    tx.send(ApiEvent::Done).unwrap();
+
+    pane.poll();
+
+    assert_eq!(pane.status, AgentPaneStatus::Failed);
+    assert!(
+        pane.output.contains("iteration limit"),
+        "completed agent that still hit the round limit must keep the generic reason; got:\n{}",
+        pane.output
+    );
+    assert!(
+        !pane.output.contains("exited without complete_task"),
+        "must not falsely report 'exited without complete_task' when completion_result is set; got:\n{}",
+        pane.output
+    );
+}
+
+#[test]
+fn complete_task_schema_invalid_increments_validation_failure_count() {
+    // A single schema-invalid `complete_task` must increment the counter to
+    // 1 (sub-threshold) and keep the pane in Working state so the agent loop
+    // can retry on a later turn.
+    let (mut pane, tx) = agent_with_handle();
+    pane.agent.set_requires_complete_task(true);
+
+    tx.send(ApiEvent::CompleteTask {
+        id: "toolu_bad_1".into(),
+        result: serde_json::json!("not an object"),
+    })
+    .unwrap();
+    tx.send(ApiEvent::Done).unwrap();
+
+    pane.poll();
+
+    assert_eq!(pane.validation_failure_count, 1);
+    assert_eq!(
+        pane.status,
+        AgentPaneStatus::Working,
+        "single sub-threshold failure must keep the pane in Working state",
+    );
+    assert!(
+        pane.output.contains("complete_task: result must be a JSON object"),
+        "pane output must surface the schema-validation failure; got:\n{}",
+        pane.output
+    );
+}
+
+#[test]
+fn three_consecutive_complete_task_schema_failures_flatline_pane() {
+    // The 3-strike consumer gate. Three back-to-back schema-invalid
+    // `complete_task` calls transition the pane to Failed with the canonical
+    // reason text.
+    let (mut pane, tx) = agent_with_handle();
+    pane.agent.set_requires_complete_task(true);
+
+    // Three poll() cycles, each with one bad CompleteTask + Done.
+    for n in 1..=3 {
+        tx.send(ApiEvent::CompleteTask {
+            id: format!("toolu_bad_{n}"),
+            result: serde_json::json!(format!("not an object #{n}")),
+        })
+        .unwrap();
+        tx.send(ApiEvent::Done).unwrap();
+        pane.poll();
+    }
+
+    assert_eq!(pane.validation_failure_count, 3);
+    assert_eq!(
+        pane.status,
+        AgentPaneStatus::Failed,
+        "three consecutive schema-invalid complete_task calls must flatline the pane",
+    );
+    assert!(
+        pane.output.contains("complete_task: schema validation failed 3x"),
+        "flatline reason must appear in pane output; got:\n{}",
+        pane.output
+    );
+    assert!(pane.api_handle.is_none(), "api_handle must be cleared on flatline");
+}
+
+#[test]
+fn complete_task_validation_count_resets_on_successful_call() {
+    // Counter resets to 0 on a successful schema-valid `complete_task` call.
+    let (mut pane, tx) = agent_with_handle();
+    pane.agent.set_requires_complete_task(true);
+
+    // Two failures, then a success.
+    for n in 1..=2 {
+        tx.send(ApiEvent::CompleteTask {
+            id: format!("toolu_bad_{n}"),
+            result: serde_json::json!("not an object"),
+        })
+        .unwrap();
+        tx.send(ApiEvent::Done).unwrap();
+        pane.poll();
+    }
+    assert_eq!(pane.validation_failure_count, 2);
+    assert_eq!(pane.status, AgentPaneStatus::Working);
+
+    // Successful call: schema-valid result, counter resets, pane transitions
+    // to Done.
+    tx.send(ApiEvent::CompleteTask {
+        id: "toolu_good".into(),
+        result: serde_json::json!({"summary": "did it"}),
+    })
+    .unwrap();
+    pane.poll();
+
+    assert_eq!(
+        pane.validation_failure_count, 0,
+        "successful complete_task must reset the validation failure counter",
+    );
+    assert_eq!(pane.status, AgentPaneStatus::Done);
+    assert_eq!(
+        pane.agent.completion_result(),
+        Some(&serde_json::json!({"summary": "did it"})),
+        "successful complete_task must capture the typed result on the agent",
+    );
+}
+
+#[test]
+fn complete_task_validation_count_resets_on_non_complete_task_tool_call() {
+    // Consecutive-failure semantics: a non-`complete_task` tool call between
+    // two bad complete_tasks resets the counter so the streak does NOT
+    // accumulate across the intervening tool use.
+    let (mut pane, tx) = agent_with_handle();
+    pane.agent.set_requires_complete_task(true);
+
+    // Two failures.
+    for n in 1..=2 {
+        tx.send(ApiEvent::CompleteTask {
+            id: format!("toolu_bad_{n}"),
+            result: serde_json::json!("not an object"),
+        })
+        .unwrap();
+        tx.send(ApiEvent::Done).unwrap();
+        pane.poll();
+    }
+    assert_eq!(pane.validation_failure_count, 2);
+
+    // Intervening successful tool call.
+    tx.send(ApiEvent::ToolUse {
+        id: "toolu_intervening".into(),
+        call: phantom_agents::tools::ToolCall {
+            tool: phantom_agents::tools::ToolType::GitStatus,
+            args: serde_json::json!({}),
+        },
+    })
+    .unwrap();
+    // No Done — we only need to observe the ToolUse arm's reset side-effect
+    // without triggering the full execute_pending_tools dispatch (which would
+    // make a live API call). Closing the channel ends poll().
+    drop(tx);
+    pane.poll();
+
+    assert_eq!(
+        pane.validation_failure_count, 0,
+        "non-complete_task tool call must reset the validation failure counter; got {}",
+        pane.validation_failure_count,
+    );
+}
+
+#[test]
+fn lifecycle_tools_match_definition_count_and_names() {
+    // Cross-check: the tool list the pane will hand to the LLM contains
+    // exactly the two lifecycle definitions when the agent opted in. This
+    // pins the contract: the LLM-facing manifest extension is a single
+    // `tools.extend(lifecycle_tools())` and never anything narrower or
+    // wider.
+    use phantom_agents::tools::lifecycle_tools;
+    let lifecycle = lifecycle_tools();
+    assert_eq!(lifecycle.len(), 2);
+    let names: Vec<&str> = lifecycle.iter().map(|t| t.name.as_str()).collect();
+    assert!(names.contains(&"complete_task"));
+    assert!(names.contains(&"abort_task"));
 }


### PR DESCRIPTION
## Summary

Builds on the #646 spike ([PR #652](https://github.com/jdmiranda/phantom/pull/652)) which proved the parser short-circuit, the `Agent::complete_with_result` lifecycle, and the `AgentSpawnOpts::with_requires_complete_task` builder. The spike landed the substrate but explicitly deferred the production wiring; this PR lands it.

## Three production tool-list callsites extended

When `agent.requires_complete_task()` is true, the LLM tool manifest is extended with `tools::lifecycle_tools()` (`complete_task` + `abort_task`):

- `crates/phantom-app/src/agent_pane/execute.rs:268` — agent loop continuation
- `crates/phantom-app/src/agent_pane/mod.rs:512` — agent pane spawn
- `crates/phantom-app/src/agent_pane/mod.rs:1006` — agent resume (`send_followup`)

The brain investigator and headless CLI runner are intentionally not touched, scoping the lifecycle requirement to loop-spawned agents (per the spike PR's out-of-scope list).

## MAX_TOOL_ROUNDS failure reason rewrite

`execute.rs:86-119`: when the agent opted into the lifecycle contract and never captured a `completion_result`, the failure reason is rewritten to `"exited without complete_task"` (in both the journal record and the pane output). Legacy callers with `requires_complete_task=false` keep the generic iteration-limit message byte-for-byte. Defensive guard: if `completion_result()` is `Some`, the generic reason is used (the model did call `complete_task` earlier in the loop).

## `validation_failure_count` 3-strike flatline

- New `AgentPane::validation_failure_count: u8` field, default 0.
- New `COMPLETE_TASK_VALIDATION_FLATLINE = 3` constant.
- `ApiEvent::CompleteTask` handler now schema-validates `result` (must be a JSON Object). Per-loop `exit_schema` binding is **out of scope** (deferred to the loop overseer / future issue).
- Three consecutive invalid calls transition the pane to `Failed` with reason `"complete_task: schema validation failed 3x"`.
- Counter resets to 0 on either a successful `complete_task` OR any non-`complete_task` tool call (consecutive-failure semantics).
- Sub-threshold failures stay in `Working` and surface a `User`-role correction message to the model so it can self-correct on the next turn.

To make the consumer-side gate testable, `phantom-agents/src/api.rs` relaxes its strict non-object guard specifically for `complete_task`. File/git tools still receive the strict guard.

## AgentPane spawn wiring

`opts.requires_complete_task()` is forwarded to the constructed `Agent` via `set_requires_complete_task` at `mod.rs:474`, completing the spawn-opts → agent → tool-manifest chain.

## Tests

### `crates/phantom-agents/tests/complete_task_broader.rs` (5 tests, all pass)
- `lifecycle_tools()` returns exactly `[complete_task, abort_task]` with object schemas.
- Lifecycle tool names disjoint from `available_tools()` (no parser collision).
- Parser passes non-object `complete_task` input through as `CompleteTask` (string, null, array, number).
- Parser preserves strict non-object guard for file/git tools.
- Valid-object `complete_task` round-trip preserved.

### `crates/phantom-app/src/agent_pane/tests.rs` (8 new tests appended after the existing suite)
- `agent_pane_defaults_validation_failure_count_to_zero`.
- `max_tool_rounds_reason_rewritten_when_requires_complete_task_and_no_completion`.
- `max_tool_rounds_keeps_generic_reason_when_requires_complete_task_unset` (regression guard).
- `max_tool_rounds_keeps_generic_reason_when_completion_already_set` (defensive guard).
- `complete_task_schema_invalid_increments_validation_failure_count`.
- `three_consecutive_complete_task_schema_failures_flatline_pane`.
- `complete_task_validation_count_resets_on_successful_call`.
- `complete_task_validation_count_resets_on_non_complete_task_tool_call`.
- `lifecycle_tools_match_definition_count_and_names`.

## Pre-PR check numbers

| Crate | Gate | Branch | Baseline | Delta |
|---|---|---|---|---|
| phantom-agents | build | PASS | PASS | 0 |
| phantom-agents | test  | PASS (793 tests) | PASS | 0 |
| phantom-agents | clippy | PASS | PASS | 0 |
| phantom-app | lib build | 8 errors | 8 errors | 0 |
| phantom-app | test build | 13 errors | 16 errors | **-3** |
| phantom-app | clippy | 7 errors | 7 errors | 0 |

phantom-app pre-existing failures (settings_ui mismatched types, pane_messages role field, etc.) are unrelated to #646 and were confirmed via stash/restore comparison. The -3 test-build delta comes from fixing three pre-existing `mcp_registry` missing-field initializers in `agent_pane/tests.rs` as part of adding `validation_failure_count: 0` alongside them — a no-cost cleanup since both fields appear in the same three `AgentPane` literals.

CLAUDE.md rule overrides apply: pre-existing failures on origin/main do NOT block (rule 2 override).

## Out of scope (deferred)

- Per-loop `exit_schema` binding beyond must-be-object (loop overseer / future issue).
- Full `abort_task` consumer wiring (only the manifest definition is added; the issue scopes the lifecycle requirement to `complete_task`).
- Any crate outside `phantom-agents`, `phantom-app`.
- `CLAUDE.md` edits.

## Test plan

- [x] `cargo test -p phantom-agents --test complete_task_spike` — 4/4 pass (no regression)
- [x] `cargo test -p phantom-agents --test complete_task_broader` — 5/5 pass
- [x] `cargo test -p phantom-agents` — 793/793 pass
- [x] `./scripts/pre-pr-check.sh phantom-agents` — PASS (all 3 gates)
- [x] `cargo clippy -p phantom-agents --tests -- -D warnings` — clean
- [x] Hot-file conflict check via `gh pr list --state open` — no overlap with open PRs in `agent_pane/execute.rs` or `agent_pane/mod.rs` lifecycle regions

Closes #646.

🤖 Generated with [Claude Code](https://claude.com/claude-code)