### PR TITLE
feat(phantom-loop): SubstrateDriver wires loop CLI to real agent spawning

### DIFF
--- a/crates/phantom-loop/src/dispatcher/driver.rs
+++ b/crates/phantom-loop/src/dispatcher/driver.rs
@@ -1,0 +1,636 @@
+//! Headless substrate driver for `phantom loop run`.
+//!
+//! The full `phantom-app::App` event loop drains
+//! [`phantom_agents::composer_tools::SpawnSubagentQueue`] every frame and
+//! materialises each [`SpawnSubagentRequest`] into a real agent pane backed
+//! by a Claude API call. That path requires a winit window, a wgpu surface,
+//! a layout engine, and a scene graph — all of which `phantom loop run`
+//! deliberately avoids.
+//!
+//! This module ships the CLI-side counterpart: a [`SubstrateDriver`] that
+//! drains the same queue from an async task, drives the agent through a
+//! pluggable [`SubstrateBackend`] (real Claude API by default, mockable for
+//! tests), and emits a `phantom_protocol::Event::AgentTaskComplete` onto a
+//! tokio mpsc bus when each agent finishes. The
+//! [`crate::SubstrateCompletionRouter`] is then fed from the other end of
+//! that bus, closing the loop with the [`crate::SubstrateAgentDispatcher`].
+//!
+//! # Topology
+//!
+//! ```text
+//!   LoopRunner.dispatch
+//!         │  (1) push SpawnSubagentRequest onto SpawnSubagentQueue
+//!         ▼
+//!   SubstrateAgentDispatcher        ◄───────────────────────────────┐
+//!         │                                                         │
+//!         │  (2) registers pending oneshot for AgentId              │
+//!         ▼                                                         │
+//!   ┌─────────────────────────────────────────────────────────┐     │
+//!   │ SubstrateDriver.tick()                                  │     │
+//!   │   for each pending SpawnSubagentRequest:                │     │
+//!   │     spawn task → SubstrateBackend.run_agent(req)        │     │
+//!   │     on completion: send Event::AgentTaskComplete onto   │     │
+//!   │       the driver's event sender                         │     │
+//!   └─────────────────────────────────────────────────────────┘     │
+//!                                          │                        │
+//!                                          ▼                        │
+//!   ┌─────────────────────────────────────────────────────────┐     │
+//!   │ Forwarder task: read Event from rx, call                │     │
+//!   │ router.on_completion(event) which fulfils the oneshot   │─────┘
+//!   └─────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! # Why a separate trait
+//!
+//! Mocking a `phantom-agents` `ChatBackend` end-to-end across the agent
+//! loop (system prompt, multi-turn tool calls, JSON validation, completion
+//! emission) is brittle. [`SubstrateBackend`] is a one-method abstraction
+//! over "drive a [`SpawnSubagentRequest`] to a terminal result". The
+//! default impl in this module wraps the real Claude / OpenAI API. Tests
+//! plug in [`MockSubstrateBackend`] to return a canned `complete_task`
+//! result without touching the network.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use serde_json::Value;
+use tokio::sync::mpsc;
+use tokio::time::interval;
+
+use phantom_agents::agent::{Agent, AgentMessage, AgentTask, allocate_agent_id};
+use phantom_agents::api::{ApiEvent, ClaudeConfig, send_message};
+use phantom_agents::chat::{
+    ChatBackend, ChatError, ChatModel, ChatRequest, build_backend_with_privacy,
+};
+use phantom_agents::composer_tools::{SpawnSubagentQueue, SpawnSubagentRequest};
+use phantom_agents::tools::{
+    ToolDefinition, available_tools, execute_tool_with_provenance, lifecycle_tools,
+};
+use phantom_protocol::Event;
+
+// ---------------------------------------------------------------------------
+// SubstrateBackend
+// ---------------------------------------------------------------------------
+
+/// Pluggable agent runner.
+///
+/// The driver does not know how to talk to Claude — it only knows how to
+/// drain the queue and emit completion events. The mapping from one
+/// [`SpawnSubagentRequest`] to one terminal result lives behind this trait.
+///
+/// Implementations may be sync or async internally. Each invocation is
+/// expected to return promptly; the actual long-running agent execution
+/// runs inside the spawned tokio task the driver creates.
+pub trait SubstrateBackend: Send + Sync {
+    /// Drive `req` to completion and return the agent's `complete_task`
+    /// payload (or an error describing why the agent failed).
+    ///
+    /// This call is made from inside a tokio task spawned by
+    /// [`SubstrateDriver::tick`]. The implementation may block — the
+    /// caller is on a dedicated task and a blocking call is the cheapest
+    /// path for the synchronous `ureq`-backed [`send_message`] path.
+    fn run_agent(&self, req: &SpawnSubagentRequest) -> Result<Value, String>;
+}
+
+// ---------------------------------------------------------------------------
+// ChatBackedSubstrateBackend — the production impl
+// ---------------------------------------------------------------------------
+
+/// Production [`SubstrateBackend`] backed by the real `phantom-agents` chat
+/// stack.
+///
+/// Drives one agent's full conversation: build the [`Agent`], pump
+/// [`ApiEvent`]s from the chat backend, execute tool calls, loop until the
+/// agent emits `complete_task` or hits the round budget.
+///
+/// `MAX_ROUNDS` mirrors the GUI pane's `MAX_TOOL_ROUNDS` so loop agents do
+/// not differ from interactive panes on the round budget. `MAX_TOKENS`
+/// matches the default per-request budget downstream of `ClaudeConfig`.
+///
+/// The working directory is the process cwd; loop agents are expected to
+/// have file tools sandboxed to the repo root, which `phantom loop run`
+/// canonicalises ahead of time.
+pub struct ChatBackedSubstrateBackend {
+    privacy_mode: bool,
+    max_rounds: usize,
+}
+
+/// Maximum tool-call rounds before a loop agent flatlines with
+/// `"iteration limit"`. Mirrors the GUI's `MAX_TOOL_ROUNDS`.
+pub const DEFAULT_MAX_ROUNDS: usize = 32;
+
+impl Default for ChatBackedSubstrateBackend {
+    fn default() -> Self {
+        Self {
+            privacy_mode: false,
+            max_rounds: DEFAULT_MAX_ROUNDS,
+        }
+    }
+}
+
+impl ChatBackedSubstrateBackend {
+    /// Construct with explicit settings.
+    #[must_use]
+    pub fn new(privacy_mode: bool, max_rounds: usize) -> Self {
+        Self {
+            privacy_mode,
+            max_rounds,
+        }
+    }
+
+    /// Drive the agent loop synchronously. Returns the
+    /// `complete_task(result)` payload on success.
+    fn drive_agent(&self, req: &SpawnSubagentRequest) -> Result<Value, String> {
+        let chat_model = req.chat_model.clone().unwrap_or_default();
+
+        // Resolve the API key for the requested backend. ClaudeConfig is
+        // also used by the legacy `send_message` path when no chat backend
+        // is configured, so we always need a config to thread through.
+        let Some(claude_config) = resolve_api_config(&chat_model) else {
+            return Err(format!(
+                "no API key configured for {}",
+                chat_model.backend_name()
+            ));
+        };
+
+        // Build the chat backend. PrivacyGuard wraps every cloud backend
+        // even though privacy_mode is typically off in CLI mode.
+        let chat_backend: Option<Box<dyn ChatBackend>> =
+            match build_backend_with_privacy(&chat_model, self.privacy_mode) {
+                Ok(b) => Some(b),
+                Err(ChatError::NotConfigured(msg)) => {
+                    return Err(format!("chat backend not configured: {msg}"));
+                }
+                Err(e) => return Err(format!("chat backend init failed: {e}")),
+            };
+
+        // Build the Agent. Loop agents always opt into the complete_task
+        // contract so the runner can validate the exit payload against the
+        // configured ExitSchema.
+        let mut agent = Agent::new(
+            req.assigned_id.max(allocate_agent_id()),
+            AgentTask::FreeForm {
+                prompt: req.task.clone(),
+            },
+        );
+        agent.set_requires_complete_task(true);
+
+        let sys = agent.system_prompt();
+        agent.push_message(AgentMessage::System(sys));
+        agent.push_message(AgentMessage::User(req.task.clone()));
+
+        let mut tools = available_tools();
+        tools.extend(lifecycle_tools());
+
+        let working_dir = std::env::current_dir()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_else(|_| ".".into());
+
+        let mut tool_use_ids: Vec<String> = Vec::new();
+
+        for round in 0..self.max_rounds {
+            tracing::debug!(
+                agent_id = req.assigned_id,
+                round,
+                "loop substrate driver: starting round"
+            );
+
+            let mut handle = dispatch_one_turn(
+                chat_backend.as_deref(),
+                &claude_config,
+                &agent,
+                &tools,
+                &tool_use_ids,
+            );
+
+            // Pump events from this turn until Done / Error / CompleteTask.
+            let mut pending_calls: Vec<(String, phantom_agents::tools::ToolCall)> = Vec::new();
+            let mut current_assistant = String::new();
+
+            loop {
+                match handle.try_recv() {
+                    Some(ApiEvent::TextDelta(text)) => {
+                        current_assistant.push_str(&text);
+                    }
+                    Some(ApiEvent::ToolUse { id, call }) => {
+                        tool_use_ids.push(id.clone());
+                        pending_calls.push((id, call));
+                    }
+                    Some(ApiEvent::CompleteTask { id: _, result }) => {
+                        if !current_assistant.is_empty() {
+                            agent.push_message(AgentMessage::Assistant(current_assistant));
+                        }
+                        if !result.is_object() {
+                            return Err(format!(
+                                "complete_task: result must be a JSON object (got {result})"
+                            ));
+                        }
+                        agent.complete_with_result(result.clone());
+                        return Ok(result);
+                    }
+                    Some(ApiEvent::Done) => {
+                        if !current_assistant.is_empty() {
+                            agent
+                                .push_message(AgentMessage::Assistant(std::mem::take(
+                                    &mut current_assistant,
+                                )));
+                        }
+                        break;
+                    }
+                    Some(ApiEvent::Error(e)) => {
+                        return Err(format!("chat backend error: {e}"));
+                    }
+                    None => {
+                        if handle.is_done() {
+                            break;
+                        }
+                        std::thread::sleep(Duration::from_millis(25));
+                    }
+                }
+            }
+
+            if pending_calls.is_empty() {
+                // Conversation ended without complete_task. Treat as
+                // failure so the runner records the iteration as failed.
+                return Err("agent exited without complete_task".to_string());
+            }
+
+            // Execute pending tools, append results, loop back for the
+            // next turn.
+            for (_id, call) in pending_calls.drain(..) {
+                agent.push_message(AgentMessage::ToolCall(call.clone()));
+                let result = execute_tool_with_provenance(
+                    call.tool,
+                    &call.args,
+                    &working_dir,
+                    &req.role,
+                    None,
+                );
+                agent.push_message(AgentMessage::ToolResult(result));
+            }
+        }
+
+        Err(format!(
+            "iteration limit reached ({} tool rounds)",
+            self.max_rounds
+        ))
+    }
+}
+
+impl SubstrateBackend for ChatBackedSubstrateBackend {
+    fn run_agent(&self, req: &SpawnSubagentRequest) -> Result<Value, String> {
+        self.drive_agent(req)
+    }
+}
+
+/// Resolve the appropriate API config for the requested chat model.
+///
+/// Returns `None` when the required env var is unset. Mirrors the
+/// `phantom-app::agent_pane::resolve_api_config` private helper without
+/// pulling phantom-app into this crate's dependency graph.
+fn resolve_api_config(model: &ChatModel) -> Option<ClaudeConfig> {
+    match model {
+        ChatModel::Claude(_) => ClaudeConfig::from_env(),
+        ChatModel::OpenAi(_) => {
+            let key = std::env::var("OPENAI_API_KEY").ok().filter(|k| !k.is_empty());
+            // OpenAI keys are consumed inside the ChatBackend, but the
+            // legacy `send_message` path still wants a ClaudeConfig for
+            // its `max_tokens` field. Mirror phantom-app and synthesise a
+            // placeholder.
+            key.map(|_| ClaudeConfig::new("__openai__"))
+        }
+    }
+}
+
+/// Dispatch one turn of the chat conversation, mirroring the GUI pane's
+/// dispatch path. Routes through [`ChatBackend::complete`] when a backend
+/// is configured, otherwise falls through to the legacy [`send_message`]
+/// Claude path so behaviour stays byte-for-byte identical when no
+/// `--model` was selected.
+fn dispatch_one_turn(
+    backend: Option<&dyn ChatBackend>,
+    claude_config: &ClaudeConfig,
+    agent: &Agent,
+    tools: &[ToolDefinition],
+    tool_use_ids: &[String],
+) -> phantom_agents::api::ApiHandle {
+    if let Some(backend) = backend {
+        let request = ChatRequest {
+            agent,
+            tools,
+            tool_use_ids,
+            max_tokens: claude_config.max_tokens,
+        };
+        match backend.complete(request) {
+            Ok(response) => response.into_handle(),
+            Err(e) => {
+                let (tx, rx) = std::sync::mpsc::channel();
+                let _ = tx.send(ApiEvent::Error(format!(
+                    "chat backend ({}) error: {e}",
+                    backend.name()
+                )));
+                phantom_agents::api::ApiHandle::from_receiver(rx)
+            }
+        }
+    } else {
+        send_message(claude_config, agent, tools, tool_use_ids)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SubstrateDriver
+// ---------------------------------------------------------------------------
+
+/// Default queue drain cadence. The substrate is push-only on the
+/// dispatcher side, so an aggressive poll keeps newly-dispatched agents
+/// from sitting in the queue longer than necessary.
+pub const DEFAULT_TICK_INTERVAL: Duration = Duration::from_millis(100);
+
+/// The headless queue drainer.
+///
+/// Owns the same [`SpawnSubagentQueue`] the
+/// [`crate::SubstrateAgentDispatcher`] writes to. Each tick pops every
+/// pending request and spawns one tokio task per request. The task drives
+/// the request through the configured [`SubstrateBackend`] and emits an
+/// [`Event::AgentTaskComplete`] on the driver's event sender when done.
+///
+/// Construct with [`Self::new`]; spawn the periodic tick loop with
+/// [`Self::run`].
+pub struct SubstrateDriver {
+    spawn_queue: SpawnSubagentQueue,
+    backend: Arc<dyn SubstrateBackend>,
+    event_tx: mpsc::Sender<Event>,
+    tick_interval: Duration,
+}
+
+impl SubstrateDriver {
+    /// Build a driver. The `event_tx` is the bus the
+    /// [`crate::SubstrateCompletionRouter`] is expected to subscribe to —
+    /// typically the CLI sets up a forwarder task that reads each event
+    /// and calls `router.on_completion(event)`.
+    #[must_use]
+    pub fn new(
+        spawn_queue: SpawnSubagentQueue,
+        backend: Arc<dyn SubstrateBackend>,
+        event_tx: mpsc::Sender<Event>,
+    ) -> Self {
+        Self {
+            spawn_queue,
+            backend,
+            event_tx,
+            tick_interval: DEFAULT_TICK_INTERVAL,
+        }
+    }
+
+    /// Override the queue-drain interval.
+    #[must_use]
+    pub fn with_tick_interval(mut self, interval: Duration) -> Self {
+        self.tick_interval = interval;
+        self
+    }
+
+    /// Spawn the periodic drain loop. The returned [`tokio::task::JoinHandle`]
+    /// can be aborted on Ctrl-C to stop the driver.
+    #[must_use]
+    pub fn run(self) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(self.run_loop())
+    }
+
+    async fn run_loop(self) {
+        let mut ticker = interval(self.tick_interval);
+        // `interval` fires immediately for the first tick, which causes
+        // a no-op drain (queue is empty at boot). Skip it so the first
+        // actual drain happens after the first interval elapses.
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            self.tick();
+        }
+    }
+
+    /// One drain cycle. Public so tests can step the driver synchronously
+    /// rather than racing against an `interval()` clock.
+    pub fn tick(&self) {
+        let pending: Vec<SpawnSubagentRequest> = match self.spawn_queue.lock() {
+            Ok(mut q) => q.drain(..).collect(),
+            Err(_) => {
+                tracing::warn!("substrate driver: spawn queue mutex poisoned");
+                Vec::new()
+            }
+        };
+
+        for req in pending {
+            let backend = Arc::clone(&self.backend);
+            let tx = self.event_tx.clone();
+            tokio::spawn(async move {
+                let agent_id = req.assigned_id;
+                tracing::debug!(agent_id, label = %req.label, "substrate driver: running agent");
+
+                // Drive the backend on a blocking thread so blocking
+                // network calls (`send_message`'s `ureq` path) do not
+                // park a tokio worker.
+                let outcome = tokio::task::spawn_blocking(move || backend.run_agent(&req))
+                    .await
+                    .unwrap_or_else(|e| Err(format!("backend task panicked: {e}")));
+
+                let event = match outcome {
+                    Ok(result) => Event::AgentTaskComplete {
+                        agent_id,
+                        success: true,
+                        summary: format!("agent #{agent_id} completed via substrate driver"),
+                        spawn_tag: None,
+                        result: Some(result),
+                    },
+                    Err(reason) => Event::AgentTaskComplete {
+                        agent_id,
+                        success: false,
+                        summary: reason,
+                        spawn_tag: None,
+                        result: None,
+                    },
+                };
+
+                if tx.send(event).await.is_err() {
+                    tracing::trace!(
+                        agent_id,
+                        "substrate driver: event bus closed; dropping completion"
+                    );
+                }
+            });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MockSubstrateBackend — test helper
+// ---------------------------------------------------------------------------
+
+/// In-process [`SubstrateBackend`] that returns a canned outcome.
+///
+/// Used in the e2e smoke test to exercise the driver → dispatcher
+/// completion path without hitting a Claude endpoint. The same `outcome`
+/// is returned for every spawned request.
+pub struct MockSubstrateBackend {
+    outcome: std::sync::Mutex<Result<Value, String>>,
+}
+
+impl MockSubstrateBackend {
+    /// Build a mock that returns `Ok(result)` on every spawn.
+    #[must_use]
+    pub fn ok(result: Value) -> Self {
+        Self {
+            outcome: std::sync::Mutex::new(Ok(result)),
+        }
+    }
+
+    /// Build a mock that returns `Err(reason)` on every spawn.
+    #[must_use]
+    pub fn err(reason: impl Into<String>) -> Self {
+        Self {
+            outcome: std::sync::Mutex::new(Err(reason.into())),
+        }
+    }
+}
+
+impl SubstrateBackend for MockSubstrateBackend {
+    fn run_agent(&self, _req: &SpawnSubagentRequest) -> Result<Value, String> {
+        self.outcome
+            .lock()
+            .map(|g| g.clone())
+            .unwrap_or_else(|_| Err("mock backend mutex poisoned".to_string()))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::SubstrateAgentDispatcher;
+    use crate::runner::dispatcher::AgentDispatcher;
+    use crate::runner::source::{CorrelationId, LoopInput};
+    use crate::spec::{LoopAgentSpec, LoopPolicy};
+    use phantom_agents::composer_tools::new_spawn_subagent_queue;
+    use serde_json::json;
+
+    fn make_spec() -> LoopAgentSpec {
+        LoopAgentSpec {
+            role: phantom_agents::role::AgentRole::Actor,
+            allow_tools: None,
+            system_prompt: "Do the thing.".to_string(),
+            exit_schema: json!({"type": "object"}),
+            policy: LoopPolicy::default(),
+        }
+    }
+
+    fn make_input() -> LoopInput {
+        LoopInput {
+            key: "test-key".to_string(),
+            payload: json!({"hello": "world"}),
+            correlation_id: CorrelationId::new("corr-1"),
+        }
+    }
+
+    #[tokio::test]
+    async fn mock_backend_returns_canned_outcome() {
+        let backend = MockSubstrateBackend::ok(json!({"answer": 42}));
+        let req = SpawnSubagentRequest {
+            assigned_id: 1,
+            role: phantom_agents::role::AgentRole::Actor,
+            label: "test".to_string(),
+            task: "noop".to_string(),
+            chat_model: None,
+            parent: 0,
+            handoff_context: None,
+        };
+        let outcome = backend.run_agent(&req).unwrap();
+        assert_eq!(outcome, json!({"answer": 42}));
+    }
+
+    /// End-to-end driver test: a dispatcher pushes onto the queue, the
+    /// driver drains and runs the mock backend, the event bus carries an
+    /// AgentTaskComplete back, the completion router fulfils the
+    /// pending oneshot.
+    #[tokio::test]
+    async fn driver_drains_queue_and_routes_completion_back_to_dispatcher() {
+        let queue = new_spawn_subagent_queue();
+        let dispatcher = Arc::new(SubstrateAgentDispatcher::with_default_parent(queue.clone()));
+        let router = dispatcher.completion_router();
+
+        let (tx, mut rx) = mpsc::channel::<Event>(8);
+        let backend: Arc<dyn SubstrateBackend> = Arc::new(MockSubstrateBackend::ok(json!({
+            "decision": "approved"
+        })));
+        let driver = SubstrateDriver::new(queue.clone(), backend, tx);
+
+        // Forwarder task: pipe events into the router.
+        let router_clone = router.clone();
+        tokio::spawn(async move {
+            while let Some(event) = rx.recv().await {
+                router_clone.on_completion(event);
+            }
+        });
+
+        // Dispatch one iteration through the dispatcher (pushes onto queue).
+        let handle = dispatcher
+            .dispatch(&make_spec(), &make_input())
+            .expect("dispatch must succeed");
+
+        // Drive the driver once — it spawns a task that runs the mock
+        // backend and emits onto the event bus.
+        driver.tick();
+
+        // Await completion. The forwarder routes the event into the
+        // router, which fulfils the oneshot.
+        let outcome = handle
+            .completion_rx
+            .await
+            .expect("oneshot must resolve")
+            .expect("dispatch must succeed");
+        assert_eq!(outcome, json!({"decision": "approved"}));
+        assert_eq!(dispatcher.pending_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn driver_routes_backend_error_as_dispatch_failure() {
+        let queue = new_spawn_subagent_queue();
+        let dispatcher = Arc::new(SubstrateAgentDispatcher::with_default_parent(queue.clone()));
+        let router = dispatcher.completion_router();
+
+        let (tx, mut rx) = mpsc::channel::<Event>(8);
+        let backend: Arc<dyn SubstrateBackend> = Arc::new(MockSubstrateBackend::err("synthetic"));
+        let driver = SubstrateDriver::new(queue.clone(), backend, tx);
+
+        let router_clone = router.clone();
+        tokio::spawn(async move {
+            while let Some(event) = rx.recv().await {
+                router_clone.on_completion(event);
+            }
+        });
+
+        let handle = dispatcher
+            .dispatch(&make_spec(), &make_input())
+            .expect("dispatch must succeed");
+        driver.tick();
+
+        let outcome = handle.completion_rx.await.expect("oneshot resolves");
+        match outcome {
+            Err(crate::DispatchError::Execution(msg)) => {
+                assert!(msg.contains("synthetic"), "got `{msg}`");
+            }
+            other => panic!("expected Execution error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn driver_tick_no_panic_on_empty_queue() {
+        let queue = new_spawn_subagent_queue();
+        let (tx, _rx) = mpsc::channel::<Event>(8);
+        let backend: Arc<dyn SubstrateBackend> = Arc::new(MockSubstrateBackend::ok(json!({})));
+        let driver = SubstrateDriver::new(queue, backend, tx);
+        // First tick on an empty queue must be a no-op.
+        driver.tick();
+    }
+}

--- a/crates/phantom-loop/src/dispatcher/mod.rs
+++ b/crates/phantom-loop/src/dispatcher/mod.rs
@@ -1,14 +1,28 @@
 //! Concrete [`crate::runner::AgentDispatcher`] implementations.
 //!
 //! The trait itself lives at [`crate::runner::dispatcher::AgentDispatcher`].
-//! This module ships the **production** implementation for C3:
+//! This module ships the **production** implementation for C3 plus the
+//! **headless driver** that makes `phantom loop run` actually drain the
+//! spawn queue without booting the full `phantom-app` event loop:
 //!
 //! - [`substrate::SubstrateAgentDispatcher`] — backed by
 //!   [`phantom_agents::composer_tools::SpawnSubagentQueue`]. It pushes a
 //!   [`phantom_agents::composer_tools::SpawnSubagentRequest`] when
 //!   `dispatch` is called and resolves the oneshot when the substrate fires
 //!   a matching [`phantom_protocol::Event::AgentTaskComplete`].
+//! - [`driver::SubstrateDriver`] — the CLI-side counterpart to the
+//!   `App::update` queue drain. Spawns a tokio task that periodically
+//!   drains the same queue, runs each request through a pluggable
+//!   [`driver::SubstrateBackend`] (real Claude API by default,
+//!   [`driver::MockSubstrateBackend`] in tests), and emits
+//!   `Event::AgentTaskComplete` onto a tokio mpsc bus the
+//!   [`SubstrateCompletionRouter`] subscribes to.
 
+pub mod driver;
 pub mod substrate;
 
+pub use driver::{
+    ChatBackedSubstrateBackend, DEFAULT_MAX_ROUNDS, DEFAULT_TICK_INTERVAL, MockSubstrateBackend,
+    SubstrateBackend, SubstrateDriver,
+};
 pub use substrate::{SubstrateAgentDispatcher, SubstrateCompletionRouter};

--- a/crates/phantom-loop/src/lib.rs
+++ b/crates/phantom-loop/src/lib.rs
@@ -83,7 +83,10 @@ pub mod source;
 pub mod sources;
 pub mod spec;
 
-pub use dispatcher::{SubstrateAgentDispatcher, SubstrateCompletionRouter};
+pub use dispatcher::{
+    ChatBackedSubstrateBackend, DEFAULT_MAX_ROUNDS, DEFAULT_TICK_INTERVAL, MockSubstrateBackend,
+    SubstrateAgentDispatcher, SubstrateBackend, SubstrateCompletionRouter, SubstrateDriver,
+};
 pub use effect::{FieldMap, LoopEffect};
 pub use effect_runner::{EffectContext, EffectError, EffectOutcome, run_effects};
 pub use error::LoopSpecError;

--- a/crates/phantom-loop/tests/e2e_substrate.rs
+++ b/crates/phantom-loop/tests/e2e_substrate.rs
@@ -1,0 +1,207 @@
+//! End-to-end integration test for the substrate driver wired into a real
+//! [`phantom_loop::LoopRunner`].
+//!
+//! This is the regression-net for the structural blocker that
+//! [`phantom_loop::SubstrateDriver`] solves: when the driver is wired into
+//! a runner via a [`phantom_loop::SubstrateAgentDispatcher`] +
+//! [`phantom_loop::SubstrateCompletionRouter`], `phantom loop run` can
+//! actually drain its spawn queue and complete iterations without booting
+//! the full GUI app.
+//!
+//! The driver is exercised with a [`phantom_loop::MockSubstrateBackend`]
+//! so the test does not hit Claude. The mock returns a canned schema-valid
+//! payload — exactly the contract real agents are expected to honor via
+//! `complete_task`. Every component between the dispatcher and the router
+//! is real: the runner FSM, the spawn queue, the driver tick loop, the
+//! tokio mpsc event bus, and the completion router. The only thing we mock
+//! is the chat backend.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use phantom_agents::composer_tools::new_spawn_subagent_queue;
+use phantom_loop::{
+    CorrelationId, LoopContext, LoopInput, LoopPullResult, LoopQueueRegistry, LoopRunner,
+    LoopSource, MockSubstrateBackend, SubstrateAgentDispatcher, SubstrateBackend, SubstrateDriver,
+    parse_spec_str,
+};
+use phantom_protocol::Event;
+use serde_json::json;
+
+/// Stub source: emits one input, then `Done`. Mirrors the helper in
+/// `tests/end_to_end_loop.rs` but kept local so the e2e test does not
+/// depend on cross-file fixture wiring.
+struct OneShotSource {
+    input: Option<LoopInput>,
+    pull_count: Arc<AtomicUsize>,
+}
+
+impl LoopSource for OneShotSource {
+    fn next(&mut self, _ctx: &LoopContext) -> LoopPullResult {
+        self.pull_count.fetch_add(1, Ordering::SeqCst);
+        match self.input.take() {
+            Some(i) => LoopPullResult::Available(i),
+            None => LoopPullResult::Done,
+        }
+    }
+}
+
+/// Minimal reviewer-style spec: one agent, integer `pr_number`, decision
+/// enum, one effect that pushes onto a downstream queue. Used in both the
+/// success and failure paths below.
+const REVIEWER_TOML: &str = r#"
+id = "e2e-driver-reviewer"
+
+[agent]
+role = "Actor"
+system_prompt = "Review the PR."
+
+[agent.exit_schema]
+type = "object"
+required = ["pr_number", "decision"]
+
+[agent.exit_schema.properties.pr_number]
+type = "integer"
+
+[agent.exit_schema.properties.decision]
+enum = ["approved", "rejected", "needs_changes"]
+
+[source]
+kind = "queue"
+name = "review-queue"
+
+[[on_complete]]
+kind = "enqueue_to"
+queue = "downstream"
+
+[[on_complete.fields]]
+from = "pr_number"
+to = "reviewed_pr"
+"#;
+
+/// Happy path: one iteration round-trips from a real `LoopRunner` through
+/// the dispatcher → driver → mock backend → event bus → completion
+/// router. The downstream queue receives the field-mapped message.
+#[tokio::test]
+async fn driver_round_trips_real_runner_to_mock_backend() {
+    let (spec, schema) = parse_spec_str(REVIEWER_TOML).expect("parse e2e spec");
+
+    let pulls = Arc::new(AtomicUsize::new(0));
+    let queues = Arc::new(LoopQueueRegistry::new());
+
+    let source = Box::new(OneShotSource {
+        input: Some(LoopInput {
+            key: "pr#7".to_string(),
+            payload: json!({"pr_number": 7}),
+            correlation_id: CorrelationId::new("e2e-driver-corr"),
+        }),
+        pull_count: pulls.clone(),
+    });
+
+    // Real dispatcher against a real spawn queue.
+    let spawn_queue = new_spawn_subagent_queue();
+    let dispatcher = Arc::new(SubstrateAgentDispatcher::with_default_parent(
+        spawn_queue.clone(),
+    ));
+
+    // Real driver with a mock backend. The backend returns a canned
+    // schema-valid payload for every spawned request, simulating an agent
+    // that called `complete_task({"pr_number": 7, "decision": "approved"})`.
+    let canned = json!({"pr_number": 7, "decision": "approved"});
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<Event>(16);
+    let backend: Arc<dyn SubstrateBackend> = Arc::new(MockSubstrateBackend::ok(canned.clone()));
+    let driver = SubstrateDriver::new(spawn_queue.clone(), backend, tx)
+        .with_tick_interval(std::time::Duration::from_millis(10));
+    let _driver_handle = driver.run();
+
+    // Forwarder: pipe events into the completion router.
+    let router = dispatcher.completion_router();
+    let router_clone = router.clone();
+    tokio::spawn(async move {
+        while let Some(event) = rx.recv().await {
+            router_clone.on_completion(event);
+        }
+    });
+
+    let runner = LoopRunner::new(
+        Arc::new(spec),
+        schema,
+        source,
+        queues.clone(),
+        dispatcher.clone(),
+    );
+
+    let reason = runner.run().await;
+    assert_eq!(reason, "source exhausted");
+
+    assert!(
+        pulls.load(Ordering::SeqCst) >= 2,
+        "expected ≥2 pulls, got {}",
+        pulls.load(Ordering::SeqCst)
+    );
+
+    let downstream = queues.get_or_create("downstream");
+    assert_eq!(downstream.len(), 1);
+    let msg = downstream.pop().expect("downstream message");
+    assert_eq!(msg.from_loop, "e2e-driver-reviewer");
+    assert_eq!(msg.payload["reviewed_pr"], 7);
+
+    assert_eq!(dispatcher.pending_count(), 0);
+}
+
+/// Failure path: the backend returns an error. The driver synthesises a
+/// failed `AgentTaskComplete` event; the runner stops with a
+/// dispatch-failure reason carrying the backend's error message.
+#[tokio::test]
+async fn driver_propagates_backend_error_to_runner_stop_reason() {
+    let (spec, schema) = parse_spec_str(REVIEWER_TOML).expect("parse e2e spec");
+    let queues = Arc::new(LoopQueueRegistry::new());
+    let pulls = Arc::new(AtomicUsize::new(0));
+
+    let source = Box::new(OneShotSource {
+        input: Some(LoopInput {
+            key: "pr#8".to_string(),
+            payload: json!({"pr_number": 8}),
+            correlation_id: CorrelationId::new("e2e-driver-err"),
+        }),
+        pull_count: pulls.clone(),
+    });
+
+    let spawn_queue = new_spawn_subagent_queue();
+    let dispatcher = Arc::new(SubstrateAgentDispatcher::with_default_parent(
+        spawn_queue.clone(),
+    ));
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<Event>(16);
+    let backend: Arc<dyn SubstrateBackend> =
+        Arc::new(MockSubstrateBackend::err("synthetic-backend-failure"));
+    let driver = SubstrateDriver::new(spawn_queue.clone(), backend, tx)
+        .with_tick_interval(std::time::Duration::from_millis(10));
+    let _driver_handle = driver.run();
+
+    let router = dispatcher.completion_router();
+    let router_clone = router.clone();
+    tokio::spawn(async move {
+        while let Some(event) = rx.recv().await {
+            router_clone.on_completion(event);
+        }
+    });
+
+    let runner = LoopRunner::new(
+        Arc::new(spec),
+        schema,
+        source,
+        queues.clone(),
+        dispatcher,
+    );
+
+    let reason = runner.run().await;
+    assert!(
+        reason.starts_with("dispatch failure:"),
+        "expected dispatch-failure reason, got `{reason}`"
+    );
+    assert!(
+        reason.contains("synthetic-backend-failure"),
+        "expected backend error to be threaded through, got `{reason}`"
+    );
+}

--- a/crates/phantom/src/headless.rs
+++ b/crates/phantom/src/headless.rs
@@ -59,6 +59,7 @@ pub fn run_headless(_config: PhantomConfig) -> Result<()> {
         privacy_mode: false,
         // Headless mode has no relay connection by default.
         relay_inbound_rx: None,
+        // Headless boot has no prior history snapshot to seed the brain with.
         history_context: Vec::new(),
         // Self-improvement defaults to OFF per design doc §5.1; the operator
         // opts in by supplying a `SelfImprovementState` and `goal_sources`.
@@ -450,6 +451,16 @@ fn run_agent_loop(
                     }
                     break;
                 }
+                Some(ApiEvent::CompleteTask { id: _, result }) => {
+                    // Headless REPL does not yet propagate complete_task
+                    // payloads. Treat the lifecycle signal as a normal
+                    // completion and continue.
+                    println!("\n[AGENT #{}]: complete_task: {result}", agent_id);
+                    if let Some(a) = agents.get_mut(agent_id) {
+                        a.complete_with_result(result);
+                    }
+                    break;
+                }
                 None => {
                     std::thread::sleep(std::time::Duration::from_millis(50));
                 }
@@ -783,6 +794,13 @@ fn run_chat(
             }
             Some(ApiEvent::Error(e)) => {
                 println!("\n[ERROR]: {e}");
+                break;
+            }
+            Some(ApiEvent::CompleteTask { id: _, result }) => {
+                // Chat-level complete_task: surface the payload and end
+                // the conversation turn. The headless REPL does not
+                // distinguish complete_task from a normal Done.
+                println!("\n[PHANTOM]: complete_task: {result}");
                 break;
             }
             None => {

--- a/crates/phantom/src/loop_cli.rs
+++ b/crates/phantom/src/loop_cli.rs
@@ -29,21 +29,24 @@
 //! 6. Block on `tokio::signal::ctrl_c()`. On Ctrl-C, abort every
 //!    registered loop, drop the runlock, and exit.
 //!
-//! # Why this is *not* wired to a real App
+//! # Headless agent driver
 //!
-//! Running real Claude-backed loop agents requires the full `phantom-app`
-//! event loop — `App::update` drains the spawn queue, GPU resources are
-//! allocated for agent panes, and so on. That is far heavier than the
-//! "CLI" the user expects from `phantom loop run`. C3 therefore ships
-//! the structural wire-up (specs → runners → dispatcher → CLI) but the
-//! dispatcher's spawn queue is *not* drained inside `phantom loop run`.
-//! In production, this CLI is expected to be invoked from a context that
-//! also runs the substrate App; alternatively the dispatcher's
-//! `completion_router` can be fed directly from a test harness.
+//! Running real Claude-backed loop agents in the GUI app requires
+//! `phantom-app::App::update` to drain
+//! [`phantom_agents::composer_tools::SpawnSubagentQueue`] every frame and
+//! materialise each request into an agent pane backed by a real chat
+//! backend. That path requires winit, wgpu, layout, and scene state — far
+//! heavier than the CLI surface the user expects from `phantom loop run`.
 //!
-//! Wiring `phantom loop run` to a headless agent driver — so the CLI
-//! actually runs Claude requests against the configured API key — is
-//! tracked as a follow-up to this slice.
+//! Instead, the CLI boots a headless [`phantom_loop::SubstrateDriver`]
+//! that drains the same queue from an async tick loop, drives each request
+//! through a pluggable [`phantom_loop::SubstrateBackend`] (the production
+//! [`phantom_loop::ChatBackedSubstrateBackend`] wraps the real Claude /
+//! OpenAI API; tests substitute a mock), and emits
+//! `phantom_protocol::Event::AgentTaskComplete` onto a tokio mpsc bus the
+//! [`phantom_loop::SubstrateCompletionRouter`] subscribes to. This closes
+//! the substrate loop without any GUI dependencies — the same `LoopRunner`
+//! FSM that runs in the App now runs end-to-end from the CLI.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -53,8 +56,9 @@ use std::time::SystemTime;
 use anyhow::{Result, bail};
 use phantom_agents::composer_tools::new_spawn_subagent_queue;
 use phantom_loop::{
-    LoopHandle, LoopId, LoopQueueRegistry, LoopRegistry, LoopRunner, LoopSource, LoopSourceSpec,
-    LoopSpec, LoopStatus, SubstrateAgentDispatcher,
+    ChatBackedSubstrateBackend, LoopHandle, LoopId, LoopQueueRegistry, LoopRegistry, LoopRunner,
+    LoopSource, LoopSourceSpec, LoopSpec, LoopStatus, SubstrateAgentDispatcher, SubstrateBackend,
+    SubstrateDriver,
 };
 
 /// Top-level dispatcher: `phantom loop <subcommand> ...`
@@ -184,11 +188,32 @@ fn run_command(args: &[String]) -> Result<()> {
         spawn_queue.clone(),
     ));
 
+    // Headless substrate driver: drains the spawn queue and runs each
+    // request through a real chat backend, mirroring what
+    // `phantom-app::App::update` does inside the GUI app. The driver emits
+    // `Event::AgentTaskComplete` onto an in-process tokio mpsc bus; a
+    // forwarder task pipes each event into the dispatcher's completion
+    // router so the runner's pending oneshot resolves.
+    let (event_tx, mut event_rx) =
+        tokio::sync::mpsc::channel::<phantom_protocol::Event>(64);
+    let backend: Arc<dyn SubstrateBackend> = Arc::new(ChatBackedSubstrateBackend::default());
+    let driver = SubstrateDriver::new(spawn_queue.clone(), backend, event_tx);
+    let router = dispatcher.completion_router();
+
     // Stamp every requested loop as a tokio task on the runtime.
     let registry_clone = Arc::clone(&registry);
     let queues_clone = Arc::clone(&queues);
     let dispatcher_clone: Arc<dyn phantom_loop::AgentDispatcher> = dispatcher.clone();
-    runtime.block_on(async move {
+    let driver_handle = runtime.block_on(async move {
+        // Spawn the driver tick loop and the event-forwarder task on the
+        // same runtime as the runners.
+        let driver_join = driver.run();
+        tokio::spawn(async move {
+            while let Some(event) = event_rx.recv().await {
+                router.on_completion(event);
+            }
+        });
+
         for (spec, schema) in targeted {
             let id = registry_clone.alloc_id();
             let status = Arc::new(std::sync::Mutex::new(LoopStatus::Idle));
@@ -223,12 +248,13 @@ fn run_command(args: &[String]) -> Result<()> {
             );
             eprintln!("  started {id} (spec_id ↑ above)");
         }
-        anyhow::Ok(())
+        anyhow::Ok(driver_join)
     })?;
 
     eprintln!("phantom loop run: all loops started. Press Ctrl-C to stop.");
 
-    // Block on ctrl-c. When it fires, abort every registered loop and exit.
+    // Block on ctrl-c. When it fires, abort every registered loop, abort
+    // the substrate driver, and exit.
     runtime.block_on(async move {
         if let Err(e) = tokio::signal::ctrl_c().await {
             eprintln!("phantom loop run: ctrl-c handler error: {e}");
@@ -237,6 +263,7 @@ fn run_command(args: &[String]) -> Result<()> {
         for snap in registry.list() {
             let _ = registry.stop(snap.id);
         }
+        driver_handle.abort();
     });
 
     // Drop the lock explicitly so the message lines up after the loop teardown.


### PR DESCRIPTION
## Summary

Closes the C3 follow-up architectural blocker (post PR #664): `phantom loop run` now drains the substrate `SpawnSubagentQueue` and drives each request to a terminal `complete_task` result, mirroring what `App::update` does inside the full GUI app. Without this, `SubstrateAgentDispatcher` pushed spawn requests that nobody ever consumed in CLI mode.

After this lands, `phantom loop run --repo ... --loops pr_finder_review,reviewer,implementer` actually runs real loops against real PRs.

## What's new

- **`phantom-loop::SubstrateDriver`** — headless queue drainer. Owns a clone of the same `SpawnSubagentQueue` the dispatcher writes to. Each tick drains pending requests and spawns one tokio task per request that drives the agent through a pluggable `SubstrateBackend`. On completion the driver emits `Event::AgentTaskComplete` onto a tokio mpsc bus.

- **`phantom-loop::SubstrateBackend`** trait — one method `run_agent(&SpawnSubagentRequest) -> Result<Value, String>`. The production impl `ChatBackedSubstrateBackend` uses the real `phantom-agents` chat stack (`build_backend_with_privacy`, `dispatch_one_turn`, `execute_tool_with_provenance`, loops until `complete_task` / Done / Error / round budget). The mock impl `MockSubstrateBackend` returns a canned outcome for tests.

- **`phantom::loop_cli::run_command`** now constructs the driver alongside the dispatcher, spawns its tick loop, and wires a forwarder task that pipes each emitted `Event::AgentTaskComplete` into the dispatcher's `SubstrateCompletionRouter` — closing the loop with the runner's pending oneshot. On Ctrl-C the driver is aborted alongside every registered loop.

## Option chosen and why

**Option B (factor out a headless driver in phantom-loop)** rather than Option A (extract the queue-drain logic from `App::update`).

`App::update`'s queue drain calls `spawn_agent_pane_with_opts`, which requires `self.coordinator`, `self.gpu.surface_config`, `self.layout`, `self.scene`, `self.mcp_discovery_complete`, `self.runtime`, `self.quarantine_registry`, `self.agent_snapshot_queue`, `self.tts.tts_tx`, `self.ticket_dispatcher`, `self.dag_explorer`, `self.notifications`, `self.blocked_event_sink`, `self.denied_event_sink` — and that's just the immediate field dependencies. Extracting it cleanly would require either duplicating most of those types as stubs or making `phantom-loop` depend on `phantom-app` (wrong direction in the crate graph).

Option B isolates the CLI-side drain logic to `phantom-loop` with zero GUI dependency. The only crate dependencies the driver adds are `phantom-agents` (already a dep) and `phantom-protocol` (already a dep for the dispatcher). The trade-off is that the driver re-implements the agent loop instead of sharing code with `agent_pane::poll`/`execute_pending_tools` — but the GUI pane's loop has 30+ rendering/journal/capture concerns the loop CLI does not need, so the duplication is much smaller than the coupling cost.

## Driver tick() cycle (pseudocode)

```
fn tick(&self):
    let pending: Vec<SpawnSubagentRequest> = self.queue.drain()
    for req in pending:
        tokio::spawn(async move {
            let outcome = spawn_blocking(|| backend.run_agent(&req)).await
            let event = match outcome {
                Ok(result) => AgentTaskComplete { success: true, result: Some(result), .. },
                Err(reason) => AgentTaskComplete { success: false, summary: reason, .. },
            }
            event_tx.send(event).await
        })
```

The blocking-call wrap is load-bearing: `send_message` uses `ureq` (blocking I/O), so running it directly on a tokio worker would park the runtime. `spawn_blocking` moves it to the blocking pool.

## Event::AgentTaskComplete flow

```
LoopRunner.dispatch
   -> dispatcher.dispatch(spec, input)        [pushes onto SpawnSubagentQueue]
   -> returns DispatchHandle { agent_id, completion_rx }
   -> runner awaits completion_rx

SubstrateDriver.tick (every 100ms)
   -> drains queue -> spawn_blocking(backend.run_agent(req))
   -> backend drives the chat backend through the ApiEvent loop
      (TextDelta -> ToolUse -> execute_tool_with_provenance -> loop until
       CompleteTask, Done without complete_task, or Error)
   -> on completion: event_tx.send(AgentTaskComplete { ... })

Forwarder task (in loop_cli)
   -> reads from event_rx
   -> router.on_completion(event)
      -> look up pending entry by agent_id
      -> fulfil oneshot with result payload (success) or DispatchError::Execution (failure)

-> LoopRunner.await_completion resolves
-> FSM transitions to Validating
-> schema check -> effects run -> next iteration pulled
```

## Smoke test (`crates/phantom-loop/tests/e2e_substrate.rs`)

Two tests; both exercise the **real** `LoopRunner` + `SubstrateAgentDispatcher` + `SubstrateDriver` + tokio mpsc event bus + `SubstrateCompletionRouter` end-to-end. Only the `SubstrateBackend` is mocked.

1. `driver_round_trips_real_runner_to_mock_backend` — source emits one input, runner dispatches, driver spawns + runs mock backend, mock returns a schema-valid payload, runner validates against the exit schema, the configured `enqueue_to` effect fires, the downstream queue receives the field-mapped message, runner exits with `"source exhausted"`. Asserts dispatcher pending count is zero (router cleaned up).

2. `driver_propagates_backend_error_to_runner_stop_reason` — same setup but the mock returns `Err("synthetic-backend-failure")`; the runner stops with `"dispatch failure: agent execution failed: synthetic-backend-failure"`.

Four unit tests in `crates/phantom-loop/src/dispatcher/driver.rs` cover the driver and mock in isolation.

## Mock backend trait surface

```rust
pub trait SubstrateBackend: Send + Sync {
    fn run_agent(&self, req: &SpawnSubagentRequest) -> Result<Value, String>;
}

pub struct ChatBackedSubstrateBackend { privacy_mode: bool, max_rounds: usize }
pub struct MockSubstrateBackend { outcome: Mutex<Result<Value, String>> }
```

One method, sync (the driver calls it inside `spawn_blocking`). The production impl carries the full chat-driven agent loop; the mock returns its preconfigured outcome regardless of input. Mocking at this trait boundary avoids the brittleness of mocking `ChatBackend::complete` plus the full multi-turn `ApiEvent` stream across crate boundaries.

## Pre-PR check numbers

`./scripts/pre-pr-check.sh phantom-loop` — all gates pass:
- build:  PASS
- test:   90 passing (84 lib + 2 new e2e + existing integration)
- clippy: PASS (with `-D warnings`)

`./scripts/pre-pr-check.sh phantom` — same gate failures as baseline `origin/main` (pre-existing clippy issues in `phantom-terminal` and `phantom-renderer`, unrelated to this PR). Build, lib tests, and clippy on the phantom binary's own code are clean.

Baseline `cargo build -p phantom` on `origin/main` fails with two pre-existing errors (missing `history_context` field in `BrainConfig` init, non-exhaustive matches on `ApiEvent::CompleteTask`); this PR fixes both as a precondition for the phantom binary to even build.

## Followups

After this lands, real `phantom loop run` against a live repo is gated only on:
- (a) Task #4 brain self-improvement landing so loops can be enqueued autonomously from observed events
- (b) a real-repo dry run against `jdmiranda/phantom` with `--loops pr_finder_review,reviewer,implementer`

## Out of scope

- GUI / winit / GPU / scene / rendering — untouched
- phantom-brain (Task #4 owns it) — untouched
- CLAUDE.md edits — follow-up PR

## Test plan

- [x] `cargo build -p phantom-loop` — clean
- [x] `cargo build -p phantom` — clean (previously broken on main, fixed here)
- [x] `cargo test -p phantom-loop` — 90 tests pass
- [x] `cargo test -p phantom-loop --test e2e_substrate` — both e2e tests pass
- [x] `cargo clippy -p phantom-loop -- -D warnings` — clean
- [x] `./scripts/pre-pr-check.sh phantom-loop` — all gates PASS
- [ ] Real-repo dry run with `phantom loop run --repo /Users/jermiranda/Documents/GitHub/badass-cli --loops reviewer` (gated on Task #4 landing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)