### PR TITLE
fix(phantom-loop): forward LoopInput.key+payload to effects for agentless loops (closes #665)

### DIFF
--- a/crates/phantom-loop/src/runner/fsm.rs
+++ b/crates/phantom-loop/src/runner/fsm.rs
@@ -271,14 +271,22 @@ impl LoopRunner {
     }
 
     async fn dispatch(&mut self, input: LoopInput) -> LoopState {
-        // Agentless path: no agent, just run effects with a null result.
+        // Agentless path: no agent, so the source's `LoopInput` *is* the
+        // iteration result. Synthesise a JSON object that exposes both
+        // `key` and `payload` to the effect runner so `EnqueueTo.fields`
+        // mappings like `from = "key"` or `from = "payload.<...>"` resolve
+        // against the input the source just produced. See issue #665.
         let Some(agent_spec) = self.spec.agent.as_ref() else {
             tracing::debug!(
                 loop_id = %self.spec.id,
                 key = %input.key,
-                "agentless dispatch; running effects with null result",
+                "agentless dispatch; running effects with synthesised input result",
             );
-            return self.run_effects_and_continue(&input, &Value::Null);
+            let synthetic_result = serde_json::json!({
+                "key": input.key,
+                "payload": input.payload,
+            });
+            return self.run_effects_and_continue(&input, &synthetic_result);
         };
 
         // Agent path: ask the dispatcher to spawn.
@@ -553,8 +561,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn agentless_dispatch_runs_effects_with_null_result() {
-        // Build an agentless spec with one enqueue_to effect.
+    async fn agentless_dispatch_forwards_loop_input_to_effects() {
+        // Regression for issue #665. Agentless loops must surface the
+        // source-produced `LoopInput` as the effect-runner result so
+        // field maps like `from = "key"` or `from = "payload.<x>"`
+        // resolve. With an empty `fields` list the whole synthetic
+        // result is forwarded as the message payload.
         let mut spec = make_spec_with_agent(json!({"type": "object"}));
         spec.agent = None;
         spec.on_complete = vec![LoopEffect::EnqueueTo {
@@ -565,7 +577,7 @@ mod tests {
         let source = Box::new(OneShotSource {
             input: Some(LoopInput {
                 key: "k".to_string(),
-                payload: json!({"ignored": true}),
+                payload: json!({"surfaced": true}),
                 correlation_id: CorrelationId::new("c"),
             }),
         });
@@ -580,7 +592,8 @@ mod tests {
         let reason = runner.run().await;
         // After processing one input, source returns Done → stop.
         assert_eq!(reason, "source exhausted");
-        // The effect fired with a null payload — queue should have 1 message.
-        assert_eq!(queues.get_or_create("out").len(), 1);
+        // The synthetic result wraps the LoopInput verbatim.
+        let msg = queues.get_or_create("out").pop().expect("one enqueued message");
+        assert_eq!(msg.payload, json!({"key": "k", "payload": {"surfaced": true}}));
     }
 }

--- a/crates/phantom-loop/tests/agentless_effects.rs
+++ b/crates/phantom-loop/tests/agentless_effects.rs
@@ -1,0 +1,133 @@
+//! Integration coverage for the agentless-dispatch branch of
+//! [`phantom_loop::LoopRunner`].
+//!
+//! Regression for [#665](https://github.com/jdmiranda/phantom/issues/665):
+//! `LoopRunner::dispatch` used to forward `serde_json::Value::Null` as the
+//! effect-runner result on the agentless path, discarding both `LoopInput.key`
+//! and `LoopInput.payload`. That meant `EnqueueTo.fields` mappings with
+//! `from = "key"` or `from = "payload.<field>"` could not resolve — every
+//! agentless loop with a non-empty field map (e.g. `pr_finder_review.toml`,
+//! `pr_finder_impl.toml`) stopped on the first input with
+//! `EffectError::FieldMapMissing`.
+//!
+//! After the fix, `dispatch` synthesises a `{ "key": ..., "payload": ... }`
+//! JSON object from the source's `LoopInput` and hands it to the effect
+//! runner so the documented contract holds.
+
+use std::sync::Arc;
+
+use phantom_loop::{
+    AgentDispatcher, CorrelationId, DispatchError, DispatchHandle, LoopAgentSpec, LoopContext,
+    LoopInput, LoopPullResult, LoopQueueRegistry, LoopRunner, LoopSource,
+    parse_spec_str,
+};
+use serde_json::json;
+
+/// One-shot stub source: emits a single canned [`LoopInput`], then `Done`.
+struct OneShotSource {
+    input: Option<LoopInput>,
+}
+
+impl LoopSource for OneShotSource {
+    fn next(&mut self, _ctx: &LoopContext) -> LoopPullResult {
+        match self.input.take() {
+            Some(i) => LoopPullResult::Available(i),
+            None => LoopPullResult::Done,
+        }
+    }
+}
+
+/// Dispatcher stub that should never be invoked on the agentless path.
+///
+/// If the runner ever calls into this on an agentless spec, the test fails
+/// loudly via the `panic!` — the agentless branch is supposed to bypass the
+/// dispatcher entirely.
+struct UnreachableDispatcher;
+
+impl AgentDispatcher for UnreachableDispatcher {
+    fn dispatch(
+        &self,
+        _spec: &LoopAgentSpec,
+        _input: &LoopInput,
+    ) -> Result<DispatchHandle, DispatchError> {
+        panic!("agentless runner must not invoke the agent dispatcher");
+    }
+}
+
+/// Agentless spec wired against a cron source: the runner doesn't actually
+/// drive the cron — the test swaps in a one-shot stub source via
+/// [`LoopRunner::new`] — but the spec still has to parse, so we declare a
+/// `cron` source to satisfy schema requirements.
+///
+/// `on_complete` declares the exact field-map shape from the broken
+/// `pr_finder_*.toml` specs: `from = "key"` resolves to the input's stable
+/// identifier; `from = "payload.title"` resolves into a source-emitted
+/// payload field. Both must resolve against the synthesised result the
+/// agentless path now forwards.
+const AGENTLESS_TOML: &str = r#"
+id = "test-agentless"
+
+[source]
+kind = "cron"
+interval_seconds = 60
+
+[[on_complete]]
+kind = "enqueue_to"
+queue = "test-queue"
+
+[[on_complete.fields]]
+from = "key"
+to = "pr_number"
+
+[[on_complete.fields]]
+from = "payload.title"
+to = "title"
+"#;
+
+#[tokio::test]
+async fn agentless_loop_forwards_key_and_payload_fields_to_effects() {
+    let (spec, schema) = parse_spec_str(AGENTLESS_TOML).expect("parse agentless spec");
+    assert!(spec.agent.is_none(), "spec must be agentless for this test");
+
+    let queues = Arc::new(LoopQueueRegistry::new());
+
+    let source = Box::new(OneShotSource {
+        input: Some(LoopInput {
+            key: "pr#1241".to_string(),
+            payload: json!({"title": "fix X", "author": "alice"}),
+            correlation_id: CorrelationId::new("agentless:1"),
+        }),
+    });
+
+    let mut runner = LoopRunner::new(
+        Arc::new(spec),
+        schema,
+        source,
+        queues.clone(),
+        Arc::new(UnreachableDispatcher),
+    );
+
+    // Drive: Idle → Pulling → Dispatching → (agentless effects) → Pulling.
+    // We stop after the effects fire, before the second Pulling would call
+    // `next` again and observe `Done`, so each transition is asserted on the
+    // shape downstream consumers actually see.
+    runner.step().await; // Idle → Pulling
+    runner.step().await; // Pulling → Dispatching
+    runner.step().await; // Dispatching → (effects) → Pulling
+
+    // Pop from `test-queue` and confirm the payload carries both mappings.
+    let msg = queues
+        .pop("test-queue")
+        .expect("agentless effect must enqueue exactly one message");
+    assert_eq!(msg.from_loop, "test-agentless");
+    assert_eq!(
+        msg.payload,
+        json!({"pr_number": "pr#1241", "title": "fix X"}),
+        "field map must resolve `key` to the input key and `payload.title` to the source-emitted title",
+    );
+
+    // The agentless branch must bypass the dispatcher entirely. The
+    // `UnreachableDispatcher::dispatch` panic above is the load-bearing
+    // assertion — reaching this point at all proves the dispatcher was not
+    // invoked.
+}


### PR DESCRIPTION
## Summary

`LoopRunner::dispatch`'s agentless branch in `crates/phantom-loop/src/runner/fsm.rs` used to forward `serde_json::Value::Null` as the effect-runner result, discarding both `LoopInput.key` and `LoopInput.payload`. That meant `EnqueueTo.fields` mappings with `from = "key"` or `from = "payload.<...>"` could not resolve — the runner stopped on the first input with `EffectError::FieldMapMissing`.

## The broken line + the fix

```diff
     async fn dispatch(&mut self, input: LoopInput) -> LoopState {
-        // Agentless path: no agent, just run effects with a null result.
+        // Agentless path: no agent, so the source's `LoopInput` *is* the
+        // iteration result. Synthesise a JSON object that exposes both
+        // `key` and `payload` to the effect runner so `EnqueueTo.fields`
+        // mappings like `from = "key"` or `from = "payload.<...>"` resolve
+        // against the input the source just produced. See issue #665.
         let Some(agent_spec) = self.spec.agent.as_ref() else {
             tracing::debug!(
                 loop_id = %self.spec.id,
                 key = %input.key,
-                "agentless dispatch; running effects with null result",
+                "agentless dispatch; running effects with synthesised input result",
             );
-            return self.run_effects_and_continue(&input, &Value::Null);
+            let synthetic_result = serde_json::json!({
+                "key": input.key,
+                "payload": input.payload,
+            });
+            return self.run_effects_and_continue(&input, &synthetic_result);
         };
```

The agent path is untouched — it still forwards the agent's `complete_task` result verbatim, which exercises a different code path in `await_completion → validate → run_effects_and_continue`.

## Unblocks PR #666

PR #666 split `pr_finder.toml` into `pr_finder_review.toml` and `pr_finder_impl.toml`. Both new specs declare `[[on_complete.fields]] from = "key"` against the `GhPrReviewQueueSource`-produced `LoopInput { key: "owner/repo#pr-N", payload: { "number": N, ... } }`. The TOML specs already parse; this fix is what lets them actually run end-to-end. `GhPrReviewQueueSource::pr_to_input` produces the right shape — the runner just needed to surface it.

## New test

`crates/phantom-loop/tests/agentless_effects.rs` — drives a parsed agentless cron spec with the exact field-map shape used by the broken `pr_finder_*.toml` specs:

```toml
[[on_complete.fields]]
from = "key"
to = "pr_number"

[[on_complete.fields]]
from = "payload.title"
to = "title"
```

A one-shot stub source emits `LoopInput { key: "pr#1241", payload: { "title": "fix X", "author": "alice" } }`. After three `step()` calls (`Idle → Pulling → Dispatching → Pulling`), the test pops from `test-queue` and asserts the payload is `{"pr_number": "pr#1241", "title": "fix X"}`. The test also wires an `UnreachableDispatcher` whose `dispatch` panics, proving the agentless branch bypasses the dispatcher entirely.

The existing inline `agentless_dispatch_runs_effects_with_null_result` test is renamed to `agentless_dispatch_forwards_loop_input_to_effects` and updated to assert the new shape.

## Pre-PR check numbers

- `./scripts/pre-pr-check.sh phantom-loop` (with fix) — PASS. `cargo test -p phantom-loop` runs 80 unit tests + 19 integration tests (including the new one) green; clippy clean.
- `./scripts/pre-pr-check.sh phantom-loop` (baseline, fix stashed) — PASS. Confirms no pre-existing breakage on `origin/main`.

## Scope

One function (`LoopRunner::dispatch`), one new integration test file, one inline-test update. No refactoring, no other crates touched, no schema changes.

## Test plan

- [x] `cargo test -p phantom-loop` — all 80 unit + 19 integration tests pass
- [x] `./scripts/pre-pr-check.sh phantom-loop` — fmt + clippy + tests pass
- [x] Baseline check (origin/main) — pass, no pre-existing failures
- [ ] Follow-up: confirm both `pr_finder_review.toml` and `pr_finder_impl.toml` from PR #666 light up end-to-end against a live `gh pr list`

Generated with [Claude Code](https://claude.com/claude-code).