### PR TITLE
feat(phantom-loop): scaffold crate with types and TOML spec parser (closes part of #650)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,7 @@ dependencies = [
  "const-random",
  "getrandom 0.3.4",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -776,12 +777,27 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -946,6 +962,12 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 dependencies = [
  "allocator-api2",
 ]
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -2741,6 +2763,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex-automata 0.4.14",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fast-float2"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2921,6 +2954,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -3855,6 +3898,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "iso8601"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
+dependencies = [
+ "nom 8.0.0",
+]
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4033,6 +4085,35 @@ dependencies = [
  "serde",
  "serde_json",
  "zmij",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2eef4e82b548e08ac880d307c8e8838b45f497a08d3202f3b26c9debaed8058"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "base64",
+ "bytecount",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.2.17",
+ "iso8601",
+ "itoa",
+ "memchr",
+ "num-cmp",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "time",
+ "url",
+ "uuid-simd",
 ]
 
 [[package]]
@@ -5099,7 +5180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b977c445f26e49757f9aca3631c3b8b836942cb278d69a92e7b80d3b24da632"
 dependencies = [
  "arrayvec",
- "bit-set",
+ "bit-set 0.8.0",
  "bitflags 2.11.1",
  "cfg_aliases",
  "codespan-reporting",
@@ -5250,6 +5331,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5258,6 +5353,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
 
 [[package]]
 name = "num-complex"
@@ -5291,6 +5392,28 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -5796,6 +5919,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
 name = "owned_ttf_parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6155,6 +6284,18 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "phantom-loop"
+version = "0.1.0"
+dependencies = [
+ "jsonschema",
+ "phantom-agents",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "toml",
 ]
 
 [[package]]
@@ -9116,6 +9257,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "uuid",
+ "vsimd",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9138,6 +9290,12 @@ name = "virtue"
 version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vte"
@@ -9729,8 +9887,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7b882196f8368511d613c6aeec80655160db6646aebddf8328879a88d54e500"
 dependencies = [
  "arrayvec",
- "bit-set",
- "bit-vec",
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
  "bitflags 2.11.1",
  "cfg_aliases",
  "document-features",
@@ -9789,7 +9947,7 @@ dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set",
+ "bit-set 0.8.0",
  "bitflags 2.11.1",
  "block",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ members = [
     "crates/phantom-hub",
     # Hot-module reload host — Phase 1 dylib loading (issue #382).
     "crates/phantom-skill-host",
+    # Loop overseer — types and TOML spec parsing (C1 of issue #650).
+    "crates/phantom-loop",
 ]
 resolver = "2"
 

--- a/crates/phantom-loop/Cargo.toml
+++ b/crates/phantom-loop/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "phantom-loop"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+phantom-agents = { path = "../phantom-agents" }
+
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+toml = "0.8"
+# JSON Schema validation. The `jsonschema` crate at 0.20 deprecates the old
+# `JSONSchema` type in favour of `Validator`/`validator_for`; we use the
+# `Validator` API and re-export it under our own [`crate::ExitSchema`] wrapper
+# so future major-version bumps stay localised.
+jsonschema = "0.20"
+thiserror = "2"
+
+[lints]
+workspace = true

--- a/crates/phantom-loop/src/effect.rs
+++ b/crates/phantom-loop/src/effect.rs
@@ -1,0 +1,118 @@
+//! Side effects fired after a loop iteration emits a valid exit payload.
+//!
+//! Each [`LoopEffect`] is declarative — it describes *what* should happen
+//! after a successful iteration, not *how* the runner accomplishes it. The
+//! C2 slice (the runner) is what dispatches these.
+
+use serde::{Deserialize, Serialize};
+
+/// A declarative post-iteration action.
+///
+/// `LoopEffect` is encoded as a tagged enum in TOML so the user can list
+/// multiple effects against the same exit:
+///
+/// ```toml
+/// [[on_complete]]
+/// kind = "enqueue_to"
+/// queue = "implementer-queue"
+///
+/// [[on_complete.fields]]
+/// from = "result.pr_url"
+/// to = "target_pr"
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum LoopEffect {
+    /// Push a typed message onto a named queue. `fields` maps slots of the
+    /// iteration result onto slots of the outgoing `LoopMessage` payload.
+    EnqueueTo {
+        queue: String,
+        #[serde(default)]
+        fields: Vec<FieldMap>,
+    },
+
+    /// Emit a custom event on the cross-loop bus. The runner will forward
+    /// the iteration result verbatim under the given `event_kind`.
+    LogToBus { event_kind: String },
+
+    /// Halt the loop entirely. No further inputs are consumed. The runner
+    /// transitions to a terminal `Stopped` state — restarting requires a
+    /// fresh `phantom loop run`.
+    StopLoop,
+}
+
+/// Maps a dotted path inside an iteration result onto a target field on the
+/// outgoing message payload.
+///
+/// `from` is a JSON pointer-like dotted path (`result.pr_url`); `to` is a
+/// flat field name on the `LoopMessage` payload. Future slices will decide
+/// the exact resolution semantics for the dotted path; for C1 we only
+/// preserve the strings verbatim.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct FieldMap {
+    pub from: String,
+    pub to: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enqueue_to_with_field_map_roundtrips_through_toml() {
+        let input = r#"
+            kind = "enqueue_to"
+            queue = "implementer-queue"
+
+            [[fields]]
+            from = "result.pr_url"
+            to = "target_pr"
+        "#;
+        let effect: LoopEffect = toml::from_str(input).expect("parse enqueue_to");
+        match effect {
+            LoopEffect::EnqueueTo { queue, fields } => {
+                assert_eq!(queue, "implementer-queue");
+                assert_eq!(fields.len(), 1);
+                assert_eq!(fields[0].from, "result.pr_url");
+                assert_eq!(fields[0].to, "target_pr");
+            }
+            other => panic!("expected EnqueueTo, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn log_to_bus_parses_with_only_event_kind() {
+        let input = r#"
+            kind = "log_to_bus"
+            event_kind = "pr_reviewed"
+        "#;
+        let effect: LoopEffect = toml::from_str(input).expect("parse log_to_bus");
+        match effect {
+            LoopEffect::LogToBus { event_kind } => assert_eq!(event_kind, "pr_reviewed"),
+            other => panic!("expected LogToBus, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stop_loop_parses_with_no_fields() {
+        let input = r#"kind = "stop_loop""#;
+        let effect: LoopEffect = toml::from_str(input).expect("parse stop_loop");
+        assert!(matches!(effect, LoopEffect::StopLoop));
+    }
+
+    #[test]
+    fn enqueue_to_with_no_fields_defaults_to_empty_vec() {
+        let input = r#"
+            kind = "enqueue_to"
+            queue = "review-queue"
+        "#;
+        let effect: LoopEffect = toml::from_str(input).expect("parse enqueue_to no-fields");
+        match effect {
+            LoopEffect::EnqueueTo { queue, fields } => {
+                assert_eq!(queue, "review-queue");
+                assert!(fields.is_empty());
+            }
+            other => panic!("expected EnqueueTo, got {other:?}"),
+        }
+    }
+}

--- a/crates/phantom-loop/src/error.rs
+++ b/crates/phantom-loop/src/error.rs
@@ -1,0 +1,72 @@
+//! Error types for loop spec loading.
+//!
+//! Errors are deliberately coarse — TOML parse, schema compile, IO, semantic
+//! validation. Future slices may add runtime-error variants (queue-overflow,
+//! task-stalled) at which point those should live in a separate `RuntimeError`.
+
+use std::path::PathBuf;
+use thiserror::Error;
+
+/// Anything that can go wrong while reading and compiling a [`crate::LoopSpec`].
+#[derive(Debug, Error)]
+pub enum LoopSpecError {
+    /// Failed to read the TOML file from disk.
+    #[error("failed to read loop spec at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// TOML deserialization rejected the file.
+    #[error("invalid TOML in loop spec at {path}: {source}")]
+    TomlParse {
+        path: PathBuf,
+        #[source]
+        source: toml::de::Error,
+    },
+
+    /// TOML deserialization rejected a raw string (no path context — used by
+    /// in-memory parsing in tests and the future runner).
+    #[error("invalid TOML in loop spec: {0}")]
+    TomlParseRaw(#[from] toml::de::Error),
+
+    /// The embedded `exit_schema` value failed JSON Schema compilation.
+    ///
+    /// The wrapped string carries the human-readable description the
+    /// `jsonschema` crate produced — we deliberately do not store the
+    /// `ValidationError<'static>` directly because it transitively borrows
+    /// crate-internal state we do not want to leak through our public API.
+    #[error("exit_schema is not a valid JSON Schema: {0}")]
+    SchemaCompile(String),
+
+    /// A field was present but the value violated a structural constraint that
+    /// serde alone cannot express (e.g. an empty `id`).
+    #[error("invalid field `{field}` in loop spec: {reason}")]
+    InvalidField {
+        field: &'static str,
+        reason: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_field_message_includes_field_and_reason() {
+        let err = LoopSpecError::InvalidField {
+            field: "id",
+            reason: "must not be empty".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("id"));
+        assert!(msg.contains("must not be empty"));
+    }
+
+    #[test]
+    fn schema_compile_message_includes_underlying_reason() {
+        let err = LoopSpecError::SchemaCompile("not an object".to_string());
+        assert!(err.to_string().contains("not an object"));
+    }
+}

--- a/crates/phantom-loop/src/exit.rs
+++ b/crates/phantom-loop/src/exit.rs
@@ -1,0 +1,137 @@
+//! Structured exit schema compiled from a raw JSON value.
+//!
+//! Every [`crate::LoopAgentSpec`] declares an `exit_schema` (raw `serde_json::Value`)
+//! describing what a successful loop-iteration result must look like. The
+//! reviewer-loop example (issue #650) carries something like:
+//!
+//! ```toml
+//! [agent.exit_schema]
+//! type = "object"
+//! required = ["pr_number", "decision"]
+//!
+//! [agent.exit_schema.properties.pr_number]
+//! type = "integer"
+//!
+//! [agent.exit_schema.properties.decision]
+//! enum = ["approved", "rejected", "needs_changes"]
+//! ```
+//!
+//! At spec-load time we compile that raw value into a reusable
+//! [`jsonschema::Validator`] wrapped in an [`std::sync::Arc`] so the eventual
+//! `LoopRunner` (C2) can share one schema across all iterations of a loop
+//! without re-compiling it on every result.
+
+use std::sync::Arc;
+
+use jsonschema::Validator;
+use serde_json::Value;
+
+use crate::error::LoopSpecError;
+
+/// Pre-compiled JSON Schema gating the typed "exit" payload that agents must
+/// emit at the end of each loop iteration.
+///
+/// `ExitSchema` is cheap to clone — the inner [`Validator`] sits behind an
+/// [`Arc`] so the future runner can hold one copy per spec and hand
+/// references to every iteration without bumping a reference count for
+/// validation alone.
+#[derive(Clone)]
+pub struct ExitSchema(pub Arc<Validator>);
+
+impl std::fmt::Debug for ExitSchema {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `Validator` does not implement `Debug`, so we elide its contents
+        // rather than leak its `Display` impl into our trait surface.
+        f.debug_struct("ExitSchema")
+            .field("compiled", &"<jsonschema::Validator>")
+            .finish()
+    }
+}
+
+impl ExitSchema {
+    /// Compile a raw JSON Schema value into a reusable [`Validator`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LoopSpecError::SchemaCompile`] if the value is not a valid
+    /// JSON Schema — for example, a non-object root, an unknown keyword in a
+    /// strict draft, or a `$ref` that fails to resolve.
+    pub fn compile(raw: &Value) -> Result<Self, LoopSpecError> {
+        let validator = jsonschema::validator_for(raw)
+            .map_err(|e| LoopSpecError::SchemaCompile(e.to_string()))?;
+        Ok(Self(Arc::new(validator)))
+    }
+
+    /// Check whether the given instance satisfies the schema.
+    ///
+    /// Returns `Ok(())` if the instance is valid, otherwise `Err(Vec<String>)`
+    /// where each string describes one validation failure. The `Vec` form
+    /// keeps the API allocation-free for the happy path and avoids leaking
+    /// the borrowing lifetimes that `jsonschema::ErrorIterator` carries.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` containing a non-empty `Vec` of human-readable error
+    /// messages when the instance fails to validate. The vector preserves
+    /// the order in which the underlying validator surfaced the errors.
+    pub fn validate(&self, instance: &Value) -> Result<(), Vec<String>> {
+        // `Validator::validate` returns `Err(ErrorIterator<'instance>)` on
+        // failure — we materialise the iterator into owned `String`s so
+        // callers don't need to hold the instance reference, and so we don't
+        // leak the upstream borrowing lifetimes through our public API.
+        match self.0.validate(instance) {
+            Ok(()) => Ok(()),
+            Err(errors) => Err(errors.map(|e| e.to_string()).collect()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn compile_accepts_simple_object_schema() {
+        let raw = json!({
+            "type": "object",
+            "required": ["x"],
+            "properties": {
+                "x": { "type": "integer" }
+            }
+        });
+        let schema = ExitSchema::compile(&raw).expect("compile");
+        // Valid instance.
+        schema
+            .validate(&json!({ "x": 1 }))
+            .expect("valid instance must pass");
+        // Missing required field.
+        assert!(schema.validate(&json!({})).is_err());
+        // Wrong type.
+        assert!(schema.validate(&json!({ "x": "str" })).is_err());
+    }
+
+    #[test]
+    fn compile_rejects_obviously_invalid_schema() {
+        // `type` must be a string or array of strings — a bare integer is a
+        // structural violation that the validator catches at compile time.
+        let raw = json!({ "type": 42 });
+        assert!(ExitSchema::compile(&raw).is_err());
+    }
+
+    #[test]
+    fn validate_returns_multiple_errors_in_aggregate() {
+        let raw = json!({
+            "type": "object",
+            "required": ["a", "b"],
+            "properties": {
+                "a": { "type": "integer" },
+                "b": { "type": "integer" }
+            }
+        });
+        let schema = ExitSchema::compile(&raw).expect("compile");
+        // Missing both required keys.
+        let err = schema.validate(&json!({})).unwrap_err();
+        assert!(!err.is_empty(), "expected at least one error");
+    }
+}

--- a/crates/phantom-loop/src/id.rs
+++ b/crates/phantom-loop/src/id.rs
@@ -1,0 +1,37 @@
+//! Stable identifiers for a running [`crate::LoopSpec`] instance.
+//!
+//! A [`LoopId`] is the runtime handle the (future) loop runner assigns when it
+//! materialises a spec — it is distinct from the user-chosen string id on
+//! [`crate::LoopSpec::id`], which exists at TOML-edit time. Future slices
+//! (C2 — runner) will mint these ids monotonically.
+
+use serde::{Deserialize, Serialize};
+
+/// Runtime handle for a single loop instance. Opaque to callers; future
+/// slices mint these via a monotonic counter inside the loop registry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct LoopId(pub u64);
+
+impl std::fmt::Display for LoopId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "loop#{}", self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loop_id_roundtrips_through_json() {
+        let id = LoopId(42);
+        let json = serde_json::to_string(&id).expect("serialize");
+        let back: LoopId = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, id);
+    }
+
+    #[test]
+    fn loop_id_display_uses_pound_prefix() {
+        assert_eq!(LoopId(7).to_string(), "loop#7");
+    }
+}

--- a/crates/phantom-loop/src/lib.rs
+++ b/crates/phantom-loop/src/lib.rs
@@ -1,0 +1,60 @@
+//! Loop overseer crate — types and spec parsing for repo-scoped autonomous loops.
+//!
+//! This is the C1 slice of issue [#650](https://github.com/jdmiranda/phantom/issues/650):
+//! the type-system foundation for repo-pointable loops (PR-finder, Reviewer,
+//! Implementer). Subsequent slices add:
+//!
+//! - **C2** — `LoopRunner` state machine, `LoopSource` trait implementations,
+//!   `LoopQueueRegistry`, and `LoopEffect` execution.
+//! - **C3** — `phantom loop` CLI subcommand.
+//!
+//! # Spec format
+//!
+//! A loop is declared by a TOML file at `<repo>/.phantom/loops/<name>.toml`.
+//! For example:
+//!
+//! ```toml
+//! id = "reviewer"
+//!
+//! [agent]
+//! role = "Actor"
+//! allow_tools = ["read_file", "gh_pr_review", "gh_pr_merge"]
+//! system_prompt = "Review the PR..."
+//!
+//! [agent.exit_schema]
+//! type = "object"
+//! required = ["pr_number", "decision"]
+//!
+//! [agent.exit_schema.properties.pr_number]
+//! type = "integer"
+//!
+//! [agent.exit_schema.properties.decision]
+//! enum = ["approved", "rejected", "needs_changes"]
+//!
+//! [source]
+//! kind = "gh_pr"
+//! repo = "jdmiranda/phantom"
+//!
+//! [source.predicate]
+//! state = "open"
+//! review_required = true
+//! ```
+//!
+//! Use [`load_spec`] (or [`parse_spec_str`] for in-memory specs) to obtain a
+//! [`LoopSpec`] paired with its compiled [`ExitSchema`].
+
+pub mod effect;
+pub mod error;
+pub mod exit;
+pub mod id;
+pub mod source;
+pub mod spec;
+
+pub use effect::{FieldMap, LoopEffect};
+pub use error::LoopSpecError;
+pub use exit::ExitSchema;
+pub use id::LoopId;
+pub use source::{GhPrPredicate, GhPrState, LoopSourceSpec};
+pub use spec::{
+    LoopAgentSpec, LoopPolicy, LoopQuarantinePolicy, LoopSpec, load_spec, parse_spec_str,
+};

--- a/crates/phantom-loop/src/source.rs
+++ b/crates/phantom-loop/src/source.rs
@@ -1,0 +1,182 @@
+//! Where a loop pulls work from.
+//!
+//! A [`LoopSourceSpec`] describes the *input side* of a loop: GitHub issues
+//! or PRs, an internal cross-loop queue, or a cron timer. The future runner
+//! (C2) will implement a `LoopSource` trait keyed on this enum's discriminant
+//! and produce a stream of typed `LoopMessage`s for each variant.
+
+use serde::{Deserialize, Serialize};
+
+/// Tagged union over the available loop input sources.
+///
+/// Encoded in TOML as:
+///
+/// ```toml
+/// [source]
+/// kind = "gh_pr"
+/// repo = "jdmiranda/phantom"
+///
+/// [source.predicate]
+/// state = "open"
+/// review_required = true
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum LoopSourceSpec {
+    /// Poll `gh issue list` against a repository.
+    ///
+    /// `query` accepts the same string the `gh` CLI accepts for `--search`;
+    /// `label` is a convenience filter equivalent to `--label`. When both are
+    /// `None` the source returns *all* open issues — narrowing is the
+    /// caller's responsibility.
+    GhIssues {
+        repo: String,
+        #[serde(default)]
+        label: Option<String>,
+        #[serde(default)]
+        query: Option<String>,
+    },
+
+    /// Poll `gh pr list` against a repository with a structured predicate.
+    GhPr {
+        repo: String,
+        #[serde(default)]
+        predicate: GhPrPredicate,
+    },
+
+    /// Pull from an in-process named queue. The PR-finder loop publishes
+    /// `LoopMessage`s into a named queue and the Reviewer loop drains it.
+    Queue { name: String },
+
+    /// Fire on a fixed interval. Used by agentless poll loops like PR-finder.
+    Cron { interval_seconds: u64 },
+}
+
+/// Structured predicate for filtering pull-request results.
+///
+/// Each `Some` field tightens the filter; `None` means "don't constrain".
+/// The boolean fields default to `false` because they describe additive
+/// constraints — `review_required = true` means *also* require that the
+/// PR is awaiting review, not the inverse.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default)]
+pub struct GhPrPredicate {
+    /// Restrict to PRs in this state. Defaults to [`GhPrState::Open`].
+    pub state: GhPrState,
+    /// Require the PR to be awaiting review.
+    pub review_required: bool,
+    /// Require the PR to have at least one failing CI check.
+    pub failing_ci: bool,
+    /// Restrict to PRs by this author.
+    pub author: Option<String>,
+    /// Restrict to PRs carrying this label.
+    pub label: Option<String>,
+}
+
+/// Whether to scope a [`LoopSourceSpec::GhPr`] query to open, closed, or all PRs.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum GhPrState {
+    /// Only open PRs. The default — almost every loop wants this.
+    #[default]
+    Open,
+    /// Only closed (merged or rejected) PRs.
+    Closed,
+    /// Every PR, regardless of state.
+    All,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gh_pr_state_defaults_to_open() {
+        assert_eq!(GhPrState::default(), GhPrState::Open);
+    }
+
+    #[test]
+    fn gh_pr_predicate_defaults_are_permissive() {
+        let p = GhPrPredicate::default();
+        assert_eq!(p.state, GhPrState::Open);
+        assert!(!p.review_required);
+        assert!(!p.failing_ci);
+        assert!(p.author.is_none());
+        assert!(p.label.is_none());
+    }
+
+    #[test]
+    fn loop_source_spec_deserializes_gh_pr_kind() {
+        let src: LoopSourceSpec = toml::from_str(
+            r#"
+            kind = "gh_pr"
+            repo = "jdmiranda/phantom"
+
+            [predicate]
+            state = "open"
+            review_required = true
+            "#,
+        )
+        .expect("parse gh_pr source");
+        match src {
+            LoopSourceSpec::GhPr { repo, predicate } => {
+                assert_eq!(repo, "jdmiranda/phantom");
+                assert_eq!(predicate.state, GhPrState::Open);
+                assert!(predicate.review_required);
+            }
+            other => panic!("expected GhPr, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn loop_source_spec_deserializes_cron_kind() {
+        let src: LoopSourceSpec = toml::from_str(
+            r#"
+            kind = "cron"
+            interval_seconds = 300
+            "#,
+        )
+        .expect("parse cron source");
+        match src {
+            LoopSourceSpec::Cron { interval_seconds } => {
+                assert_eq!(interval_seconds, 300);
+            }
+            other => panic!("expected Cron, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn loop_source_spec_deserializes_queue_kind() {
+        let src: LoopSourceSpec = toml::from_str(
+            r#"
+            kind = "queue"
+            name = "review-queue"
+            "#,
+        )
+        .expect("parse queue source");
+        match src {
+            LoopSourceSpec::Queue { name } => assert_eq!(name, "review-queue"),
+            other => panic!("expected Queue, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn loop_source_spec_deserializes_gh_issues_kind() {
+        let src: LoopSourceSpec = toml::from_str(
+            r#"
+            kind = "gh_issues"
+            repo = "jdmiranda/phantom"
+            label = "bug"
+            "#,
+        )
+        .expect("parse gh_issues source");
+        match src {
+            LoopSourceSpec::GhIssues { repo, label, query } => {
+                assert_eq!(repo, "jdmiranda/phantom");
+                assert_eq!(label.as_deref(), Some("bug"));
+                assert!(query.is_none());
+            }
+            other => panic!("expected GhIssues, got {other:?}"),
+        }
+    }
+}

--- a/crates/phantom-loop/src/spec.rs
+++ b/crates/phantom-loop/src/spec.rs
@@ -1,0 +1,314 @@
+//! The top-level [`LoopSpec`] and its sub-types.
+//!
+//! A `LoopSpec` is the TOML-deserialised description of one repo-scoped loop:
+//! a (possibly absent) agent, a source, an exit schema, post-iteration
+//! effects, and a quarantine policy. The runner (C2) consumes the spec; this
+//! slice does no execution.
+//!
+//! # Why [`LoopPolicy`] mirrors [`phantom_agents::policy::AgentPolicy`]
+//!
+//! [`phantom_agents::policy::AgentPolicy`] is the policy the agent crate
+//! enforces at runtime, but it does *not* derive `serde`. Since C1 is
+//! deliberately scoped to *the new crate plus the workspace `Cargo.toml`*,
+//! we cannot bolt serde derives onto `AgentPolicy` from here. The clean
+//! workaround is to keep a TOML-shaped mirror inside `phantom-loop` and
+//! convert at the boundary the runner will own in C2.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use crate::effect::LoopEffect;
+use crate::error::LoopSpecError;
+use crate::exit::ExitSchema;
+use crate::source::LoopSourceSpec;
+
+// ---------------------------------------------------------------------------
+// Top-level spec
+// ---------------------------------------------------------------------------
+
+/// Deserialised view of a `<repo>/.phantom/loops/<name>.toml` file.
+///
+/// This struct is intentionally *data only*. The runtime LoopRunner that
+/// consumes it lives in a future slice (C2) and will hold an [`ExitSchema`]
+/// alongside this spec rather than embedding the compiled validator inside
+/// the spec value itself (so the spec stays cheap to clone and inspect).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct LoopSpec {
+    /// User-chosen identifier — `reviewer`, `pr-finder`, `implementer`.
+    /// Distinct from the runtime [`crate::LoopId`] which the runner assigns.
+    pub id: String,
+
+    /// The agent that drives each iteration. `None` for agentless loops
+    /// like PR-finder, which just transform inputs into queue messages
+    /// without any LLM in the loop.
+    #[serde(default)]
+    pub agent: Option<LoopAgentSpec>,
+
+    /// Where iteration inputs come from. Always present.
+    pub source: LoopSourceSpec,
+
+    /// Effects fired after each iteration completes with a valid exit.
+    /// Defaults to no effects — perfectly fine for a watcher-style loop
+    /// that only logs.
+    #[serde(default)]
+    pub on_complete: Vec<LoopEffect>,
+
+    /// Maximum number of in-flight iterations. Loops are sequential by
+    /// default (1) so the user must opt in to parallelism explicitly.
+    #[serde(default = "default_max_concurrent")]
+    pub max_concurrent: u8,
+
+    /// What to do when an iteration's exit fails to validate against the
+    /// schema. Defaults to [`LoopQuarantinePolicy::SkipAndContinue`] —
+    /// matching the loop-overseer expectation that one bad PR shouldn't
+    /// stop the entire reviewer.
+    #[serde(default)]
+    pub on_quarantine: LoopQuarantinePolicy,
+}
+
+const fn default_max_concurrent() -> u8 {
+    1
+}
+
+// ---------------------------------------------------------------------------
+// Agent spec — TOML-friendly view of the per-iteration agent config
+// ---------------------------------------------------------------------------
+
+/// Per-iteration agent configuration.
+///
+/// The runner (C2) spawns a fresh agent of the given role for each iteration,
+/// optionally narrowing the role's default tool whitelist via `allow_tools`,
+/// installing the `system_prompt`, and tagging the iteration result with the
+/// compiled [`ExitSchema`].
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct LoopAgentSpec {
+    /// Which agent role to spawn — typically [`phantom_agents::role::AgentRole::Actor`]
+    /// for review/implementer loops since those need `Act` capability.
+    pub role: phantom_agents::role::AgentRole,
+
+    /// Optional intersection on top of the role's default tool whitelist.
+    /// `None` means "no narrowing — use the role's full default whitelist
+    /// as-is". An empty `Some(vec![])` means "deny everything", which is
+    /// almost never what the user wants but is allowed for completeness.
+    #[serde(default)]
+    pub allow_tools: Option<Vec<String>>,
+
+    /// Prompt installed at agent spawn. Carries the loop's task description
+    /// and any role-specific framing.
+    pub system_prompt: String,
+
+    /// Raw JSON Schema (verbatim from TOML) describing the exit payload.
+    /// `load_spec` compiles this into an [`ExitSchema`] at parse time;
+    /// the runner uses the compiled form.
+    pub exit_schema: serde_json::Value,
+
+    /// Per-agent runtime policy (timeouts, retries, auto-approve, planning).
+    /// Mirrors [`phantom_agents::policy::AgentPolicy`] — see the module-level
+    /// note on why this is a mirror rather than a direct reuse.
+    #[serde(default)]
+    pub policy: LoopPolicy,
+}
+
+// ---------------------------------------------------------------------------
+// LoopPolicy — TOML-shaped mirror of phantom_agents::policy::AgentPolicy
+// ---------------------------------------------------------------------------
+
+/// Serde-friendly mirror of [`phantom_agents::policy::AgentPolicy`].
+///
+/// Field semantics are identical to the upstream type — see its rustdoc for
+/// the canonical description. The wrapper exists only because `AgentPolicy`
+/// does not derive `serde` and this C1 slice is scoped strictly to the new
+/// crate plus the workspace `Cargo.toml`.
+///
+/// The [`From`] impl below converts to the upstream type for runtime use.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct LoopPolicy {
+    /// Maps to [`phantom_agents::policy::AgentPolicy::max_attempts`].
+    #[serde(default = "default_max_attempts")]
+    pub max_attempts: u32,
+    /// Maps to [`phantom_agents::policy::AgentPolicy::timeout_seconds`].
+    #[serde(default = "default_timeout_seconds")]
+    pub timeout_seconds: u64,
+    /// Maps to [`phantom_agents::policy::AgentPolicy::auto_approve`].
+    #[serde(default)]
+    pub auto_approve: bool,
+    /// Maps to [`phantom_agents::policy::AgentPolicy::skip_planning`].
+    #[serde(default)]
+    pub skip_planning: bool,
+}
+
+const fn default_max_attempts() -> u32 {
+    3
+}
+
+const fn default_timeout_seconds() -> u64 {
+    1800
+}
+
+impl Default for LoopPolicy {
+    fn default() -> Self {
+        Self {
+            max_attempts: default_max_attempts(),
+            timeout_seconds: default_timeout_seconds(),
+            auto_approve: false,
+            skip_planning: false,
+        }
+    }
+}
+
+impl From<LoopPolicy> for phantom_agents::policy::AgentPolicy {
+    fn from(p: LoopPolicy) -> Self {
+        Self {
+            max_attempts: p.max_attempts,
+            timeout_seconds: p.timeout_seconds,
+            auto_approve: p.auto_approve,
+            skip_planning: p.skip_planning,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Quarantine policy
+// ---------------------------------------------------------------------------
+
+/// How the runner should react when an iteration's exit payload fails to
+/// validate against the [`ExitSchema`].
+///
+/// The default is [`Self::SkipAndContinue`] — for the typical loop-overseer
+/// use case (reviewer, implementer) you want to move past one bad iteration
+/// rather than halting the entire loop.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LoopQuarantinePolicy {
+    /// Treat the failure as terminal and stop the loop.
+    FailAndStop,
+    /// Drop the offending input and pick up the next one.
+    #[default]
+    SkipAndContinue,
+    /// Halt the loop and wait for external manual clearance.
+    Park,
+}
+
+// ---------------------------------------------------------------------------
+// Spec loading
+// ---------------------------------------------------------------------------
+
+/// Read a TOML file at `path`, parse it into a [`LoopSpec`], and compile the
+/// agent's exit schema into an [`ExitSchema`].
+///
+/// Returns both values so the runner can hold the compiled validator
+/// alongside the spec data. For agentless specs (no `[agent]` section), the
+/// returned `Option<ExitSchema>` is `None`.
+///
+/// # Errors
+///
+/// - [`LoopSpecError::Io`] if `path` cannot be read.
+/// - [`LoopSpecError::TomlParse`] if the TOML is malformed or fails type
+///   constraints.
+/// - [`LoopSpecError::SchemaCompile`] if the embedded `exit_schema` is not a
+///   valid JSON Schema.
+/// - [`LoopSpecError::InvalidField`] for structural issues serde alone
+///   cannot catch (e.g. an empty `id`).
+pub fn load_spec(path: &Path) -> Result<(LoopSpec, Option<ExitSchema>), LoopSpecError> {
+    let raw = std::fs::read_to_string(path).map_err(|source| LoopSpecError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    parse_spec_str(&raw).map_err(|e| match e {
+        // Re-annotate the bare TomlParseRaw with the file path so end users
+        // see *which* spec is malformed.
+        LoopSpecError::TomlParseRaw(source) => LoopSpecError::TomlParse {
+            path: path.to_path_buf(),
+            source,
+        },
+        other => other,
+    })
+}
+
+/// Parse a [`LoopSpec`] from an in-memory TOML string.
+///
+/// Used by tests and by callers that load specs from a non-filesystem
+/// source. Identical semantics to [`load_spec`] minus the IO step.
+///
+/// # Errors
+///
+/// Same as [`load_spec`] minus the [`LoopSpecError::Io`] variant.
+pub fn parse_spec_str(raw: &str) -> Result<(LoopSpec, Option<ExitSchema>), LoopSpecError> {
+    let spec: LoopSpec = toml::from_str(raw)?;
+
+    if spec.id.trim().is_empty() {
+        return Err(LoopSpecError::InvalidField {
+            field: "id",
+            reason: "must not be empty".to_string(),
+        });
+    }
+
+    let schema = match spec.agent.as_ref() {
+        Some(agent) => Some(ExitSchema::compile(&agent.exit_schema)?),
+        None => None,
+    };
+
+    Ok((spec, schema))
+}
+
+// ---------------------------------------------------------------------------
+// Tests — module-local, unit-only. End-to-end TOML round-trip lives in
+// `tests/spec_roundtrip.rs`.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loop_policy_default_matches_agent_policy_default() {
+        let lp = LoopPolicy::default();
+        let ap = phantom_agents::policy::AgentPolicy::default();
+        assert_eq!(lp.max_attempts, ap.max_attempts);
+        assert_eq!(lp.timeout_seconds, ap.timeout_seconds);
+        assert_eq!(lp.auto_approve, ap.auto_approve);
+        assert_eq!(lp.skip_planning, ap.skip_planning);
+    }
+
+    #[test]
+    fn loop_policy_converts_to_agent_policy() {
+        let lp = LoopPolicy {
+            max_attempts: 5,
+            timeout_seconds: 600,
+            auto_approve: true,
+            skip_planning: true,
+        };
+        let ap: phantom_agents::policy::AgentPolicy = lp.into();
+        assert_eq!(ap.max_attempts, 5);
+        assert_eq!(ap.timeout_seconds, 600);
+        assert!(ap.auto_approve);
+        assert!(ap.skip_planning);
+    }
+
+    #[test]
+    fn empty_id_is_rejected() {
+        let toml_src = r#"
+            id = ""
+
+            [source]
+            kind = "cron"
+            interval_seconds = 60
+        "#;
+        let err = parse_spec_str(toml_src).expect_err("empty id must error");
+        match err {
+            LoopSpecError::InvalidField { field, .. } => assert_eq!(field, "id"),
+            other => panic!("expected InvalidField, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn quarantine_policy_defaults_to_skip_and_continue() {
+        assert_eq!(LoopQuarantinePolicy::default(), LoopQuarantinePolicy::SkipAndContinue);
+    }
+
+    #[test]
+    fn max_concurrent_defaults_to_one() {
+        assert_eq!(default_max_concurrent(), 1);
+    }
+}

--- a/crates/phantom-loop/tests/spec_roundtrip.rs
+++ b/crates/phantom-loop/tests/spec_roundtrip.rs
@@ -1,0 +1,209 @@
+//! End-to-end TOML round-trip for [`phantom_loop::LoopSpec`].
+//!
+//! These tests exercise the full parse path: serde → semantic validation →
+//! JSON Schema compilation. They cover the two canonical shapes from
+//! issue #650:
+//!
+//! - A reviewer-style loop with an `[agent]` section and `gh_pr` source.
+//! - An agentless PR-finder loop with a `cron` source and no `[agent]`.
+
+use phantom_loop::{
+    GhPrState, LoopEffect, LoopQuarantinePolicy, LoopSourceSpec, parse_spec_str,
+};
+use serde_json::json;
+
+const REVIEWER_TOML: &str = r#"
+id = "reviewer"
+max_concurrent = 2
+
+[agent]
+role = "Actor"
+allow_tools = ["read_file", "gh_pr_review", "gh_pr_merge"]
+system_prompt = "Review the PR for correctness and style. Approve, reject, or request changes."
+
+[agent.exit_schema]
+type = "object"
+required = ["pr_number", "decision"]
+additionalProperties = false
+
+[agent.exit_schema.properties.pr_number]
+type = "integer"
+
+[agent.exit_schema.properties.decision]
+enum = ["approved", "rejected", "needs_changes"]
+
+[agent.policy]
+max_attempts = 2
+timeout_seconds = 900
+
+[source]
+kind = "gh_pr"
+repo = "jdmiranda/phantom"
+
+[source.predicate]
+state = "open"
+review_required = true
+
+[[on_complete]]
+kind = "log_to_bus"
+event_kind = "pr_reviewed"
+"#;
+
+#[test]
+fn reviewer_spec_roundtrips_with_compiled_schema() {
+    let (spec, schema) = parse_spec_str(REVIEWER_TOML).expect("parse reviewer spec");
+    let schema = schema.expect("reviewer spec has an [agent] so schema must be Some");
+
+    // Identity + structural assertions on the spec itself.
+    assert_eq!(spec.id, "reviewer");
+    assert_eq!(spec.max_concurrent, 2);
+    assert_eq!(spec.on_quarantine, LoopQuarantinePolicy::SkipAndContinue);
+
+    let agent = spec.agent.as_ref().expect("reviewer spec has an agent");
+    assert_eq!(agent.role, phantom_agents::role::AgentRole::Actor);
+
+    let allow_tools = agent
+        .allow_tools
+        .as_ref()
+        .expect("reviewer narrows allow_tools");
+    assert!(allow_tools.iter().any(|t| t == "read_file"));
+    assert!(allow_tools.iter().any(|t| t == "gh_pr_review"));
+    assert!(allow_tools.iter().any(|t| t == "gh_pr_merge"));
+
+    // Policy was overridden in the TOML — both fields must reflect the override.
+    assert_eq!(agent.policy.max_attempts, 2);
+    assert_eq!(agent.policy.timeout_seconds, 900);
+    // Fields not present in TOML take the LoopPolicy defaults.
+    assert!(!agent.policy.auto_approve);
+    assert!(!agent.policy.skip_planning);
+
+    // Source must match GhPr { state = Open, review_required = true }.
+    match &spec.source {
+        LoopSourceSpec::GhPr { repo, predicate } => {
+            assert_eq!(repo, "jdmiranda/phantom");
+            assert_eq!(predicate.state, GhPrState::Open);
+            assert!(predicate.review_required);
+            assert!(!predicate.failing_ci);
+        }
+        other => panic!("expected GhPr, got {other:?}"),
+    }
+
+    // One on_complete effect: LogToBus { event_kind: "pr_reviewed" }.
+    assert_eq!(spec.on_complete.len(), 1);
+    match &spec.on_complete[0] {
+        LoopEffect::LogToBus { event_kind } => assert_eq!(event_kind, "pr_reviewed"),
+        other => panic!("expected LogToBus, got {other:?}"),
+    }
+
+    // Compiled exit_schema accepts a well-formed payload.
+    schema
+        .validate(&json!({ "pr_number": 1234, "decision": "approved" }))
+        .expect("valid exit payload");
+
+    // ... and rejects type-mismatched pr_number.
+    assert!(
+        schema
+            .validate(&json!({ "pr_number": "not_a_number", "decision": "approved" }))
+            .is_err(),
+        "string pr_number must be rejected"
+    );
+
+    // ... and rejects an unknown enum value for decision.
+    assert!(
+        schema
+            .validate(&json!({ "pr_number": 1, "decision": "bogus_value" }))
+            .is_err(),
+        "out-of-enum decision must be rejected"
+    );
+
+    // ... and rejects a payload missing both required fields.
+    assert!(
+        schema.validate(&json!({})).is_err(),
+        "empty object must be rejected"
+    );
+}
+
+const PR_FINDER_TOML: &str = r#"
+id = "pr-finder"
+
+[source]
+kind = "cron"
+interval_seconds = 300
+
+[[on_complete]]
+kind = "enqueue_to"
+queue = "review-queue"
+
+[[on_complete.fields]]
+from = "result.pr_url"
+to = "target_pr"
+"#;
+
+#[test]
+fn agentless_pr_finder_spec_parses() {
+    let (spec, schema) = parse_spec_str(PR_FINDER_TOML).expect("parse pr-finder spec");
+
+    assert_eq!(spec.id, "pr-finder");
+    assert!(spec.agent.is_none(), "PR-finder must be agentless");
+    assert!(
+        schema.is_none(),
+        "agentless specs return no compiled exit schema"
+    );
+
+    match &spec.source {
+        LoopSourceSpec::Cron { interval_seconds } => assert_eq!(*interval_seconds, 300),
+        other => panic!("expected Cron, got {other:?}"),
+    }
+
+    assert_eq!(spec.on_complete.len(), 1);
+    match &spec.on_complete[0] {
+        LoopEffect::EnqueueTo { queue, fields } => {
+            assert_eq!(queue, "review-queue");
+            assert_eq!(fields.len(), 1);
+            assert_eq!(fields[0].from, "result.pr_url");
+            assert_eq!(fields[0].to, "target_pr");
+        }
+        other => panic!("expected EnqueueTo, got {other:?}"),
+    }
+
+    // Defaults: max_concurrent=1, on_quarantine=SkipAndContinue.
+    assert_eq!(spec.max_concurrent, 1);
+    assert_eq!(spec.on_quarantine, LoopQuarantinePolicy::SkipAndContinue);
+}
+
+#[test]
+fn malformed_toml_surfaces_parse_error() {
+    let (err_kind, has_msg) = match parse_spec_str("this is = not = valid = toml") {
+        Err(e) => (format!("{e:?}"), !e.to_string().is_empty()),
+        Ok(_) => panic!("malformed TOML must error"),
+    };
+    assert!(has_msg, "error must produce a non-empty Display");
+    assert!(
+        err_kind.contains("Toml"),
+        "expected a TomlParse* variant, got {err_kind}"
+    );
+}
+
+#[test]
+fn invalid_exit_schema_fails_at_compile_time() {
+    let bad = r#"
+        id = "bad-schema"
+
+        [agent]
+        role = "Actor"
+        system_prompt = "noop"
+
+        [agent.exit_schema]
+        type = 42
+
+        [source]
+        kind = "cron"
+        interval_seconds = 60
+    "#;
+    let err = parse_spec_str(bad).expect_err("invalid schema must error");
+    let kind = format!("{err:?}");
+    assert!(
+        kind.contains("SchemaCompile"),
+        "expected SchemaCompile variant, got {kind}"
+    );
+}


### PR DESCRIPTION
## Summary

C1 of the loop-overseer epic ([#650](https://github.com/jdmiranda/phantom/issues/650)). Scaffolds a new `phantom-loop` crate carrying the type-system foundation for repo-pointable autonomous loops (PR-finder, Reviewer, Implementer). This slice is **types and TOML parsing only** — no runner, no execution, no CLI. Issue #650 stays open and tracks C2 (`LoopRunner` + queue registry + effect dispatch) and C3 (`phantom loop` CLI subcommand).

## Files created

- `crates/phantom-loop/Cargo.toml` — deps on `phantom-agents`, `serde`, `serde_json`, `toml = "0.8"`, `jsonschema = "0.20"`, `thiserror = "2"`.
- `crates/phantom-loop/src/lib.rs` — module wiring and crate-level docs.
- `crates/phantom-loop/src/id.rs` — `LoopId` newtype.
- `crates/phantom-loop/src/error.rs` — `LoopSpecError` (`Io` / `TomlParse` / `TomlParseRaw` / `SchemaCompile` / `InvalidField`).
- `crates/phantom-loop/src/exit.rs` — `ExitSchema` wrapping `Arc<jsonschema::Validator>`.
- `crates/phantom-loop/src/source.rs` — `LoopSourceSpec` tagged enum + `GhPrPredicate` + `GhPrState`.
- `crates/phantom-loop/src/effect.rs` — `LoopEffect` tagged enum + `FieldMap`.
- `crates/phantom-loop/src/spec.rs` — `LoopSpec`, `LoopAgentSpec`, `LoopPolicy`, `LoopQuarantinePolicy`, `load_spec`, `parse_spec_str`.
- `crates/phantom-loop/tests/spec_roundtrip.rs` — 4 integration tests (reviewer round-trip + schema validation, agentless PR-finder, malformed TOML, invalid JSON Schema).

Workspace `Cargo.toml` adds `crates/phantom-loop` to `[workspace.members]`. `Cargo.lock` updates pull in `jsonschema 0.20` and its transitive deps.

## Public API

Types: `LoopSpec`, `LoopAgentSpec`, `LoopPolicy`, `LoopQuarantinePolicy`, `LoopSourceSpec`, `GhPrPredicate`, `GhPrState`, `LoopEffect`, `FieldMap`, `ExitSchema`, `LoopId`, `LoopSpecError`.

Functions: `load_spec(&Path) -> Result<(LoopSpec, Option<ExitSchema>), LoopSpecError>`, `parse_spec_str(&str) -> Result<(LoopSpec, Option<ExitSchema>), LoopSpecError>`.

`From<LoopPolicy> for phantom_agents::policy::AgentPolicy` for the C2 runner to convert at the boundary.

## Notes

- `phantom_agents::policy::AgentPolicy` does not derive `serde` on `main` and the C1 scope explicitly forbids editing other crates, so a serde-friendly `LoopPolicy` mirror lives inside `phantom-loop` with a `From` impl. C2 can either keep the conversion or land a separate PR that derives serde on `AgentPolicy` upstream.
- `jsonschema 0.20` deprecates the old `JSONSchema` type in favour of `Validator` + `validator_for`; the wrapper uses the modern API. `Validator::validate` returns `Result<(), ErrorIterator<'instance>>` — `ExitSchema::validate` materialises the iterator into owned `Vec<String>` to avoid leaking the upstream lifetimes through our API.
- `LoopSpec` enums use `#[serde(tag = "kind", rename_all = "snake_case")]` for TOML-friendly `kind = "gh_pr"` / `kind = "cron"` discriminants.
- Default `max_concurrent = 1` (sequential by default; parallelism is opt-in).
- Default `on_quarantine = SkipAndContinue` so one bad PR doesn't halt a reviewer.

## Pre-PR check numbers

`./scripts/pre-pr-check.sh phantom-loop` — all three gates PASS:

- `cargo build -p phantom-loop` — PASS.
- `cargo test -p phantom-loop` — PASS (22 unit + 4 integration = **26 tests**, 0 failed).
- `cargo clippy -p phantom-loop -- -D warnings` — PASS.

Workspace check confirmed via `git stash` / `cargo check --workspace` / `git stash pop`: the only `cargo check --workspace` failures (`phantom-app/src/settings_ui.rs` E0308/E0614 in `value.clamp(...)`) are **pre-existing on `origin/main`** and unrelated to this PR.

## Status of #650

Stays open. This PR is **C1 of 3**:

- **C1 (this PR)** — types + TOML parsing.
- **C2** — `LoopRunner` state machine, `LoopSource` trait impls, `LoopQueueRegistry`, `LoopEffect` execution.
- **C3** — `phantom loop` CLI subcommand.

## Test plan

- [x] `cargo test -p phantom-loop` — 26/26 pass.
- [x] `cargo clippy -p phantom-loop -- -D warnings` — clean.
- [x] `cargo build -p phantom-loop` — clean.
- [x] Pre-existing `phantom-app/settings_ui.rs` errors confirmed to exist on `origin/main` without this PR's changes.
- [ ] Manual TOML round-trip via the reviewer fixture from `tests/spec_roundtrip.rs` (already covered by the integration test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)