### PR TITLE
docs(claude-md): refresh for self-improvement pipeline operational state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,8 +76,8 @@ Legend: ✅ complete/active · 🔧 skeletal/stubbed · 🚧 Phase 2+ (open issu
 
 ### AI & Intelligence
 - **phantom-agents** ✅ — Agent lifecycle, tool execution, Claude API chat, 10-variant `AgentRole` enum (Conversational/Watcher/Capturer/Transcriber/Reflector/Indexer/Actor/Composer/Fixer/Defender), role-based tool whitelisting at the `dispatch/mod.rs` capability gate, `complete_task` lifecycle tool + `AgentSpawnOpts::with_requires_complete_task` builder, `try_auto_approve_with_audit` audit-traced fast-path, permission model, taint levels ([#60](https://github.com/jdmiranda/phantom/issues/60), [#87](https://github.com/jdmiranda/phantom/issues/87), [#93](https://github.com/jdmiranda/phantom/issues/93)–[#96](https://github.com/jdmiranda/phantom/issues/96), [#103](https://github.com/jdmiranda/phantom/issues/103)–[#105](https://github.com/jdmiranda/phantom/issues/105), [#646](https://github.com/jdmiranda/phantom/issues/646), [#648](https://github.com/jdmiranda/phantom/issues/648))
-- **phantom-brain** ✅ — Ambient OODA loop on a dedicated thread: event scoring, utility AI, action dispatch, autonomous reconciler, `TaskLedger::try_dispatch` guarded mutator with `DispatchBlocked` enum, `StepFailureCause` + `QuarantinePolicy` cascade semantics on `PlanStep` ([#32](https://github.com/jdmiranda/phantom/issues/32), [#36](https://github.com/jdmiranda/phantom/issues/36)–[#40](https://github.com/jdmiranda/phantom/issues/40), [#45](https://github.com/jdmiranda/phantom/issues/45)–[#47](https://github.com/jdmiranda/phantom/issues/47), [#61](https://github.com/jdmiranda/phantom/issues/61), [#98](https://github.com/jdmiranda/phantom/issues/98)–[#99](https://github.com/jdmiranda/phantom/issues/99), [#647](https://github.com/jdmiranda/phantom/issues/647), [#649](https://github.com/jdmiranda/phantom/issues/649))
-- **phantom-loop** 🔧 — Loop overseer: durable repo-scoped LoopRunner pulling typed input from `LoopSource`, validating agent `complete_task` results against per-loop JSON schemas, routing typed `LoopMessage`s through `LoopQueueRegistry`. C1 (types + TOML parser) landed; C2/C3 in progress ([#650](https://github.com/jdmiranda/phantom/issues/650))
+- **phantom-brain** ✅ — Ambient OODA loop on a dedicated thread: event scoring, utility AI, action dispatch, autonomous reconciler, `TaskLedger::try_dispatch` guarded mutator with `DispatchBlocked` enum, `StepFailureCause` + `QuarantinePolicy` cascade semantics on `PlanStep`. Self-improvement reconciler (`crates/phantom-brain/src/self_improvement.rs`): `GoalSource` trait + `GhIssueGoalSource` + `GhCiFailureGoalSource` auto-discover candidate work from `jdmiranda/phantom`, `score_candidate` weighted-sum scorer, `HardExclusions` keyword filter, `TrustBudget` with 4 autonomy bands (SuggestionOnly / Conservative / Standard / Aggressive), `RateLimiter` per-hour / per-day / cooldown windows, `AuditEntry` JSONL persistence, `AiAction::EnqueueLoopMessage` forwarded to the loop overseer ([#32](https://github.com/jdmiranda/phantom/issues/32), [#36](https://github.com/jdmiranda/phantom/issues/36)–[#40](https://github.com/jdmiranda/phantom/issues/40), [#45](https://github.com/jdmiranda/phantom/issues/45)–[#47](https://github.com/jdmiranda/phantom/issues/47), [#61](https://github.com/jdmiranda/phantom/issues/61), [#98](https://github.com/jdmiranda/phantom/issues/98)–[#99](https://github.com/jdmiranda/phantom/issues/99), [#647](https://github.com/jdmiranda/phantom/issues/647), [#649](https://github.com/jdmiranda/phantom/issues/649), [#660](https://github.com/jdmiranda/phantom/issues/660))
+- **phantom-loop** ✅ — Loop overseer: durable repo-scoped `LoopRunner` async FSM pulling typed input from a pluggable `LoopSource` trait (`CronSource` for agentless poll loops, `LoopMessageQueueSource` for cross-loop fan-out, `GhIssueQueueSource` + `GhPrReviewQueueSource` for GitHub-backed inputs). Validates each agent's `complete_task` payload against the per-loop `ExitSchema`. Routes typed `LoopMessage`s through `LoopQueueRegistry`. `SubstrateAgentDispatcher` pushes `SpawnSubagentRequest`s onto the shared spawn queue with `requires_complete_task=true`. (PR #670 in flight adds a headless `SubstrateDriver` + `SubstrateBackend` trait — `ChatBackedSubstrateBackend` for production, `MockSubstrateBackend` for tests — so `phantom loop run` drains the queue without the GUI App.) CLI entry-point `phantom loop run --repo <path> --loops <names>` runs `check_gh_binary` / `check_gh_auth` / `check_mcp_collisions` preflight, acquires a `RunLock` at `<repo>/.phantom/loops/.runlock`, and registers each runner in `LoopRegistry` ([#650](https://github.com/jdmiranda/phantom/issues/650), [#665](https://github.com/jdmiranda/phantom/issues/665))
 - **phantom-nlp** 🔧 — Natural-language command interpreter; LLM call routing is a stub ([#55](https://github.com/jdmiranda/phantom/issues/55))
 - **phantom-context** ✅ — Project/git/environment detection and context assembly for agent prompts
 - **phantom-memory** 🔧 — Per-project knowledge store with event log and memory blocks; schema and event log pending ([#28](https://github.com/jdmiranda/phantom/issues/28), [#33](https://github.com/jdmiranda/phantom/issues/33), [#62](https://github.com/jdmiranda/phantom/issues/62), [#78](https://github.com/jdmiranda/phantom/issues/78))
@@ -152,6 +152,69 @@ All four properties of harness control are now in place on `main`. The 5 audit g
 2. **External state machine** — `phantom-brain::TaskLedger` with the `try_dispatch(idx) -> Result<&PlanStep, DispatchBlocked>` guarded mutator and the 9-state `AgentStatus` FSM (Queued, Planning, AwaitingApproval, Working, WaitingForTool, Paused, Done, Failed, Flatline). (Gaps closed: PR #654 — guarded dispatch with `DispatchBlocked`; PR #657 — `StepFailureCause` + `QuarantinePolicy` typed quarantine recovery.)
 3. **Structured exit** — `complete_task` lifecycle tool emitted by `phantom_agents::tools::lifecycle_tools()` when an agent is spawned with `AgentSpawnOpts::with_requires_complete_task(true)`. Result payload is a typed `Option<serde_json::Value>` on `Event::AgentTaskComplete`, validated against the per-loop `ExitSchema` from `phantom-loop`. A 3-strike `validation_failure_count` on `AgentPane` flatlines the pane after three consecutive schema-invalid `complete_task` calls; the legacy "PARTIAL" stringly-typed exit is gone. (Gaps closed: PR #652 — spike delivery path; PR #656 — production tool-list wiring + 3-strike flatline.)
 4. **Typed inter-agent messaging** — `phantom-protocol::Event` bus with 22 typed variants (and `EventTopic` routing) plus the new `Event::FastPathTaken { agent_id, kind: FastPathKind, reason }` envelope from PR #653. `phantom-loop::LoopMessage` adds typed inter-loop routing through `LoopQueueRegistry`.
+
+### Self-Improving Phantom
+
+The four properties above sum to a closed feedback loop: phantom-on-phantom. The brain auto-discovers work in its own repository, scores it for utility, and forwards the highest-scoring candidates to the loop overseer for autonomous implementation — no human prompting required. Phase 1 (harness control) is complete; the brain self-improvement layer landed in PR #669; the substrate driver wires the loop CLI to real agent spawning in PR #670; the brain↔queue bridge (`LoopQueueActionHandler` + headless brain boot in `phantom loop run`) is the final hookup.
+
+End-to-end flow once the bridge lands:
+
+```
+phantom-brain GoalSource polls jdmiranda/phantom (GhIssueGoalSource + GhCiFailureGoalSource)
+    -> phantom-brain self_improvement::score_candidate weighted-sum scorer
+    -> HardExclusions keyword filter + TrustBand threshold + RateLimiter window
+    -> AiAction::EnqueueLoopMessage emitted onto the brain action channel
+    -> LoopQueueActionHandler.enqueue_loop_message  (in-flight, brain<->queue bridge)
+    -> LoopQueueRegistry.push(implementer-queue, LoopMessage{...})
+    -> LoopRunner pulls via LoopMessageQueueSource
+    -> SubstrateAgentDispatcher builds AgentSpawnOpts with requires_complete_task=true
+    -> SubstrateDriver.tick drains SpawnSubagentQueue, runs ChatBackedSubstrateBackend
+    -> Claude API stream loops through TextDelta / ToolUse until complete_task tool call
+    -> Event::AgentTaskComplete fulfils the dispatcher's oneshot
+    -> LoopRunner validates the payload against the loop's ExitSchema
+    -> on_complete LoopEffects fire (typically EnqueueTo a downstream review-queue)
+```
+
+Source paths:
+- Brain scorer + state machine: `crates/phantom-brain/src/self_improvement.rs`
+- Goal sources: `crates/phantom-brain/src/goal_source/{mod,gh_issues,gh_ci}.rs`
+- Dispatch action variant: `crates/phantom-brain/src/events.rs` (`AiAction::EnqueueLoopMessage`)
+- Loop FSM: `crates/phantom-loop/src/runner/{fsm,source,dispatcher}.rs`
+- Substrate dispatcher: `crates/phantom-loop/src/dispatcher/substrate.rs`
+- Substrate driver (PR #670 branch): `crates/phantom-loop/src/dispatcher/driver.rs`
+- CLI entry-point: `crates/phantom/src/loop_cli.rs`
+- Design doc: `docs/design/brain-self-improvement.md`
+
+### Operating Phantom Self-Improvement
+
+```bash
+phantom loop run --repo <path> --loops pr_finder_review,pr_finder_impl,reviewer,implementer
+```
+
+Preflight gates (`crates/phantom/src/loop_cli.rs::run_command`, calling `phantom_loop::preflight`):
+- `check_gh_binary` — `gh` binary on PATH and executable.
+- `check_gh_auth` — `gh auth status` reports a logged-in account.
+- `check_mcp_collisions` — MCP tool names do not collide with the reserved `complete_task` / `abort_task` lifecycle names.
+- `RunLock::acquire(&repo)` — exclusive runlock at `<repo>/.phantom/loops/.runlock`. Released on Ctrl-C or process exit via `Drop`.
+
+Loop spec discovery: `<repo>/.phantom/loops/*.toml`. The shipped specs are `pr_finder_review.toml`, `pr_finder_impl.toml`, `reviewer.toml`, `implementer.toml` (see `.phantom/loops/` at repo root).
+
+Brain self-improvement config (`SelfImprovementConfig` in `crates/phantom-brain/src/self_improvement.rs`):
+- `enabled: bool` — default OFF per design doc §5.1; operator must opt in.
+- `queue_name: "implementer-queue"` — the brain's default destination.
+- `audit_log_path: Option<PathBuf>` — when set, every decision (enqueue or skip) appends one `AuditEntry` JSONL envelope.
+- `per_hour: u32`, `per_day: u32`, `cooldown: Duration` — `RateLimiter` ceilings.
+- `max_in_flight: u32` — concurrent in-flight cap.
+
+Trust bands (`TrustBand` in `self_improvement.rs`, ramps automatically on enqueue success / failure):
+- **SuggestionOnly** (budget 0) — no auto-enqueue regardless of score.
+- **Conservative** (budget 1-3) — raised threshold 0.85, halved per-hour ceiling.
+- **Standard** (budget 4-9) — design-doc defaults.
+- **Aggressive** (budget 10-20) — lowered threshold 0.65, doubled per-hour ceiling.
+
+A `critical` / `regression` / `blocker` label on a candidate floors the score at `CRITICAL_LABEL_FLOOR = 0.85` per design doc §7.1.
+
+The audit log JSONL file (path passed via `SelfImprovementConfig::audit_log_path`) captures every decision with `external_id`, `source`, `score`, `score_breakdown`, `decision`, and `reason`. Tail it to inspect autonomous activity.
 
 ## Build Process Details
 


### PR DESCRIPTION
## Summary

Doc-only refresh of `CLAUDE.md` to reflect the eight PRs that landed (or are landing) since THETA's last refresh in #659. After this PR, `CLAUDE.md` describes the full phantom-on-phantom self-improvement pipeline end-to-end.

## Sections updated

- **Architecture Overview -> AI & Intelligence -> `phantom-brain` bullet** — appended self-improvement reconciler symbols: `GoalSource` trait + `GhIssueGoalSource` + `GhCiFailureGoalSource` auto-discovery, `score_candidate` weighted-sum scorer, `HardExclusions` keyword filter, `TrustBudget` with 4 autonomy bands, `RateLimiter` per-hour / per-day / cooldown windows, `AuditEntry` JSONL persistence, `AiAction::EnqueueLoopMessage`. Issue refs: #647, #649, #660.
- **Architecture Overview -> AI & Intelligence -> `phantom-loop` bullet** — promoted from skeletal to operational. Documents the full picture now: `LoopRunner` async FSM, `LoopSource` trait + 4 concrete sources (`CronSource`, `LoopMessageQueueSource`, `GhIssueQueueSource`, `GhPrReviewQueueSource`), `SubstrateAgentDispatcher`, the in-flight `SubstrateDriver` + `SubstrateBackend` trait from PR #670, `LoopQueueRegistry`, and the `phantom loop run` CLI with `check_gh_binary` / `check_gh_auth` / `check_mcp_collisions` preflight + `RunLock`. Issue refs: #650, #665.
- **Key Architectural Decisions -> Self-Improving Phantom (new subsection)** — pipeline-diagram description of the end-to-end flow from `GoalSource` poll through `score_candidate` filtering, `AiAction::EnqueueLoopMessage` emission, `LoopQueueActionHandler` (in-flight brain<->queue bridge), `LoopQueueRegistry` push, `LoopMessageQueueSource` pull, `SubstrateAgentDispatcher` build, `SubstrateDriver.tick` drain, `ChatBackedSubstrateBackend` Claude API stream, `complete_task` tool call, `Event::AgentTaskComplete` oneshot fulfilment, `ExitSchema` validation, and `on_complete` effects. Includes source-path citations.
- **Key Architectural Decisions -> Operating Phantom Self-Improvement (new subsection)** — operator-facing reference: the CLI invocation, preflight gates with source paths, loop spec discovery convention (`.phantom/loops/*.toml`), `SelfImprovementConfig` knobs (`enabled`, `queue_name`, `audit_log_path`, `per_hour`, `per_day`, `cooldown`, `max_in_flight`), 4 trust bands with thresholds and ceilings, the `critical` / `regression` / `blocker` label score floor of 0.85, and the JSONL audit-log format.

## Verification

Every cited symbol verified against `git show origin/main:<path>` before edit:

- `phantom-brain` — `self_improvement::{score_candidate, TrustBand, HardExclusions, RateLimiter, AuditEntry, SelfImprovementConfig}`, `goal_source::{GoalSource, GhIssueGoalSource, GhCiFailureGoalSource}`, `events::AiAction::EnqueueLoopMessage`.
- `phantom-loop` — `runner::{LoopRunner, LoopSource}`, `sources::{CronSource, LoopMessageQueueSource, GhIssueQueueSource, GhPrReviewQueueSource}`, `dispatcher::SubstrateAgentDispatcher`, `queue::{LoopMessage, LoopQueueRegistry}`, `preflight::{check_gh_binary, check_gh_auth, check_mcp_collisions, RunLock}`.
- `phantom` — `crates/phantom/src/loop_cli.rs::run_loop_subcommand`, lines 129 / 131 / 136 / 138 for the preflight calls.

PR #670 (open) symbols (`SubstrateDriver`, `SubstrateBackend`, `ChatBackedSubstrateBackend`, `MockSubstrateBackend`) verified against the PR's source branch `feat/substrate-driver-for-loop-cli`.

## Confirmation

**Doc-only.** Diff is `CLAUDE.md` +65/-2 and nothing else. No code, no build, no test invocation. No question-mark sentences introduced (rule 8 compliance). Crate count unchanged at 32 (verified via `git show origin/main:Cargo.toml | grep -c '^crates/'`).

## Cited PRs (Wave C2/C3 landings + brain self-improvement)

- #658 — C1 scaffold: `phantom-loop` types + TOML parser + JSON-Schema binding.
- #661 — C2: `LoopRunner` async FSM, `LoopSource` trait, `LoopQueueRegistry`, effect runner, `CronSource`, `LoopMessageQueueSource`, `AgentDispatcher` trait.
- #664 — C3: `phantom loop run` CLI, `SubstrateAgentDispatcher`, `GhIssueQueueSource`, `GhPrReviewQueueSource`, preflight gates, `LoopRegistry`. Closed #650.
- #666 — Split `pr_finder` into single-source `pr_finder_review` + `pr_finder_impl`.
- #667 — Forward `LoopInput.key` + `payload` to effects for agentless loops.
- #668 — Cleared 30 pre-existing `phantom-app` errors (8 build + 13 test-build + 5 latent runtime + 4 clippy).
- #669 — Brain self-improvement scoring per `docs/design/brain-self-improvement.md`: `GoalSource` trait, `GhIssueGoalSource`, `GhCiFailureGoalSource`, `HardExclusions`, `TrustBudget`, `RateLimiter`, JSONL audit log, `AiAction::EnqueueLoopMessage`.
- #670 (open) — `SubstrateDriver` + `SubstrateBackend` trait + `ChatBackedSubstrateBackend` (prod) + `MockSubstrateBackend` (test); wires `phantom loop run` to real agent spawning.

## Test plan

- [x] `git diff --stat` shows only `CLAUDE.md` modified, +65/-2.
- [x] `git log origin/main..HEAD --oneline` shows exactly one commit (single-commit hygiene).
- [x] No question-mark sentences in `CLAUDE.md` (rule 8); `grep -c '?'` returns 0.
- [x] Crate count (32) matches `Cargo.toml` workspace members on `origin/main`.
- [x] All cited symbols resolved against `origin/main` (or the PR #670 branch for in-flight symbols).

## Rot noted but not fixed (out of scope per mission)

- The `phantom-bundles` bullet still says "schema-only types; serialization and capture pipeline integration pending" but PR #627 wired `CaptureSession` + the OpenAI embedding backend end-to-end. Already flagged by THETA in PR #659; remains unfixed.
- The `phantom-voice` bullet says "real TTS pending" but PR #618 wired TTS end-to-end and closed issue #69. Already flagged by THETA in PR #659; remains unfixed.
- The `AI Agent System` decision still says "Tool Framework: 7 core tools" — the dispatch routes through file / git / chat / composer / defender / dispatcher / carto / lifecycle tool surfaces now, well past the original 7. Already flagged by THETA in PR #659; remains unfixed.
- The `phantom-dag` bullet still wears the skeletal mark even though the in-progress branch `feat/phantom-context-codedag-wiring` (commit `320a013`) wired `CodeDag` into `ContextAssembler`. That commit is unmerged so the mark is technically correct, but worth tracking once the PR lands.

The mission scoped this PR to the self-improvement landings only; the above are flagged for a follow-up refresh.

Generated with [Claude Code](https://claude.com/claude-code)