### PR TITLE
feat(phantom-brain): typed quarantine recovery semantics for PlanStep (closes #649)

### DIFF
--- a/crates/phantom-app/src/adapters/agent.rs
+++ b/crates/phantom-app/src/adapters/agent.rs
@@ -5,6 +5,7 @@
 //! dispatch alongside terminals and other adapters.
 
 use std::cell::Cell;
+use std::sync::{Arc, Mutex};
 
 use serde_json::json;
 
@@ -15,6 +16,7 @@ use phantom_adapter::{
 };
 
 use phantom_agents::agent::AgentMessage;
+use phantom_agents::quarantine::{QuarantineRegistry, QuarantineState};
 use phantom_ui::render_ctx::RenderCtx;
 use phantom_ui::widgets::message_block::{MessageBlock, MessageRole};
 use phantom_ui::widgets::Widget;
@@ -61,6 +63,23 @@ pub struct AgentAdapter {
     /// Uses `Cell` because `render()` takes `&self` (required by the trait) but
     /// needs to update this value so command handlers stay consistent with it.
     cached_output_max_lines: Cell<usize>,
+    /// Substrate-owned [`QuarantineRegistry`] handle, threaded through from
+    /// `App::quarantine_registry` at adapter construction time (issue #649).
+    ///
+    /// `None` for test-only adapters and any future construction path that
+    /// has not yet wired the registry. When `Some`, the
+    /// `AgentPane::Failed → AgentTaskComplete { success: false }` emission
+    /// in [`Lifecycled::update`] queries this registry to detect a
+    /// quarantine-coincident failure and tags the emitted bus event's
+    /// summary with a typed marker so the brain reconciler can route the
+    /// completion to [`TaskLedger::record_quarantine_failure`] (the typed
+    /// recovery mutator defined in `phantom-brain`).
+    ///
+    /// Carrying the field as `Option` keeps existing constructor
+    /// signatures stable (test callers and the unmigrated production
+    /// `with_spawn_tag` path) while the typed mutator and the registry
+    /// wiring land together.
+    quarantine: Option<Arc<Mutex<QuarantineRegistry>>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -82,6 +101,7 @@ impl AgentAdapter {
             scroll_offset: 0,
             // Default to 20 until the first render() call provides the real value.
             cached_output_max_lines: Cell::new(20),
+            quarantine: None,
         }
     }
 
@@ -91,6 +111,58 @@ impl AgentAdapter {
         let mut adapter = Self::new(pane);
         adapter.spawn_tag = spawn_tag;
         adapter
+    }
+
+    /// Thread the substrate-owned [`QuarantineRegistry`] handle into the
+    /// adapter (issue #649).
+    ///
+    /// When set, the adapter consults the registry whenever the inner
+    /// pane transitions to [`AgentPaneStatus::Failed`] so a
+    /// quarantine-coincident failure can be flagged for the brain
+    /// reconciler (which then routes through the typed recovery mutator
+    /// `TaskLedger::record_quarantine_failure`). The registry is held as
+    /// `Arc<Mutex<…>>` so the substrate (`App`) keeps ownership and any
+    /// number of adapters share the same handle.
+    ///
+    /// The setter is builder-style so the production boot caller in
+    /// `agent_pane::spawn` can chain it after
+    /// [`AgentAdapter::with_spawn_tag`] without forcing a constructor
+    /// signature break for the existing test callers.
+    #[must_use]
+    pub(crate) fn with_quarantine_registry(
+        mut self,
+        quarantine: Arc<Mutex<QuarantineRegistry>>,
+    ) -> Self {
+        self.quarantine = Some(quarantine);
+        self
+    }
+
+    /// Returns `true` if the agent backing this adapter is in the
+    /// [`QuarantineState::Quarantined`] state, along with the
+    /// `since_ms` timestamp from the registry. Returns `None` when the
+    /// registry is unwired (test path) or the agent is not quarantined.
+    ///
+    /// Used by [`Lifecycled::update`] on the
+    /// `AgentPaneStatus::Failed` transition to flag quarantine-coincident
+    /// failures.
+    fn quarantined_since_ms(&self, agent_id: u64) -> Option<u64> {
+        let registry = self.quarantine.as_ref()?;
+        match registry.lock() {
+            Ok(guard) => match guard.state_of(agent_id) {
+                QuarantineState::Quarantined { since_ms, .. } => Some(since_ms),
+                _ => None,
+            },
+            Err(poisoned) => {
+                // A poisoned lock means another thread panicked while
+                // holding it; the data is still readable for our purpose
+                // (single-field state machine).
+                let guard = poisoned.into_inner();
+                match guard.state_of(agent_id) {
+                    QuarantineState::Quarantined { since_ms, .. } => Some(since_ms),
+                    _ => None,
+                }
+            }
+        }
     }
 
     /// Immutable access to the inner agent pane.
@@ -132,7 +204,33 @@ impl AppCore for AgentAdapter {
         if self.pane.status() != self.prev_status {
             let event = match self.pane.status() {
                 AgentPaneStatus::Done => Some((true, "Agent finished successfully".to_string())),
-                AgentPaneStatus::Failed => Some((false, "Agent failed".to_string())),
+                AgentPaneStatus::Failed => {
+                    // Issue #649: detect quarantine-coincident failures so
+                    // the brain reconciler can route to the typed
+                    // recovery mutator `TaskLedger::record_quarantine_failure`
+                    // instead of the generic `PlanStep::record_failure`.
+                    //
+                    // The protocol's `AgentTaskComplete` event currently
+                    // carries only a free-text `summary`; we annotate the
+                    // summary with a stable, machine-parseable marker
+                    // (`"[quarantined since_ms=<u64>]"`) so the brain can
+                    // disambiguate without a protocol break. When the
+                    // protocol grows a typed `failure_cause` field
+                    // downstream, this annotation can be dropped.
+                    let stable_agent_id = self.pane.agent_id();
+                    let summary = match self.quarantined_since_ms(stable_agent_id) {
+                        Some(since_ms) => {
+                            log::warn!(
+                                "AgentAdapter: agent {stable_agent_id} failed while \
+                                 quarantined (since_ms={since_ms}); summary will carry \
+                                 the typed marker"
+                            );
+                            format!("Agent failed [quarantined since_ms={since_ms}]")
+                        }
+                        None => "Agent failed".to_string(),
+                    };
+                    Some((false, summary))
+                }
                 AgentPaneStatus::Working => None, // Not a completion event
             };
 

--- a/crates/phantom-app/src/agent_pane/spawn.rs
+++ b/crates/phantom-app/src/agent_pane/spawn.rs
@@ -223,7 +223,12 @@ impl App {
         // This is the value returned to MCP callers (issue #399).
         let agent_id = agent_pane.agent_id();
 
-        let adapter = crate::adapters::agent::AgentAdapter::with_spawn_tag(agent_pane, spawn_tag);
+        // Thread the substrate-owned QuarantineRegistry into the adapter
+        // (issue #649) so it can detect quarantine-coincident failures on
+        // the `AgentPane::Failed → AgentTaskComplete` emit and annotate
+        // the summary for the brain reconciler.
+        let adapter = crate::adapters::agent::AgentAdapter::with_spawn_tag(agent_pane, spawn_tag)
+            .with_quarantine_registry(self.quarantine_registry.clone());
 
         let scene_node = self
             .scene

--- a/crates/phantom-brain/src/orchestrator.rs
+++ b/crates/phantom-brain/src/orchestrator.rs
@@ -80,6 +80,106 @@ pub enum StepStatus {
     NeedsApproval,
 }
 
+// ---------------------------------------------------------------------------
+// StepFailureCause (issue #649)
+// ---------------------------------------------------------------------------
+
+/// Typed cause for a `PlanStep` that did not complete successfully.
+///
+/// Stored on [`PlanStep::failure_cause`] when a step transitions to
+/// [`StepStatus::Failed`] or [`StepStatus::Skipped`]. The variant pins down
+/// *why* the step terminated unsuccessfully so the reconciler (and downstream
+/// observers like the inspector pane) can render typed diagnostics instead of
+/// only the free-text `result_summary`.
+///
+/// # Variant semantics
+///
+/// - [`StepFailureCause::AgentFailed`] — the agent ran and reported failure
+///   via the normal completion path (the default cause set by
+///   [`PlanStep::record_failure`] when no quarantine flag is present).
+/// - [`StepFailureCause::AgentQuarantined`] — the agent's [`AgentId`] is in
+///   the `Quarantined` state in the registry at the moment its completion
+///   event arrives. Set by [`TaskLedger::record_quarantine_failure`].
+/// - [`StepFailureCause::DispatchTimedOut`] — the reconciler tripped the
+///   per-step stall timeout before the agent reported back.
+/// - [`StepFailureCause::DependencyFailed`] — applied to cascaded
+///   [`StepStatus::Skipped`] steps by the `FailAndCascade` quarantine policy.
+///   `dep_idx` is the prerequisite step (in the same plan) whose failure
+///   propagated.
+/// - [`StepFailureCause::CompleteTaskNotCalled`] — reserved for the issue
+///   #646 follow-up where the agent terminated without calling
+///   `complete_task` even though the spawn opted into the explicit
+///   termination contract. Not emitted by this crate today; downstream
+///   consumers may pattern-match on it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StepFailureCause {
+    /// The agent reported failure through the normal completion path.
+    AgentFailed,
+    /// The agent's [`phantom_agents::AgentId`] is in the `Quarantined`
+    /// state in the [`phantom_agents::quarantine::QuarantineRegistry`]. The
+    /// `since_ms` field carries the wall-clock millisecond timestamp at the
+    /// moment of quarantine, propagated from `QuarantineState::Quarantined`.
+    AgentQuarantined {
+        /// The quarantined agent's stable ID.
+        agent_id: u64,
+        /// Wall-clock milliseconds at the moment the agent was quarantined.
+        since_ms: u64,
+    },
+    /// The reconciler's per-step stall timeout fired before the agent
+    /// reported back (reserved for the timeout dispatch path; today it is
+    /// produced by the reconciler's stall path via `record_failure`).
+    DispatchTimedOut,
+    /// A prerequisite step in the same plan failed, causing this step to be
+    /// skipped under the `FailAndCascade` quarantine policy. `dep_idx` is
+    /// the index of the failing prerequisite.
+    DependencyFailed {
+        /// The plan index of the dependency that propagated failure here.
+        dep_idx: usize,
+    },
+    /// The agent terminated without calling the explicit `complete_task`
+    /// tool even though its spawn opted into that contract. Reserved for
+    /// the issue #646 follow-up; not emitted by this crate today.
+    CompleteTaskNotCalled,
+}
+
+// ---------------------------------------------------------------------------
+// QuarantinePolicy (issue #649)
+// ---------------------------------------------------------------------------
+
+/// What [`TaskLedger::record_quarantine_failure`] does when the agent
+/// assigned to a step is in the `Quarantined` state at completion time.
+///
+/// Stored per-step on [`PlanStep::quarantine_policy`] so different steps in
+/// the same plan can elect different recovery semantics (e.g. a read-only
+/// audit step might tolerate a quick retry while a write-side deploy step
+/// should cascade-fail downstream).
+///
+/// The default policy is [`QuarantinePolicy::FailAndAllowRetry`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum QuarantinePolicy {
+    /// Mark the step `Failed`, set its `failure_cause` to
+    /// [`StepFailureCause::AgentQuarantined`], and clear its `agent_id` so
+    /// the next dispatch can spawn a fresh agent against the same step.
+    ///
+    /// The step is *not* re-queued automatically — callers that want a
+    /// retry must transition it back to `Pending` via the normal retry
+    /// machinery. This is the default policy.
+    #[default]
+    FailAndAllowRetry,
+    /// Apply the same per-step behaviour as `FailAndAllowRetry`, AND walk
+    /// the dependency graph: every step whose `depends_on` transitively
+    /// reaches the failing step is marked
+    /// [`StepStatus::Skipped`] with
+    /// [`StepFailureCause::DependencyFailed`] pointing back at the
+    /// originally failed step.
+    FailAndCascade,
+    /// Leave the step in its current status (typically `Active`) but stamp
+    /// `failure_cause` with [`StepFailureCause::AgentQuarantined`] for
+    /// diagnostics. The reconciler is expected to leave the step alone
+    /// until the quarantine clears externally.
+    Park,
+}
+
 /// A single step in the orchestrator's plan.
 ///
 /// From Magentic-One: "The plan is expressed in natural language and consists
@@ -143,6 +243,23 @@ pub struct PlanStep {
     /// [`TaskLedger::eligible_next`] until the human calls
     /// [`TaskLedger::approve_checkpoint`].
     requires_checkpoint: bool,
+    /// Typed cause for the most recent unsuccessful termination of this
+    /// step (issue #649).
+    ///
+    /// `None` while the step is in flight or has only seen successful
+    /// completions. Set to [`StepFailureCause::AgentFailed`] by
+    /// [`PlanStep::record_failure`] and to one of the quarantine-aware
+    /// variants by [`TaskLedger::record_quarantine_failure`].
+    pub failure_cause: Option<StepFailureCause>,
+    /// Per-step recovery policy applied when the agent assigned to this
+    /// step is quarantined at completion time (issue #649).
+    ///
+    /// Defaults to [`QuarantinePolicy::FailAndAllowRetry`] — see the policy
+    /// enum for the available variants. Existing call sites that build a
+    /// plan via `PlanStep::new` or `PlanStep::with_deps` get the default
+    /// policy automatically; opt in to a non-default policy through
+    /// [`PlanStep::with_quarantine_policy`].
+    pub quarantine_policy: QuarantinePolicy,
 }
 
 impl PlanStep {
@@ -164,6 +281,8 @@ impl PlanStep {
             preferred_provider: None,
             disposition: Disposition::default(),
             requires_checkpoint: false,
+            failure_cause: None,
+            quarantine_policy: QuarantinePolicy::default(),
         }
     }
 
@@ -256,10 +375,34 @@ impl PlanStep {
         self.preferred_provider.as_deref()
     }
 
+    /// Attach a [`QuarantinePolicy`] to this step (builder-style, issue #649).
+    ///
+    /// When the step's assigned agent is quarantined at completion time,
+    /// [`TaskLedger::record_quarantine_failure`] applies this policy.
+    /// Steps built without an explicit policy use
+    /// [`QuarantinePolicy::FailAndAllowRetry`].
+    ///
+    /// # Example
+    /// ```ignore
+    /// let step = PlanStep::new("deploy", task)
+    ///     .with_quarantine_policy(QuarantinePolicy::FailAndCascade);
+    /// ```
+    #[must_use]
+    pub fn with_quarantine_policy(mut self, policy: QuarantinePolicy) -> Self {
+        self.quarantine_policy = policy;
+        self
+    }
+
     /// Record a failed attempt. Returns true if retries remain.
+    ///
+    /// Sets [`PlanStep::failure_cause`] to
+    /// [`StepFailureCause::AgentFailed`] to distinguish ordinary agent
+    /// failures from the quarantine-coincident path handled by
+    /// [`TaskLedger::record_quarantine_failure`] (issue #649).
     pub fn record_failure(&mut self, summary: impl Into<String>) -> bool {
         self.attempts += 1;
         self.result_summary = Some(summary.into());
+        self.failure_cause = Some(StepFailureCause::AgentFailed);
         if self.attempts >= self.max_attempts {
             self.status = StepStatus::Failed;
             false
@@ -598,6 +741,163 @@ impl TaskLedger {
                 step.status = StepStatus::Pending;
                 Ok(())
             }
+        }
+    }
+
+    /// Apply the step's [`QuarantinePolicy`] to a failure that coincides
+    /// with the agent being in the `Quarantined` state (issue #649).
+    ///
+    /// Unlike [`PlanStep::record_failure`], this mutator stamps the
+    /// quarantine-aware [`StepFailureCause::AgentQuarantined`] cause and
+    /// honours the per-step [`PlanStep::quarantine_policy`]:
+    ///
+    /// - [`QuarantinePolicy::FailAndAllowRetry`] (default) — mark the
+    ///   step `Failed`, set the typed cause, and clear `agent_id` so a
+    ///   subsequent dispatch may spawn a fresh agent against the same
+    ///   step. Attempt counters are *not* incremented (this is not a
+    ///   normal failure budget consumer).
+    /// - [`QuarantinePolicy::FailAndCascade`] — perform the same per-step
+    ///   action as `FailAndAllowRetry`, then walk the dependency graph in
+    ///   topological-forward order and mark every transitive dependent
+    ///   step [`StepStatus::Skipped`] with
+    ///   [`StepFailureCause::DependencyFailed { dep_idx: idx }`].
+    ///   Dependents that are already in a terminal state
+    ///   (`Done` / `Failed` / `Skipped`) are left untouched.
+    /// - [`QuarantinePolicy::Park`] — leave the step's status as-is and
+    ///   stamp the typed cause for diagnostics. The reconciler is
+    ///   expected to ignore parked steps until the quarantine clears.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DispatchBlocked::OutOfBounds`] when `idx` is out of
+    /// bounds for the current plan. All other branches succeed.
+    ///
+    /// On success the returned reference points at the step at `idx` so
+    /// callers can inspect the resulting `status` / `failure_cause`
+    /// without a second lookup.
+    pub fn record_quarantine_failure(
+        &mut self,
+        idx: usize,
+        agent_id: u64,
+        since_ms: u64,
+    ) -> Result<&PlanStep, DispatchBlocked> {
+        let plan_len = self.plan.len();
+        if idx >= plan_len {
+            return Err(DispatchBlocked::OutOfBounds {
+                idx,
+                len: plan_len,
+            });
+        }
+
+        // Snapshot the policy before mutating so we can branch the
+        // dependency-cascade walk below without holding a mutable borrow
+        // across the loop.
+        let policy = self.plan[idx].quarantine_policy;
+        let cause = StepFailureCause::AgentQuarantined { agent_id, since_ms };
+
+        match policy {
+            QuarantinePolicy::FailAndAllowRetry | QuarantinePolicy::FailAndCascade => {
+                let step = &mut self.plan[idx];
+                step.status = StepStatus::Failed;
+                step.failure_cause = Some(cause);
+                // Clear `agent_id` so the next dispatch (if any) can spawn
+                // a fresh agent for this step. Attempt counters are left
+                // alone because a quarantine is not the agent's "fault" in
+                // the retry-budget sense.
+                step.agent_id = None;
+            }
+            QuarantinePolicy::Park => {
+                // Status is intentionally left alone. The reconciler
+                // observes the stamped `failure_cause` for diagnostics
+                // and leaves the step parked until the quarantine
+                // clears externally.
+                let step = &mut self.plan[idx];
+                step.failure_cause = Some(cause);
+            }
+        }
+
+        if matches!(policy, QuarantinePolicy::FailAndCascade) {
+            self.cascade_skip_dependents(idx);
+        }
+
+        Ok(&self.plan[idx])
+    }
+
+    /// Walk the dependency graph forward from `failed_idx` and mark every
+    /// transitive dependent step as [`StepStatus::Skipped`] with
+    /// [`StepFailureCause::DependencyFailed`] pointing at `failed_idx`.
+    ///
+    /// "Dependent" here means: any step `j` whose `depends_on` contains an
+    /// index `k` where `k == failed_idx` *or* `k` is itself transitively
+    /// skipped by this walk. Dependents that have already reached a
+    /// terminal status (`Done`, `Failed`, `Skipped`) are left untouched so
+    /// previously completed work is not silently reclassified.
+    ///
+    /// Uses an iterative breadth-first scan over `0..plan.len()` so the
+    /// walk is O(n × max_depends_on) and avoids the stack depth a naive
+    /// recursive variant would require on long plans.
+    fn cascade_skip_dependents(&mut self, failed_idx: usize) {
+        let plan_len = self.plan.len();
+        // `failed_set` tracks indices whose failure should propagate. We
+        // start with the originating failure and grow the set as we
+        // discover transitive dependents.
+        let mut failed_set: std::collections::HashSet<usize> =
+            std::collections::HashSet::new();
+        failed_set.insert(failed_idx);
+
+        // BFS-style scan: re-iterate over the plan until no new dependent
+        // is added to `failed_set`. Each iteration costs O(n × d); the
+        // outer loop runs at most O(n) times in the worst case (a linear
+        // chain), giving O(n² × d) total. For typical plans (n < 20)
+        // this is fine.
+        loop {
+            let mut grew = false;
+            for j in 0..plan_len {
+                if failed_set.contains(&j) {
+                    continue;
+                }
+                // Only propagate into steps that are still in a
+                // non-terminal status; previously completed work stays
+                // as it was.
+                let cur_status = self.plan[j].status;
+                if matches!(
+                    cur_status,
+                    StepStatus::Done | StepStatus::Failed | StepStatus::Skipped
+                ) {
+                    continue;
+                }
+                let deps = &self.plan[j].depends_on;
+                if deps.iter().any(|d| failed_set.contains(d)) {
+                    failed_set.insert(j);
+                    grew = true;
+                }
+            }
+            if !grew {
+                break;
+            }
+        }
+
+        // Apply the cascade — every transitively-failed step that is not
+        // the origin gets marked `Skipped` with the origin recorded as
+        // the propagating dependency.
+        for j in failed_set {
+            if j == failed_idx {
+                continue;
+            }
+            let step = &mut self.plan[j];
+            // Defensive: skip terminal statuses (the scan above already
+            // filtered them, but a future caller might mutate state
+            // between scan and application).
+            if matches!(
+                step.status,
+                StepStatus::Done | StepStatus::Failed | StepStatus::Skipped
+            ) {
+                continue;
+            }
+            step.status = StepStatus::Skipped;
+            step.failure_cause = Some(StepFailureCause::DependencyFailed {
+                dep_idx: failed_idx,
+            });
         }
     }
 

--- a/crates/phantom-brain/tests/quarantine_policy.rs
+++ b/crates/phantom-brain/tests/quarantine_policy.rs
@@ -1,0 +1,298 @@
+//! Integration tests for the typed-quarantine-recovery mutator (issue #649).
+//!
+//! These tests cover [`TaskLedger::record_quarantine_failure`] across every
+//! [`QuarantinePolicy`] variant and verify that the typed failure cause is
+//! stamped onto the affected `PlanStep`(s). Read-API behaviour for the new
+//! `failure_cause` and `quarantine_policy` fields is exercised here too so
+//! downstream observers (inspector pane, reconciler) can rely on them.
+//!
+//! Coverage:
+//! 1. Default policy is `FailAndAllowRetry`; `failure_cause` is `None`
+//!    before any failure has been recorded.
+//! 2. `record_quarantine_failure` with `FailAndAllowRetry` marks the
+//!    step `Failed`, sets the typed cause, and clears `agent_id` for
+//!    fresh-respawn semantics.
+//! 3. `record_quarantine_failure` with `FailAndCascade` cascades to
+//!    every transitive dependent, marking each `Skipped` with
+//!    `DependencyFailed { dep_idx: idx }`.
+//! 4. `record_quarantine_failure` with `Park` leaves the step `Active`
+//!    and only stamps the typed cause for diagnostics.
+//! 5. `record_quarantine_failure` on an out-of-bounds index returns
+//!    `DispatchBlocked::OutOfBounds` and mutates no state.
+//! 6. `PlanStep::record_failure` still stamps `StepFailureCause::AgentFailed`
+//!    on the non-quarantine path so observers can disambiguate.
+
+use phantom_agents::AgentTask;
+use phantom_brain::orchestrator::{
+    DispatchBlocked, PlanStep, QuarantinePolicy, StepFailureCause, StepStatus, TaskLedger,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn free_task(prompt: &str) -> AgentTask {
+    AgentTask::FreeForm {
+        prompt: prompt.into(),
+    }
+}
+
+fn step(description: &str, depends_on: Vec<usize>) -> PlanStep {
+    PlanStep::with_deps(description, free_task(description), depends_on)
+}
+
+/// Drive a step's status to [`StepStatus::Active`] via the guarded mutator
+/// so the test fixture mirrors what production code observes: the step
+/// holds an `agent_id`, has been incremented through the dispatch path,
+/// and is then completed externally (success or quarantine-tagged
+/// failure).
+fn drive_to_active(ledger: &mut TaskLedger, idx: usize, agent_id: u64) {
+    ledger
+        .try_dispatch(idx)
+        .expect("try_dispatch should succeed for a Pending step with no unmet deps");
+    // The reconciler stamps `agent_id` after a successful dispatch; mirror
+    // that side effect in the fixture so `record_quarantine_failure`'s
+    // `agent_id` clearing is observable.
+    ledger.plan[idx].agent_id = Some(agent_id);
+    // Force the step status to `Active` for the Park policy test, since the
+    // policy explicitly leaves the status as-is. `try_dispatch` already
+    // transitioned to `Active`; this is redundant but documents intent.
+    assert_eq!(ledger.plan[idx].status, StepStatus::Active);
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: defaults
+// ---------------------------------------------------------------------------
+
+#[test]
+fn plan_step_defaults_are_failand_allow_retry_and_no_cause() {
+    let s = PlanStep::new("only step", free_task("only step"));
+    assert_eq!(s.quarantine_policy, QuarantinePolicy::FailAndAllowRetry);
+    assert!(
+        s.failure_cause.is_none(),
+        "fresh step must not carry a failure cause"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: FailAndAllowRetry policy
+// ---------------------------------------------------------------------------
+
+#[test]
+fn record_quarantine_failure_fail_and_allow_retry_marks_failed_and_clears_agent_id() {
+    let mut ledger = TaskLedger::new("retry policy");
+    ledger.set_plan(vec![step("s0", vec![])]);
+
+    drive_to_active(&mut ledger, 0, 42);
+    assert_eq!(ledger.plan[0].agent_id, Some(42));
+
+    let returned = ledger
+        .record_quarantine_failure(0, 42, 1_700_000_000_000)
+        .expect("record_quarantine_failure must succeed for an in-range step");
+
+    assert_eq!(returned.status, StepStatus::Failed);
+    assert_eq!(
+        returned.failure_cause,
+        Some(StepFailureCause::AgentQuarantined {
+            agent_id: 42,
+            since_ms: 1_700_000_000_000,
+        }),
+    );
+    // The agent_id is cleared so the next dispatch can spawn fresh.
+    assert!(
+        returned.agent_id.is_none(),
+        "FailAndAllowRetry must clear agent_id"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: FailAndCascade policy — direct dependents
+// ---------------------------------------------------------------------------
+
+#[test]
+fn record_quarantine_failure_cascade_marks_dependents_skipped() {
+    let mut ledger = TaskLedger::new("cascade policy");
+    // Build a fan-out: step 1 and step 2 both depend on step 0.
+    let mut s0 = step("s0", vec![]);
+    s0.quarantine_policy = QuarantinePolicy::FailAndCascade;
+    let s1 = step("s1", vec![0]);
+    let s2 = step("s2", vec![0]);
+    ledger.set_plan(vec![s0, s1, s2]);
+
+    drive_to_active(&mut ledger, 0, 7);
+    ledger
+        .record_quarantine_failure(0, 7, 1_000)
+        .expect("cascade must accept the in-range index");
+
+    assert_eq!(ledger.plan[0].status, StepStatus::Failed);
+    assert_eq!(
+        ledger.plan[0].failure_cause,
+        Some(StepFailureCause::AgentQuarantined {
+            agent_id: 7,
+            since_ms: 1_000,
+        }),
+    );
+
+    // Direct dependents are now `Skipped` with `DependencyFailed`.
+    for &j in &[1usize, 2] {
+        assert_eq!(
+            ledger.plan[j].status,
+            StepStatus::Skipped,
+            "step {j} must be Skipped by the cascade"
+        );
+        assert_eq!(
+            ledger.plan[j].failure_cause,
+            Some(StepFailureCause::DependencyFailed { dep_idx: 0 }),
+            "step {j} must carry DependencyFailed pointing at the originating failure"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: FailAndCascade — transitive dependents
+// ---------------------------------------------------------------------------
+
+#[test]
+fn record_quarantine_failure_cascade_propagates_transitively() {
+    let mut ledger = TaskLedger::new("transitive cascade");
+    // Linear chain: 0 → 1 → 2 → 3. Cascading at 0 should mark 1, 2, 3 all
+    // Skipped.
+    let mut s0 = step("s0", vec![]);
+    s0.quarantine_policy = QuarantinePolicy::FailAndCascade;
+    let s1 = step("s1", vec![0]);
+    let s2 = step("s2", vec![1]);
+    let s3 = step("s3", vec![2]);
+    ledger.set_plan(vec![s0, s1, s2, s3]);
+
+    drive_to_active(&mut ledger, 0, 99);
+    ledger
+        .record_quarantine_failure(0, 99, 2_000)
+        .expect("cascade must accept the in-range index");
+
+    assert_eq!(ledger.plan[0].status, StepStatus::Failed);
+    for j in 1..=3 {
+        assert_eq!(
+            ledger.plan[j].status,
+            StepStatus::Skipped,
+            "step {j} must be Skipped by the transitive cascade"
+        );
+        assert_eq!(
+            ledger.plan[j].failure_cause,
+            Some(StepFailureCause::DependencyFailed { dep_idx: 0 }),
+            "step {j} must point back at the originating failure (idx 0)"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: FailAndCascade leaves terminal-status steps alone
+// ---------------------------------------------------------------------------
+
+#[test]
+fn record_quarantine_failure_cascade_does_not_clobber_done_dependents() {
+    let mut ledger = TaskLedger::new("done dependents");
+    let mut s0 = step("s0", vec![]);
+    s0.quarantine_policy = QuarantinePolicy::FailAndCascade;
+    let s1 = step("s1", vec![0]);
+    ledger.set_plan(vec![s0, s1]);
+
+    // Pretend step 1 already completed independently (e.g. previously
+    // ran with a relaxed dep policy). Cascade must leave it as `Done`.
+    drive_to_active(&mut ledger, 0, 1);
+    ledger.plan[1].status = StepStatus::Done;
+
+    ledger
+        .record_quarantine_failure(0, 1, 0)
+        .expect("cascade must accept the in-range index");
+
+    assert_eq!(ledger.plan[0].status, StepStatus::Failed);
+    assert_eq!(
+        ledger.plan[1].status,
+        StepStatus::Done,
+        "cascade must not reclassify a `Done` step"
+    );
+    assert!(
+        ledger.plan[1].failure_cause.is_none(),
+        "cascade must not stamp a cause on a completed step"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: Park policy
+// ---------------------------------------------------------------------------
+
+#[test]
+fn record_quarantine_failure_park_leaves_status_unchanged_and_stamps_cause() {
+    let mut ledger = TaskLedger::new("park policy");
+    let mut s = step("only", vec![]);
+    s.quarantine_policy = QuarantinePolicy::Park;
+    ledger.set_plan(vec![s]);
+
+    drive_to_active(&mut ledger, 0, 13);
+    let prior_agent_id = ledger.plan[0].agent_id;
+
+    let returned = ledger
+        .record_quarantine_failure(0, 13, 3_141)
+        .expect("park must accept the in-range index");
+
+    assert_eq!(
+        returned.status,
+        StepStatus::Active,
+        "Park must leave status untouched"
+    );
+    assert_eq!(
+        returned.failure_cause,
+        Some(StepFailureCause::AgentQuarantined {
+            agent_id: 13,
+            since_ms: 3_141,
+        }),
+    );
+    assert_eq!(
+        returned.agent_id, prior_agent_id,
+        "Park must not clear agent_id — the reconciler may revive the step on quarantine release"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: out-of-bounds index
+// ---------------------------------------------------------------------------
+
+#[test]
+fn record_quarantine_failure_rejects_out_of_bounds_index() {
+    let mut ledger = TaskLedger::new("oob test");
+    ledger.set_plan(vec![step("only", vec![])]);
+
+    let err = ledger
+        .record_quarantine_failure(7, 1, 0)
+        .expect_err("OOB index must be rejected");
+
+    assert_eq!(err, DispatchBlocked::OutOfBounds { idx: 7, len: 1 });
+    // No state mutation: the in-range step is still Pending.
+    assert_eq!(ledger.plan[0].status, StepStatus::Pending);
+    assert!(ledger.plan[0].failure_cause.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Test 8: non-quarantine record_failure stamps the AgentFailed cause
+// ---------------------------------------------------------------------------
+
+#[test]
+fn record_failure_stamps_agent_failed_cause() {
+    let mut step = PlanStep::new("flaky", free_task("flaky"));
+    step.max_attempts = 1;
+    // record_failure exhausts retries immediately (max_attempts = 1).
+    assert!(!step.record_failure("flaked out"));
+    assert_eq!(step.status, StepStatus::Failed);
+    assert_eq!(step.failure_cause, Some(StepFailureCause::AgentFailed));
+}
+
+// ---------------------------------------------------------------------------
+// Test 9: builder threads the policy through
+// ---------------------------------------------------------------------------
+
+#[test]
+fn with_quarantine_policy_threads_policy_to_field() {
+    let s = PlanStep::new("opt-in cascade", free_task("opt-in cascade"))
+        .with_quarantine_policy(QuarantinePolicy::FailAndCascade);
+    assert_eq!(s.quarantine_policy, QuarantinePolicy::FailAndCascade);
+}


### PR DESCRIPTION
## Summary

Wires the quarantine recovery path that PR #654 left as a `RESERVED`
`DispatchBlocked::Quarantined` placeholder. Adds typed failure causes
and a per-step quarantine policy so a `PlanStep` whose agent goes into
quarantine mid-flight gets a defined, observable status — and the
right downstream side effects on its dependents.

Closes #649.

## New types in `phantom-brain`

```rust
pub enum StepFailureCause {
    AgentFailed,
    AgentQuarantined { agent_id: u64, since_ms: u64 },
    DispatchTimedOut,
    DependencyFailed { dep_idx: usize },
    CompleteTaskNotCalled,
}

pub enum QuarantinePolicy {
    FailAndAllowRetry,   // <-- default (#[default])
    FailAndCascade,
    Park,
}
```

* `PlanStep` carries two new public fields: `failure_cause:
  Option<StepFailureCause>` and `quarantine_policy: QuarantinePolicy`.
  `PlanStep::new` initialises both to defaults so every existing
  builder (`with_deps`, `with_disposition`, `with_provider`,
  `with_checkpoint`) keeps compiling.
* `PlanStep::with_quarantine_policy(policy)` opts a step into a
  non-default policy.
* `PlanStep::record_failure` now stamps
  `failure_cause = Some(AgentFailed)` so non-quarantine failures still
  carry a typed cause (the variant a UI can render as "agent error" vs
  "quarantined" vs "dep cascade").

## `TaskLedger::record_quarantine_failure(idx, agent_id, since_ms)`

The new guarded mutator applies the step's policy:

* `FailAndAllowRetry` — mark `Failed`, stamp
  `AgentQuarantined { agent_id, since_ms }`, clear `agent_id` so the
  next dispatch may spawn fresh. Attempt counters are intentionally
  *not* incremented — a quarantine is not the agent's "fault" in the
  retry-budget sense.
* `FailAndCascade` — apply the per-step `FailAndAllowRetry` action,
  then walk the dependency graph in BFS-forward order and mark every
  transitive dependent `Skipped` with `DependencyFailed { dep_idx:
  idx }` pointing back at the originating failure. Dependents
  already in a terminal status (`Done` / `Failed` / `Skipped`) are
  left untouched.
* `Park` — leave the step's status untouched (typically `Active`)
  and only stamp `failure_cause` for diagnostics. The reconciler is
  expected to ignore parked steps until the quarantine clears
  externally.

Returns `Err(DispatchBlocked::OutOfBounds)` for an OOB `idx`; all
in-range branches succeed and return `&PlanStep`.

## Adapter / boot threading

* `AgentAdapter` gains a `quarantine: Option<Arc<Mutex<QuarantineRegistry>>>`
  field, kept `Option` so existing constructor signatures (`new`,
  `with_spawn_tag`) stay stable for in-file test callers and the
  unrelated sibling-agent surface (`agent_pane::tests.rs`,
  `agent_pane::mod.rs` — owned by the issue #646 work).
* Builder `AgentAdapter::with_quarantine_registry(quarantine)` threads
  the substrate-owned handle into the adapter.
* `agent_pane::spawn::spawn_agent_pane_with_opts` is the one boot
  caller — explicitly allowed per the "plus boot caller" exception
  in the operating-policy override — and now chains
  `.with_quarantine_registry(self.quarantine_registry.clone())`
  after `AgentAdapter::with_spawn_tag(...)`. This is the only
  `agent_pane/*.rs` line touched; no other `agent_pane/*` logic
  changes.
* On `AgentPaneStatus::Failed`, the adapter looks up the
  `QuarantineState` for the pane's stable `agent_id()` via the
  registry. If `Quarantined { since_ms, .. }`, the emitted
  `AgentTaskComplete` event's `summary` is annotated with a stable
  machine-parseable marker `"[quarantined since_ms=<u64>]"` so the
  brain reconciler can disambiguate without breaking the
  `phantom-protocol` `Event::AgentTaskComplete` shape. When the
  protocol grows a typed `failure_cause` field downstream, this
  annotation can be dropped.

## `AgentAdapter::new` callers (constructor stayed `(pane)`)

* `crates/phantom-app/src/agent_pane/spawn.rs:226` — production boot
  site, now chains `.with_quarantine_registry(...)` after
  `with_spawn_tag`. Only line touched in `agent_pane/*`.
* In-file unit tests in `crates/phantom-app/src/adapters/agent.rs`
  (~30 call sites) — unchanged; they keep using the bare
  `AgentAdapter::new(pane)` and the `quarantine` field stays `None`
  in those fixtures.
* `crates/phantom-app/src/agent_pane/tests.rs:1829` — unchanged
  (sibling-agent area; `quarantine` stays `None` in the test fixture,
  which is correct: the test exercises render output, not failure
  routing).

Holding the field as `Option` is the minimal deviation from the
issue's literal "thread through `AgentAdapter::new`" wording. The
deviation is justified by the operating-policy override "DO NOT
touch `phantom-app/src/agent_pane/*`" — every other call site is in
that area or in tests that don't need the registry.

## Tests

New integration tests in `crates/phantom-brain/tests/quarantine_policy.rs`:

1. `plan_step_defaults_are_failand_allow_retry_and_no_cause` — fresh
   `PlanStep::new` carries `QuarantinePolicy::FailAndAllowRetry` and
   `failure_cause = None`.
2. `record_quarantine_failure_fail_and_allow_retry_marks_failed_and_clears_agent_id`
   — `FailAndAllowRetry` marks `Failed`, stamps `AgentQuarantined`,
   clears `agent_id`.
3. `record_quarantine_failure_cascade_marks_dependents_skipped` —
   fan-out cascade (step 1 and step 2 both depend on step 0).
4. `record_quarantine_failure_cascade_propagates_transitively` —
   chain cascade (0 → 1 → 2 → 3); all dependents point back at
   `dep_idx: 0`.
5. `record_quarantine_failure_cascade_does_not_clobber_done_dependents`
   — previously-`Done` dependents are not reclassified.
6. `record_quarantine_failure_park_leaves_status_unchanged_and_stamps_cause`
   — `Park` leaves `Active` status and `agent_id` intact.
7. `record_quarantine_failure_rejects_out_of_bounds_index` —
   `DispatchBlocked::OutOfBounds` is returned with no state
   mutation.
8. `record_failure_stamps_agent_failed_cause` — the non-quarantine
   path keeps stamping `StepFailureCause::AgentFailed`.
9. `with_quarantine_policy_threads_policy_to_field` — builder threads
   the policy through.

All 9 pass:

```
cargo test -p phantom-brain --test quarantine_policy
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured;
```

Existing integration suites still pass alongside:

```
cargo test -p phantom-brain --test dispatch_guard         # 4/4
cargo test -p phantom-brain --test privacy_gate_e2e       # 5/5
```

## Pre-PR check numbers

Per orchestration Rule 2 override: pre-existing failures on
`origin/main` are preserved unchanged. Baselines captured by stashing
this branch's changes:

| | Gate failures |
|---|---|
| `phantom-brain` baseline (`origin/main`) | 2 |
| `phantom-brain` with this PR | 2 |
| `phantom-app` baseline (`origin/main`) | 3 |
| `phantom-app` with this PR | 3 |

* `phantom-brain` baseline failures: pre-existing `BrainHandle.brain_handle`
  E0063 errors (3) in `lib.rs` test fixtures + 2 pre-existing clippy
  failures in `brain.rs:123` and `ooda.rs:363`. None touched.
* `phantom-app` baseline failures: pre-existing E0425 `visible` scope
  error in `adapters/agent.rs:458` (not touched by this PR — verified
  by stash diff), E0592 / E0308 / E0614 in `agent_pane/mod.rs` and
  `settings_ui.rs`, plus the `phantom-terminal` `must_use` chain.
  None touched.

The PR introduces zero new gate failures.

## Out of scope

* Loop overseer (#650).
* `complete_task` integration (issue #646 — sibling agent owns
  `agent_pane/*.rs`).
* Reconciler wiring of `record_quarantine_failure` from the
  `AiEvent::AgentComplete` path — the marker in
  `AgentTaskComplete.summary` is the parseable hand-off, but the
  reconciler does not yet consume it. That belongs in a follow-up so
  the protocol can grow a typed `failure_cause` field rather than
  parsing the summary string.
* Closing other issues besides #649.

## Test plan

- [ ] CI: `cargo test -p phantom-brain --test quarantine_policy` green.
- [ ] CI: `cargo test -p phantom-brain --test dispatch_guard` still
      green (regression coverage on the sibling guarded mutator).
- [ ] Reviewer: confirm `crates/phantom-app/src/agent_pane/*` diff is
      one line in `spawn.rs:226` and nothing else.

Generated with [Claude Code](https://claude.com/claude-code)