### PR TITLE
feat(loops): MVP loop specs for phantom-on-phantom self-improvement

### DIFF
--- a/.phantom/loops/implementer.toml
+++ b/.phantom/loops/implementer.toml
@@ -1,0 +1,60 @@
+# Implementer loop — drains implementer-queue and ships PRs.
+#
+# Role
+# ----
+# Spawns an Actor agent per issue. The agent reads the relevant code,
+# writes tests, implements the change, runs cargo test, pushes a branch,
+# and opens a PR via gh. The PR URL is forwarded to the review-queue via
+# the on_complete effect so the reviewer loop picks it up on its next
+# drain.
+#
+# Tool whitelist is wider than reviewer's: file mutation plus run_command
+# (for cargo / gh) plus the PR creation tool. Same gh_pr_* caveat as the
+# reviewer spec: C3 resolves these names.
+
+id = "implementer"
+max_concurrent = 1
+on_quarantine = "skip_and_continue"
+
+[agent]
+role = "Actor"
+allow_tools = ["read_file", "write_file", "edit_file", "run_command", "gh_pr_create"]
+system_prompt = """
+You are an implementation agent for the Phantom repo (jdmiranda/phantom).
+Pull the assigned issue. Read the relevant code. Write tests first. Implement the change. Run cargo test. Push a branch. Open a PR.
+You MUST call complete_task with {issue_number: <int>, pr_url: <string>, summary: <string>}.
+"""
+
+[agent.policy]
+auto_approve = true
+timeout_seconds = 1800
+
+[agent.exit_schema]
+type = "object"
+required = ["issue_number", "pr_url", "summary"]
+
+[agent.exit_schema.properties.issue_number]
+type = "integer"
+
+[agent.exit_schema.properties.pr_url]
+type = "string"
+format = "uri"
+
+[agent.exit_schema.properties.summary]
+type = "string"
+
+[source]
+kind = "queue"
+name = "implementer-queue"
+
+[[on_complete]]
+kind = "enqueue_to"
+queue = "review-queue"
+
+[[on_complete.fields]]
+from = "result.pr_url"
+to = "pr_url"
+
+[[on_complete.fields]]
+from = "result.issue_number"
+to = "issue_number"

--- a/.phantom/loops/pr_finder.toml
+++ b/.phantom/loops/pr_finder.toml
@@ -1,0 +1,64 @@
+# PR-finder loop — agentless watcher for the jdmiranda/phantom repo.
+#
+# Role
+# ----
+# Polls the GitHub PR list and routes work to the reviewer / implementer
+# queues. Agentless: there is no LLM in this loop. The source itself is the
+# input transform, and on_complete dispatches messages into the cross-loop
+# queue registry.
+#
+# C1 schema gaps surfaced while writing this spec (flag for C2/C3):
+#
+# 1. The brief calls for `kind = "cron"` with a Poll-then-Enqueue effect
+#    chain. The C1 LoopEffect enum has no `PollGhPr` variant — the only
+#    effect types are EnqueueTo, LogToBus, StopLoop. A pure cron source
+#    with no body produces no payload, so EnqueueTo.fields referencing
+#    `result.*` cannot resolve. We adopt cron here as the brief specifies
+#    and leave `fields = []`; C2 will need to either (a) add a `PollGhPr`
+#    or generalised `Poll` effect, or (b) prefer LoopSourceSpec::GhPr as
+#    the canonical pattern for "scan PRs and fan out".
+#
+# 2. The brief asks for routing to "review-queue OR implementer-queue as
+#    appropriate" — i.e. conditional fan-out based on PR state
+#    (review_required → review-queue, failing_ci → implementer-queue).
+#    LoopEffect::EnqueueTo has no predicate field; every listed effect
+#    fires unconditionally. We split the intent across two EnqueueTo
+#    entries below; a future schema extension could attach a predicate
+#    (e.g. `[on_complete.when]`) to gate effects on result payload.
+#
+# 3. There is no `LoopAgentSpec::None` variant — agentless is expressed by
+#    omitting the [agent] table entirely. This works (the roundtrip test
+#    `agentless_pr_finder_spec_parses` confirms it), but means there is no
+#    way for an agentless loop to declare an `exit_schema`. That is fine
+#    for pure source-to-queue routing but limits what an agentless body
+#    can do.
+
+id = "pr-finder"
+max_concurrent = 1
+on_quarantine = "skip_and_continue"
+
+# Cron tick every 5 minutes. C2 will need to teach the runner what
+# "iterate on a cron tick" means for an agentless loop — likely "fire the
+# source poll, then dispatch on_complete effects with a synthesised
+# result payload".
+[source]
+kind = "cron"
+interval_seconds = 300
+
+# Fan out: each tick observes the open PR list (via the runner's GH
+# helper, once C2 implements it) and forwards routing decisions.
+#
+# Until conditional-routing schema gap (#2) is resolved, both effects
+# fire on every tick. The runner must filter by payload in C2; one
+# acceptable shape is to attach the PR list as `result.prs` and let the
+# EnqueueTo step iterate.
+
+[[on_complete]]
+kind = "enqueue_to"
+queue = "review-queue"
+fields = []
+
+[[on_complete]]
+kind = "enqueue_to"
+queue = "implementer-queue"
+fields = []

--- a/.phantom/loops/reviewer.toml
+++ b/.phantom/loops/reviewer.toml
@@ -1,0 +1,51 @@
+# Reviewer loop — drains the review-queue and decides on open PRs.
+#
+# Role
+# ----
+# Spawns an Actor agent per PR pulled off `review-queue`. The agent reads
+# the diff, runs whatever sanity checks the system prompt instructs, and
+# emits a structured decision via complete_task. The exit schema gates
+# the payload — a malformed decision quarantines that PR rather than
+# halting the entire loop.
+#
+# Tool whitelist: read-only filesystem plus the two gh PR write
+# operations the reviewer is allowed to call. Per the issue #650
+# decision note, gh_pr_* tool names are not yet ToolType variants on
+# main; C3 will need to resolve those (likely via shelled RunCommand
+# with a tightened system prompt, or by extending ToolType).
+
+id = "reviewer"
+max_concurrent = 1
+on_quarantine = "skip_and_continue"
+
+[agent]
+role = "Actor"
+allow_tools = ["read_file", "gh_pr_review", "gh_pr_merge"]
+system_prompt = """
+You are a code reviewer for the Phantom repo (jdmiranda/phantom).
+Pull the assigned PR. Read the diff. Verify the change is sound, tested, and matches the issue scope.
+You MUST call complete_task with {pr_number: <int>, decision: "approved" | "changes_requested" | "merged"}.
+"""
+
+[agent.policy]
+auto_approve = true
+timeout_seconds = 1200
+
+[agent.exit_schema]
+type = "object"
+required = ["pr_number", "decision"]
+
+[agent.exit_schema.properties.pr_number]
+type = "integer"
+
+[agent.exit_schema.properties.decision]
+type = "string"
+enum = ["approved", "changes_requested", "merged"]
+
+[source]
+kind = "queue"
+name = "review-queue"
+
+[[on_complete]]
+kind = "log_to_bus"
+event_kind = "reviewer.decision"

--- a/crates/phantom-loop/tests/mvp_specs.rs
+++ b/crates/phantom-loop/tests/mvp_specs.rs
@@ -1,0 +1,301 @@
+//! Validation for the three MVP loop spec TOML files committed at the
+//! repo root in `.phantom/loops/`. These are the day-one specs the loop
+//! overseer consumes when the user runs `phantom loop run` against the
+//! `jdmiranda/phantom` repo itself.
+//!
+//! Until C3 wires the CLI, this test is the only consumer that proves
+//! the three specs parse cleanly against the C1 schema. If a future
+//! schema change breaks compatibility with one of these specs, this
+//! test fails loudly rather than silently shipping broken fixtures.
+//!
+//! Layout
+//! ------
+//! `CARGO_MANIFEST_DIR` is `<repo>/crates/phantom-loop`, so the specs
+//! live at `<CARGO_MANIFEST_DIR>/../../.phantom/loops/<name>.toml`.
+
+use std::path::PathBuf;
+
+use phantom_loop::{LoopEffect, LoopQuarantinePolicy, LoopSourceSpec, load_spec};
+use serde_json::json;
+
+// ---------------------------------------------------------------------------
+// Path helper
+// ---------------------------------------------------------------------------
+
+fn loops_dir() -> PathBuf {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("phantom-loop manifest sits two levels below the repo root")
+        .join(".phantom")
+        .join("loops")
+}
+
+fn spec_path(name: &str) -> PathBuf {
+    loops_dir().join(format!("{name}.toml"))
+}
+
+// ---------------------------------------------------------------------------
+// pr_finder.toml — agentless cron-driven router
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pr_finder_spec_parses_as_agentless_cron() {
+    let path = spec_path("pr_finder");
+    assert!(
+        path.exists(),
+        "missing fixture: {} — the C1 MVP specs live at .phantom/loops/",
+        path.display()
+    );
+
+    let (spec, schema) = load_spec(&path).expect("pr_finder.toml must parse against C1 schema");
+
+    assert_eq!(spec.id, "pr-finder");
+    assert!(
+        spec.agent.is_none(),
+        "pr_finder is agentless — no [agent] table expected"
+    );
+    assert!(
+        schema.is_none(),
+        "agentless specs return no compiled exit schema"
+    );
+
+    // Source must be Cron at 5-minute cadence.
+    match &spec.source {
+        LoopSourceSpec::Cron { interval_seconds } => {
+            assert_eq!(*interval_seconds, 300, "expected 5-minute tick");
+        }
+        other => panic!("expected Cron source, got {other:?}"),
+    }
+
+    // Two enqueue effects — one per downstream queue.
+    assert_eq!(
+        spec.on_complete.len(),
+        2,
+        "pr_finder fans out to review-queue and implementer-queue"
+    );
+    let queues: Vec<&str> = spec
+        .on_complete
+        .iter()
+        .filter_map(|e| match e {
+            LoopEffect::EnqueueTo { queue, .. } => Some(queue.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        queues.contains(&"review-queue"),
+        "pr_finder must route to review-queue, got {queues:?}"
+    );
+    assert!(
+        queues.contains(&"implementer-queue"),
+        "pr_finder must route to implementer-queue, got {queues:?}"
+    );
+
+    // Sequential by default; skip-and-continue on quarantine.
+    assert_eq!(spec.max_concurrent, 1);
+    assert_eq!(spec.on_quarantine, LoopQuarantinePolicy::SkipAndContinue);
+}
+
+// ---------------------------------------------------------------------------
+// reviewer.toml — Actor agent draining review-queue
+// ---------------------------------------------------------------------------
+
+#[test]
+fn reviewer_spec_parses_and_schema_gates_payloads() {
+    let path = spec_path("reviewer");
+    assert!(path.exists(), "missing fixture: {}", path.display());
+
+    let (spec, schema) = load_spec(&path).expect("reviewer.toml must parse against C1 schema");
+    let schema = schema.expect("reviewer has [agent] so schema must be Some");
+
+    assert_eq!(spec.id, "reviewer");
+
+    let agent = spec.agent.as_ref().expect("reviewer has an agent");
+    assert_eq!(agent.role, phantom_agents::role::AgentRole::Actor);
+
+    // Tool whitelist must be the three gh-PR read/write tools.
+    let allow_tools = agent
+        .allow_tools
+        .as_ref()
+        .expect("reviewer narrows allow_tools");
+    for tool in ["read_file", "gh_pr_review", "gh_pr_merge"] {
+        assert!(
+            allow_tools.iter().any(|t| t == tool),
+            "reviewer must allow {tool}, got {allow_tools:?}"
+        );
+    }
+
+    // Policy overrides from TOML.
+    assert!(agent.policy.auto_approve, "reviewer auto_approve must be true");
+    assert_eq!(agent.policy.timeout_seconds, 1200);
+
+    // Source: queue.
+    match &spec.source {
+        LoopSourceSpec::Queue { name } => assert_eq!(name, "review-queue"),
+        other => panic!("expected Queue source, got {other:?}"),
+    }
+
+    // on_complete: log_to_bus.
+    assert_eq!(spec.on_complete.len(), 1);
+    match &spec.on_complete[0] {
+        LoopEffect::LogToBus { event_kind } => {
+            assert_eq!(event_kind, "reviewer.decision");
+        }
+        other => panic!("expected LogToBus, got {other:?}"),
+    }
+
+    // Schema gates a well-formed approve decision.
+    schema
+        .validate(&json!({ "pr_number": 658, "decision": "approved" }))
+        .expect("approved decision must validate");
+    schema
+        .validate(&json!({ "pr_number": 658, "decision": "changes_requested" }))
+        .expect("changes_requested decision must validate");
+    schema
+        .validate(&json!({ "pr_number": 658, "decision": "merged" }))
+        .expect("merged decision must validate");
+
+    // ... and rejects an out-of-enum decision.
+    assert!(
+        schema
+            .validate(&json!({ "pr_number": 1, "decision": "lgtm" }))
+            .is_err(),
+        "out-of-enum decision must be rejected"
+    );
+
+    // ... and rejects a non-integer pr_number.
+    assert!(
+        schema
+            .validate(&json!({ "pr_number": "658", "decision": "approved" }))
+            .is_err(),
+        "string pr_number must be rejected"
+    );
+
+    // ... and rejects missing-required-field payloads.
+    assert!(
+        schema.validate(&json!({})).is_err(),
+        "empty payload must be rejected"
+    );
+    assert!(
+        schema
+            .validate(&json!({ "pr_number": 1 }))
+            .is_err(),
+        "payload missing decision must be rejected"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// implementer.toml — Actor agent draining implementer-queue, forwarding PR
+// ---------------------------------------------------------------------------
+
+#[test]
+fn implementer_spec_parses_and_schema_gates_payloads() {
+    let path = spec_path("implementer");
+    assert!(path.exists(), "missing fixture: {}", path.display());
+
+    let (spec, schema) =
+        load_spec(&path).expect("implementer.toml must parse against C1 schema");
+    let schema = schema.expect("implementer has [agent] so schema must be Some");
+
+    assert_eq!(spec.id, "implementer");
+
+    let agent = spec.agent.as_ref().expect("implementer has an agent");
+    assert_eq!(agent.role, phantom_agents::role::AgentRole::Actor);
+
+    // Tool whitelist is wider — must include write_file, run_command, gh_pr_create.
+    let allow_tools = agent
+        .allow_tools
+        .as_ref()
+        .expect("implementer narrows allow_tools");
+    for tool in [
+        "read_file",
+        "write_file",
+        "edit_file",
+        "run_command",
+        "gh_pr_create",
+    ] {
+        assert!(
+            allow_tools.iter().any(|t| t == tool),
+            "implementer must allow {tool}, got {allow_tools:?}"
+        );
+    }
+
+    // Policy.
+    assert!(agent.policy.auto_approve);
+    assert_eq!(agent.policy.timeout_seconds, 1800);
+
+    // Source.
+    match &spec.source {
+        LoopSourceSpec::Queue { name } => assert_eq!(name, "implementer-queue"),
+        other => panic!("expected Queue source, got {other:?}"),
+    }
+
+    // on_complete must forward the PR URL to review-queue.
+    assert_eq!(spec.on_complete.len(), 1);
+    match &spec.on_complete[0] {
+        LoopEffect::EnqueueTo { queue, fields } => {
+            assert_eq!(queue, "review-queue");
+            assert_eq!(
+                fields.len(),
+                2,
+                "implementer forwards pr_url and issue_number"
+            );
+            // Field map: result.pr_url -> pr_url, result.issue_number -> issue_number.
+            assert!(
+                fields
+                    .iter()
+                    .any(|f| f.from == "result.pr_url" && f.to == "pr_url"),
+                "missing pr_url field map: {fields:?}"
+            );
+            assert!(
+                fields.iter().any(
+                    |f| f.from == "result.issue_number" && f.to == "issue_number"
+                ),
+                "missing issue_number field map: {fields:?}"
+            );
+        }
+        other => panic!("expected EnqueueTo, got {other:?}"),
+    }
+
+    // Schema accepts a well-formed completion.
+    schema
+        .validate(&json!({
+            "issue_number": 650,
+            "pr_url": "https://github.com/jdmiranda/phantom/pull/999",
+            "summary": "Wired loop overseer end-to-end."
+        }))
+        .expect("well-formed completion must validate");
+
+    // ... and rejects missing fields.
+    assert!(
+        schema
+            .validate(&json!({
+                "issue_number": 1,
+                "summary": "no pr_url"
+            }))
+            .is_err(),
+        "missing pr_url must be rejected"
+    );
+    assert!(
+        schema
+            .validate(&json!({
+                "pr_url": "https://example.invalid",
+                "summary": "no issue"
+            }))
+            .is_err(),
+        "missing issue_number must be rejected"
+    );
+
+    // ... and rejects a non-integer issue_number.
+    assert!(
+        schema
+            .validate(&json!({
+                "issue_number": "650",
+                "pr_url": "https://example.invalid/p/1",
+                "summary": "stringly typed"
+            }))
+            .is_err(),
+        "string issue_number must be rejected"
+    );
+}


### PR DESCRIPTION
## Summary

Three TOML loop specs at `.phantom/loops/*.toml` that the loop overseer
will consume on the first real `phantom loop run` against
`jdmiranda/phantom` itself. These land as **committed fixtures** — they
are inert until C3 wires the CLI, but they validate that the C1 schema
can express what the MVP needs, and give the C3 agent something concrete
to test against.

Closes part of #650. Pairs with #658 (C1 — types + parser) and #661
(C2 — runner). All three specs parse cleanly against the post-C2
`load_spec` API.

## The three specs

| File | Role | Source | Agent | Effects |
| --- | --- | --- | --- | --- |
| `pr_finder.toml` | Agentless cron router | `cron` 300s | none | `enqueue_to` review-queue + implementer-queue |
| `reviewer.toml` | Review draining `review-queue` | `queue` review-queue | Actor with `read_file`, `gh_pr_review`, `gh_pr_merge` | `log_to_bus` `reviewer.decision` |
| `implementer.toml` | Implementation draining `implementer-queue` | `queue` implementer-queue | Actor with read/write/edit/run + `gh_pr_create` | `enqueue_to` review-queue forwarding `pr_url` + `issue_number` |

Reviewer exit schema gates `{pr_number: integer, decision: enum["approved","changes_requested","merged"]}`.
Implementer exit schema gates `{issue_number: integer, pr_url: string (uri), summary: string}`.

## Validation

A new integration test, `crates/phantom-loop/tests/mvp_specs.rs`, reads
each repo-root TOML via `phantom_loop::load_spec`, asserts the parsed
`LoopSpec` matches the expected source / role / tools / effects, and
exercises each compiled `ExitSchema` against both passing and failing
payloads. Output from `cargo test -p phantom-loop --test mvp_specs`:

```
running 3 tests
test pr_finder_spec_parses_as_agentless_cron ... ok
test reviewer_spec_parses_and_schema_gates_payloads ... ok
test implementer_spec_parses_and_schema_gates_payloads ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Full `phantom-loop` pre-PR gates:

```
==> [build (phantom-loop)]      PASS
==> [test (phantom-loop)]       PASS  (22 unit + 9 integration + 0 doctest)
==> [clippy (phantom-loop)]     PASS
pre-pr-check passed for phantom-loop
```

## C1-schema gaps surfaced while writing real specs

Writing the three specs against the live C1 enums surfaced three places
where the schema cannot directly express what `pr_finder` needs. Calling
these out so C2 / C3 can decide whether to extend the schema or work
around them in the runner.

### Gap 1: no `PollGhPr` (or generalised `Poll`) variant in `LoopEffect`

The brief specifies `kind = "cron"` plus a Poll-then-Enqueue effect
chain for PR-finder. `LoopEffect` on `main` is `EnqueueTo | LogToBus |
StopLoop` — there is no effect that performs a `gh pr list` call. With a
`Cron` source the iteration body is empty, so an `EnqueueTo` with a
`fields = [{ from = "result.pr_url", ... }]` map has nothing to resolve
against.

**Workarounds:**
- (a) Extend `LoopEffect` with a `PollGhPr` / generalised `Poll`
  variant that fetches and synthesises the iteration result.
- (b) Make `LoopSourceSpec::GhPr` the canonical pattern for
  "scan PRs and fan out" (the source itself is the poll, the iteration
  body forwards each PR).
- Current spec adopts the brief's `cron` and leaves `fields = []`,
  flagged in the TOML's leading comment.

### Gap 2: `LoopEffect::EnqueueTo` has no predicate field

PR-finder needs to route to `review-queue` **OR** `implementer-queue`
*based on the PR's state* (review-needed vs failing-CI). Today every
listed `on_complete` entry fires unconditionally on every iteration.

**Workarounds:**
- Add a `when` / `predicate` field to `EnqueueTo` (or to every effect)
  that gates on the result payload.
- Split into two cron loops (one filters review-needed, one filters
  failing-CI), each with a single `EnqueueTo`.
- Have the C2 runner inspect the result payload's shape and decide per
  entry — the current spec lists both `EnqueueTo` entries and depends on
  this implicit runner behaviour.

### Gap 3: agentless loops cannot declare an `exit_schema`

`exit_schema` lives on `LoopAgentSpec`; agentless is expressed by
omitting the `[agent]` table. This is fine for pure routing, but means
an agentless loop has no way to express "the synthesised iteration
result must match this shape" — useful if Gap 1 is fixed via a `Poll`
effect that returns structured data.

**Workaround:** if Gap 1 is solved by extending `LoopEffect`, the
result payload schema could live on the effect itself
(`Poll { schema: ... }`), keeping the agentless / non-agentless split
clean.

## Files landed

- `.phantom/loops/pr_finder.toml` — 65 lines, leading comment documents all three gaps inline.
- `.phantom/loops/reviewer.toml` — 47 lines.
- `.phantom/loops/implementer.toml` — 55 lines.
- `crates/phantom-loop/tests/mvp_specs.rs` — 268 lines, three integration tests.

No changes to `crates/phantom-loop/src/`, no changes to `CLAUDE.md`,
no changes to `phantom-agents` / `phantom-app` / `phantom-brain` /
`phantom`.

## Test plan

- [x] `cargo test -p phantom-loop --test mvp_specs` — all three new tests pass.
- [x] `cargo test -p phantom-loop` — full crate test suite still green (22 unit + 9 integration + doctests).
- [x] `./scripts/pre-pr-check.sh phantom-loop` — build + test + clippy all PASS.
- [x] `cargo check -p phantom-loop` — clean.
- [ ] (Deferred to C3) Run `phantom loop run --repo . --loops pr-finder,reviewer,implementer` end-to-end once the CLI lands.

Links: closes part of #650; relates to #658 (C1), #661 (C2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)