### PR TITLE
feat(phantom-builder): point Phantom at any GitHub repo and eat all the issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6041,6 +6041,7 @@ dependencies = [
  "phantom-agents",
  "phantom-app",
  "phantom-brain",
+ "phantom-builder",
  "phantom-context",
  "phantom-fleet",
  "phantom-history",
@@ -6171,6 +6172,25 @@ dependencies = [
  "tokio",
  "ureq",
  "uuid",
+]
+
+[[package]]
+name = "phantom-builder"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "dirs 5.0.1",
+ "phantom-agents",
+ "phantom-brain",
+ "phantom-loop",
+ "phantom-protocol",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "toml",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ members = [
     "crates/phantom-loop",
     # App-of-apps meta-orchestrator hosting multiple builders + loops.
     "crates/phantom-fleet",
+    # Higher-level builder orchestration on top of phantom-loop + phantom-brain.
+    "crates/phantom-builder",
 ]
 resolver = "2"
 

--- a/crates/phantom-brain/src/self_improvement.rs
+++ b/crates/phantom-brain/src/self_improvement.rs
@@ -599,7 +599,19 @@ impl SelfImprovementState {
     /// [`TRUST_BUDGET_START`].
     #[must_use]
     pub fn new(config: SelfImprovementConfig) -> Self {
-        let budget = TrustBudget::new();
+        Self::with_trust_budget(config, TrustBudget::new())
+    }
+
+    /// Construct with the given config and an explicit starting trust budget.
+    ///
+    /// The standard [`Self::new`] always opens at [`TRUST_BUDGET_START`] (4 =
+    /// standard band). Callers that need to begin at a different band — most
+    /// notably the `phantom-builder` crate, which exposes a `--trust-band`
+    /// CLI flag — use this constructor to seed the budget directly. The
+    /// per-hour cap on the rate limiter is recomputed against the supplied
+    /// budget so the operator's choice takes effect immediately.
+    #[must_use]
+    pub fn with_trust_budget(config: SelfImprovementConfig, budget: TrustBudget) -> Self {
         let rate_limit = RateLimiter::with_caps(
             budget.per_hour_cap(config.per_hour),
             config.per_day,

--- a/crates/phantom-builder/Cargo.toml
+++ b/crates/phantom-builder/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "phantom-builder"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+name = "phantom_builder"
+path = "src/lib.rs"
+
+[dependencies]
+# The two infrastructure crates we orchestrate. The builder is a thin layer
+# over `phantom-loop` (the runtime that owns the FSM, queues, and dispatchers)
+# and `phantom-brain` (the OODA loop that emits goal-candidates).
+phantom-loop = { path = "../phantom-loop" }
+phantom-brain = { path = "../phantom-brain" }
+phantom-protocol = { path = "../phantom-protocol" }
+phantom-agents = { path = "../phantom-agents" }
+
+# Plain-data shapes: BuilderConfig is serde so future callers can ship one
+# from a TOML on disk if they want a `phantom-builder.toml`.
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"
+serde_json = "1"
+
+# Error plumbing matches the CLI conventions: anyhow at the top, custom error
+# types only where the public API needs to discriminate.
+anyhow = { workspace = true }
+thiserror = "1"
+
+# Observability.
+tracing = "0.1"
+
+# Async runtime — the builder's `run_builder` consumes a tokio runtime so the
+# CLI can construct it once and share it with the substrate driver tick loop
+# and the substrate completion router.
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync", "time", "process", "signal"] }
+
+# Path helpers for the default clone destination (`~/.phantom/builds/...`).
+dirs = "5"
+
+[dev-dependencies]
+tempfile = "3"
+phantom-loop = { path = "../phantom-loop" }
+
+[lints]
+workspace = true

--- a/crates/phantom-builder/src/clone.rs
+++ b/crates/phantom-builder/src/clone.rs
@@ -1,0 +1,207 @@
+//! Local checkout management for builder targets.
+//!
+//! Two paths:
+//!
+//! 1. **Override** — when [`ensure_local_checkout`] receives `Some(override_path)`,
+//!    the path is used verbatim. The function only checks the path exists and is
+//!    a directory; it does NOT validate that the remote URL matches the target
+//!    slug, because in practice `--repo-path /Users/me/work/already-cloned-repo`
+//!    is the power-user override.
+//! 2. **Default** — otherwise the checkout lives at
+//!    `~/.phantom/builds/<owner>-<repo>`. If the directory already exists, the
+//!    builder refreshes it with `git fetch && git checkout origin/main`. If it
+//!    does not, the builder clones from `https://github.com/<owner>/<repo>.git`.
+//!
+//! Both paths return an absolute [`PathBuf`] to the working directory.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::{BuilderError, parse_slug};
+
+/// Resolve a working-copy path for the target slug.
+///
+/// See module docs for the override / default split.
+///
+/// # Errors
+///
+/// - [`BuilderError::InvalidSlug`] if `slug` is malformed.
+/// - [`BuilderError::NoHomeDirectory`] when the default location is selected
+///   but `$HOME` cannot be resolved.
+/// - [`BuilderError::Git`] when the clone or refresh shells out non-zero.
+/// - [`BuilderError::Io`] when the parent directory cannot be created.
+pub fn ensure_local_checkout(
+    slug: &str,
+    override_path: Option<&Path>,
+) -> Result<PathBuf, BuilderError> {
+    let (owner, repo) = parse_slug(slug)?;
+
+    if let Some(path) = override_path {
+        if !path.exists() {
+            return Err(BuilderError::Io {
+                path: path.to_path_buf(),
+                source: std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "--repo-path does not exist",
+                ),
+            });
+        }
+        if !path.is_dir() {
+            return Err(BuilderError::Io {
+                path: path.to_path_buf(),
+                source: std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "--repo-path is not a directory",
+                ),
+            });
+        }
+        // Canonicalize so downstream filesystem ops always see an absolute
+        // path. If canonicalize fails (unusual on an existing path), fall
+        // back to the as-given form rather than failing the operation —
+        // the existence and directory checks above already cover the common
+        // error cases.
+        return Ok(path.canonicalize().unwrap_or_else(|_| path.to_path_buf()));
+    }
+
+    let default = default_checkout_path(owner, repo)?;
+    if default.exists() {
+        refresh_existing(&default)?;
+    } else {
+        clone_fresh(slug, &default)?;
+    }
+    Ok(default.canonicalize().unwrap_or(default))
+}
+
+/// Compute the default checkout path: `~/.phantom/builds/<owner>-<repo>`.
+///
+/// # Errors
+///
+/// Returns [`BuilderError::NoHomeDirectory`] when `$HOME` cannot be resolved.
+pub fn default_checkout_path(owner: &str, repo: &str) -> Result<PathBuf, BuilderError> {
+    let home = dirs::home_dir().ok_or(BuilderError::NoHomeDirectory)?;
+    Ok(home
+        .join(".phantom")
+        .join("builds")
+        .join(format!("{owner}-{repo}")))
+}
+
+/// Run `git fetch && git checkout origin/main` against an existing clone.
+///
+/// We tolerate failures of `git checkout origin/main` because some repos use
+/// `master` or another default branch. In that case the directory stays on
+/// whatever the working tree had — the loop runner will pick up the issue
+/// and the agent will deal with it.
+fn refresh_existing(path: &Path) -> Result<(), BuilderError> {
+    tracing::info!(path = %path.display(), "refreshing existing builder checkout");
+    let fetch = Command::new("git")
+        .args(["fetch", "--quiet", "--all", "--prune"])
+        .current_dir(path)
+        .output()
+        .map_err(|e| BuilderError::Git(format!("git fetch failed to spawn: {e}")))?;
+    if !fetch.status.success() {
+        return Err(BuilderError::Git(format!(
+            "git fetch returned {}: {}",
+            fetch.status,
+            String::from_utf8_lossy(&fetch.stderr).trim()
+        )));
+    }
+    // Best-effort checkout to origin/main. A non-zero exit is logged but not
+    // fatal — see the function header comment.
+    let checkout = Command::new("git")
+        .args(["checkout", "--quiet", "origin/main"])
+        .current_dir(path)
+        .output();
+    match checkout {
+        Ok(out) if out.status.success() => {
+            tracing::debug!("git checkout origin/main succeeded");
+        }
+        Ok(out) => {
+            tracing::warn!(
+                stderr = %String::from_utf8_lossy(&out.stderr).trim(),
+                "git checkout origin/main returned non-zero — leaving worktree as-is",
+            );
+        }
+        Err(e) => {
+            tracing::warn!("git checkout origin/main failed to spawn: {e}");
+        }
+    }
+    Ok(())
+}
+
+/// Run `git clone https://github.com/<slug>.git <dest>`.
+fn clone_fresh(slug: &str, dest: &Path) -> Result<(), BuilderError> {
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent).map_err(|source| BuilderError::Io {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    let url = format!("https://github.com/{slug}.git");
+    tracing::info!(url = %url, dest = %dest.display(), "cloning builder target");
+    let out = Command::new("git")
+        .args(["clone", "--quiet", &url])
+        .arg(dest)
+        .output()
+        .map_err(|e| BuilderError::Git(format!("git clone failed to spawn: {e}")))?;
+    if !out.status.success() {
+        return Err(BuilderError::Git(format!(
+            "git clone {url} returned {}: {}",
+            out.status,
+            String::from_utf8_lossy(&out.stderr).trim()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn default_path_layout_uses_owner_dash_repo() {
+        // Skip when $HOME is unset (rare in CI but possible).
+        if dirs::home_dir().is_none() {
+            return;
+        }
+        let path = default_checkout_path("jdmiranda", "phantom").unwrap();
+        let last = path.components().next_back().unwrap();
+        assert_eq!(last.as_os_str(), "jdmiranda-phantom");
+        let parent = path.parent().unwrap();
+        assert_eq!(parent.file_name().unwrap(), "builds");
+        let grand = parent.parent().unwrap();
+        assert_eq!(grand.file_name().unwrap(), ".phantom");
+    }
+
+    #[test]
+    fn override_path_returns_absolute_directory_when_it_exists() {
+        let tmp = tempdir().unwrap();
+        let path = ensure_local_checkout("foo/bar", Some(tmp.path())).unwrap();
+        assert!(path.is_absolute());
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn override_path_rejects_missing_directory() {
+        let tmp = tempdir().unwrap();
+        let missing = tmp.path().join("does-not-exist");
+        let err = ensure_local_checkout("foo/bar", Some(&missing)).unwrap_err();
+        assert!(matches!(err, BuilderError::Io { .. }));
+    }
+
+    #[test]
+    fn override_path_rejects_file_instead_of_directory() {
+        let tmp = tempdir().unwrap();
+        let file = tmp.path().join("a-file");
+        std::fs::write(&file, "not a directory").unwrap();
+        let err = ensure_local_checkout("foo/bar", Some(&file)).unwrap_err();
+        assert!(matches!(err, BuilderError::Io { .. }));
+    }
+
+    #[test]
+    fn invalid_slug_short_circuits_before_filesystem_work() {
+        let tmp = tempdir().unwrap();
+        let err = ensure_local_checkout("not-a-slug", Some(tmp.path())).unwrap_err();
+        assert!(matches!(err, BuilderError::InvalidSlug(_)));
+    }
+}

--- a/crates/phantom-builder/src/lib.rs
+++ b/crates/phantom-builder/src/lib.rs
@@ -1,0 +1,329 @@
+//! Phantom builder — a higher-level orchestration layer on top of the
+//! [`phantom_loop`] + [`phantom_brain`] infrastructure that lets the user
+//! point Phantom at any GitHub repository and have it work through all the
+//! open issues autonomously.
+//!
+//! # Topology
+//!
+//! ```text
+//!   phantom builder run <owner>/<repo>
+//!       │
+//!       ▼
+//!   ensure_local_checkout(slug, override) ──► <path>
+//!       │  git clone OR `git fetch && git checkout origin/main`
+//!       ▼
+//!   write_default_specs(path, slug)
+//!       │  drops pr_finder_review.toml, pr_finder_impl.toml,
+//!       │  reviewer.toml, implementer.toml into <path>/.phantom/loops/
+//!       │  with `repo = "<slug>"` substituted on every gh_pr/gh_issues source
+//!       ▼
+//!   build_loop_runtime(...)
+//!       │  reuses phantom-loop's LoopRegistry + LoopQueueRegistry
+//!       │  + SubstrateAgentDispatcher + SubstrateDriver
+//!       ▼
+//!   build_brain_with_self_improvement(slug, safety, trust_band)
+//!       │  reuses phantom-brain's BrainConfig + SelfImprovementState
+//!       │  + GhIssueGoalSource (label_filter = None → ALL open issues)
+//!       │  + GhCiFailureGoalSource
+//!       ▼
+//!   forward brain actions → LoopQueueActionHandler → LoopQueueRegistry
+//! ```
+//!
+//! # Safety
+//!
+//! Three knobs in [`BuilderSafetyConfig`] limit autonomy:
+//!
+//! - `dry_run`: when true, the brain emits scoring decisions but the
+//!   action forwarder substitutes a [`safety::DryRunActionHandler`] that
+//!   logs intent without enqueueing. The substrate driver never sees a
+//!   request.
+//! - `max_prs_per_hour`: clamps the brain's per-hour rate limiter cap.
+//! - `max_concurrent_agents`: the loop spec writer caps every spec's
+//!   `max_concurrent` field at this value.
+//!
+//! # Trust band
+//!
+//! The brain's [`TrustBudget`][phantom_brain::self_improvement::TrustBudget]
+//! defaults to band 1 (`Conservative`) in the builder — the per-hour cap is
+//! halved and the score threshold raised to 0.85. Operators ramp upward
+//! explicitly via [`BuilderConfig::trust_band`]. The builder never spawns
+//! at band 3 (`Aggressive`) by default — that is the operator's call.
+
+pub mod clone;
+pub mod orchestrate;
+pub mod safety;
+pub mod templates;
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+pub use phantom_brain::self_improvement::TrustBand;
+
+pub use orchestrate::{Builder, BuilderHooks, BuilderResult, RunArtifacts};
+pub use safety::{BuilderSafetyConfig, DryRunActionHandler};
+
+// ---------------------------------------------------------------------------
+// BuilderConfig — the public knob surface
+// ---------------------------------------------------------------------------
+
+/// Top-level config for [`Builder::run`].
+///
+/// Plain data so callers can construct one from CLI flags (the production
+/// path) or deserialize from TOML (a future `phantom-builder.toml`). Every
+/// field has a documented default; the CLI surfaces only the knobs that
+/// commonly diverge from the default.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BuilderConfig {
+    /// Target repository slug in `owner/repo` form, e.g. `"jdmiranda/phantom"`.
+    pub target_slug: String,
+
+    /// When set, use this directory as the working copy instead of cloning to
+    /// the default `~/.phantom/builds/<owner>-<repo>` path. The directory must
+    /// already be a git checkout of `target_slug`; the builder does not
+    /// validate the remote URL because in practice `phantom builder run`
+    /// against an existing local clone is a power-user path.
+    #[serde(default)]
+    pub repo_path: Option<PathBuf>,
+
+    /// Trust band the brain operates at. Defaults to [`TrustBand::Conservative`]
+    /// (band 1) — active but rate-limited. The operator opts up to standard
+    /// (band 2) or aggressive (band 3) by passing the `--trust-band` flag.
+    #[serde(default = "default_trust_band")]
+    pub trust_band: TrustBandConfig,
+
+    /// Optional label filter for the brain's `GhIssueGoalSource`. The default
+    /// (`None`) means **all open issues** become candidates — this is the
+    /// "builder eats every issue" mode that differentiates the builder from
+    /// `phantom loop run`'s opinionated `priority:*`-filtered default.
+    #[serde(default)]
+    pub label_filter: Option<Vec<String>>,
+
+    /// Safety rails: rate caps, concurrency caps, and dry-run mode.
+    #[serde(default)]
+    pub safety: BuilderSafetyConfig,
+
+    /// Which loop specs to start. Defaults to the canonical four-loop pipeline:
+    /// `["pr_finder_review", "pr_finder_impl", "reviewer", "implementer"]`.
+    #[serde(default = "default_loops")]
+    pub loops: Vec<String>,
+}
+
+impl BuilderConfig {
+    /// Build the minimum-viable config for a target slug. Every other field
+    /// is filled with the documented default.
+    #[must_use]
+    pub fn new(target_slug: impl Into<String>) -> Self {
+        Self {
+            target_slug: target_slug.into(),
+            repo_path: None,
+            trust_band: default_trust_band(),
+            label_filter: None,
+            safety: BuilderSafetyConfig::default(),
+            loops: default_loops(),
+        }
+    }
+}
+
+fn default_loops() -> Vec<String> {
+    vec![
+        "pr_finder_review".to_string(),
+        "pr_finder_impl".to_string(),
+        "reviewer".to_string(),
+        "implementer".to_string(),
+    ]
+}
+
+fn default_trust_band() -> TrustBandConfig {
+    TrustBandConfig::Conservative
+}
+
+/// Serializable mirror of [`phantom_brain::self_improvement::TrustBand`].
+///
+/// `TrustBand` upstream is a plain enum with no `Serialize` impl — we shadow
+/// it here so `BuilderConfig` can round-trip through TOML / JSON without
+/// requiring a third-party feature on the brain crate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrustBandConfig {
+    /// Band 0: suggestion-only. The brain never enqueues; useful for shadow runs.
+    SuggestionOnly,
+    /// Band 1: conservative. Default for the builder — score threshold 0.85,
+    /// per-hour cap halved.
+    Conservative,
+    /// Band 2: standard. Score threshold 0.75, per-hour cap at default.
+    Standard,
+    /// Band 3: aggressive. Score threshold 0.65, per-hour cap doubled.
+    Aggressive,
+}
+
+impl TrustBandConfig {
+    /// Map the symbolic band to the starting trust-budget integer.
+    ///
+    /// See `phantom_brain::self_improvement::TrustBudget::band` for the band
+    /// boundaries.
+    #[must_use]
+    pub fn starting_budget(self) -> u32 {
+        match self {
+            Self::SuggestionOnly => 0,
+            Self::Conservative => 2,
+            Self::Standard => 6,
+            Self::Aggressive => 15,
+        }
+    }
+}
+
+impl From<TrustBandConfig> for TrustBand {
+    fn from(value: TrustBandConfig) -> Self {
+        match value {
+            TrustBandConfig::SuggestionOnly => Self::SuggestionOnly,
+            TrustBandConfig::Conservative => Self::Conservative,
+            TrustBandConfig::Standard => Self::Standard,
+            TrustBandConfig::Aggressive => Self::Aggressive,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// BuilderError
+// ---------------------------------------------------------------------------
+
+/// Errors returned by the builder.
+///
+/// Variants split along the orchestration phases so the CLI can map each one
+/// to a precise stderr line.
+#[derive(Debug, Error)]
+pub enum BuilderError {
+    /// The target slug did not parse as `owner/repo`.
+    #[error("invalid slug `{0}` — expected `owner/repo`")]
+    InvalidSlug(String),
+
+    /// `git clone` (or the refresh path) failed.
+    #[error("git operation failed: {0}")]
+    Git(String),
+
+    /// Filesystem I/O failed while seeding specs or resolving the clone path.
+    #[error("io error at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The user's home directory could not be resolved (needed for the default
+    /// `~/.phantom/builds` location). Pass `--repo-path` to bypass.
+    #[error("could not resolve $HOME — pass --repo-path to override")]
+    NoHomeDirectory,
+
+    /// Loop spec parsing or seeding failed.
+    #[error("loop spec error: {0}")]
+    Spec(String),
+
+    /// Pre-flight gate (gh binary missing, gh auth, runlock) refused to run.
+    #[error("preflight failed: {0}")]
+    Preflight(String),
+
+    /// A miscellaneous error surfaced through `anyhow` from a delegated call
+    /// (e.g. the runtime building or the loop discovery walk).
+    #[error("orchestrate failed: {0}")]
+    Other(String),
+}
+
+impl From<anyhow::Error> for BuilderError {
+    fn from(value: anyhow::Error) -> Self {
+        Self::Other(value.to_string())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Slug helpers
+// ---------------------------------------------------------------------------
+
+/// Split a `owner/repo` slug into `(owner, repo)`.
+///
+/// # Errors
+///
+/// Returns [`BuilderError::InvalidSlug`] when `slug` does not contain exactly
+/// one `/` or either side is empty.
+pub fn parse_slug(slug: &str) -> Result<(&str, &str), BuilderError> {
+    let mut parts = slug.split('/');
+    match (parts.next(), parts.next(), parts.next()) {
+        (Some(owner), Some(repo), None) if !owner.is_empty() && !repo.is_empty() => {
+            Ok((owner, repo))
+        }
+        _ => Err(BuilderError::InvalidSlug(slug.to_string())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_slug_accepts_owner_repo() {
+        let (owner, repo) = parse_slug("jdmiranda/phantom").unwrap();
+        assert_eq!(owner, "jdmiranda");
+        assert_eq!(repo, "phantom");
+    }
+
+    #[test]
+    fn parse_slug_rejects_missing_slash() {
+        assert!(matches!(
+            parse_slug("nothingatall"),
+            Err(BuilderError::InvalidSlug(_))
+        ));
+    }
+
+    #[test]
+    fn parse_slug_rejects_empty_owner() {
+        assert!(matches!(
+            parse_slug("/repo"),
+            Err(BuilderError::InvalidSlug(_))
+        ));
+    }
+
+    #[test]
+    fn parse_slug_rejects_empty_repo() {
+        assert!(matches!(
+            parse_slug("owner/"),
+            Err(BuilderError::InvalidSlug(_))
+        ));
+    }
+
+    #[test]
+    fn parse_slug_rejects_extra_slash() {
+        assert!(matches!(
+            parse_slug("owner/repo/extra"),
+            Err(BuilderError::InvalidSlug(_))
+        ));
+    }
+
+    #[test]
+    fn default_loops_are_the_canonical_four() {
+        let loops = default_loops();
+        assert_eq!(loops.len(), 4);
+        assert!(loops.contains(&"pr_finder_review".to_string()));
+        assert!(loops.contains(&"pr_finder_impl".to_string()));
+        assert!(loops.contains(&"reviewer".to_string()));
+        assert!(loops.contains(&"implementer".to_string()));
+    }
+
+    #[test]
+    fn trust_band_config_maps_to_brain_band() {
+        let band: TrustBand = TrustBandConfig::Conservative.into();
+        assert_eq!(band, TrustBand::Conservative);
+        let band: TrustBand = TrustBandConfig::Aggressive.into();
+        assert_eq!(band, TrustBand::Aggressive);
+    }
+
+    #[test]
+    fn builder_config_new_uses_documented_defaults() {
+        let cfg = BuilderConfig::new("foo/bar");
+        assert_eq!(cfg.target_slug, "foo/bar");
+        assert!(cfg.repo_path.is_none());
+        assert_eq!(cfg.trust_band, TrustBandConfig::Conservative);
+        assert!(cfg.label_filter.is_none());
+        assert_eq!(cfg.loops.len(), 4);
+    }
+}

--- a/crates/phantom-builder/src/orchestrate.rs
+++ b/crates/phantom-builder/src/orchestrate.rs
@@ -1,0 +1,657 @@
+//! Builder orchestration.
+//!
+//! This module is the glue layer that turns a [`crate::BuilderConfig`] into a
+//! running pipeline. The work splits into six phases:
+//!
+//! 1. Clone or attach a local checkout via
+//!    [`crate::clone::ensure_local_checkout`].
+//! 2. Drop the default four-loop pipeline into `<repo>/.phantom/loops/` via
+//!    [`crate::templates::write_default_specs`].
+//! 3. Run the loop pre-flight gates (`gh` binary, `gh auth`, MCP names).
+//! 4. Construct the loop registry, queue registry, substrate dispatcher, and
+//!    substrate driver. Reuses [`phantom_loop`] primitives 1-for-1; nothing
+//!    is reimplemented here.
+//! 5. Construct the brain handle with a self-improvement reconciler keyed to
+//!    the target slug and the safety caps.
+//! 6. Spawn the action forwarder — either
+//!    [`phantom_loop::LoopQueueActionHandler`] (normal mode) or
+//!    [`crate::safety::DryRunActionHandler`] (dry-run mode).
+//!
+//! Tests inject a custom [`phantom_loop::SubstrateBackend`] and replace the
+//! default goal sources via [`BuilderHooks`]. The CLI never touches these
+//! hooks — it always builds the production wiring.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use phantom_agents::composer_tools::new_spawn_subagent_queue;
+use phantom_brain::brain::{BrainConfig, BrainHandle, spawn_brain};
+use phantom_brain::goal_source::{GhCiFailureGoalSource, GhIssueGoalSource, GoalSource};
+use phantom_brain::self_improvement::{
+    SelfImprovementConfig, SelfImprovementState, TrustBudget,
+};
+use phantom_loop::{
+    ChatBackedSubstrateBackend, LoopHandle, LoopQueueActionHandler, LoopQueueRegistry,
+    LoopRegistry, LoopRunner, LoopSource, LoopSourceSpec, LoopSpec, LoopStatus,
+    SubstrateAgentDispatcher, SubstrateBackend, SubstrateDriver,
+};
+
+use crate::{BuilderConfig, BuilderError};
+
+// ---------------------------------------------------------------------------
+// BuilderResult — bookkeeping returned to the caller
+// ---------------------------------------------------------------------------
+
+/// Outcome of a [`Builder::run`] invocation.
+#[derive(Debug)]
+pub struct BuilderResult {
+    /// Absolute path to the working copy the builder operated on.
+    pub repo_path: PathBuf,
+    /// Paths of the loop specs the builder seeded (or skipped because they
+    /// already existed).
+    pub seeded_specs: Vec<PathBuf>,
+    /// Number of loops successfully started.
+    pub started_loops: usize,
+}
+
+// ---------------------------------------------------------------------------
+// BuilderHooks — test injection surface
+// ---------------------------------------------------------------------------
+
+/// Optional dependency-injection seams used by integration tests.
+///
+/// Production callers leave this at [`BuilderHooks::default`]. Tests
+/// substitute:
+///
+/// - `substrate_backend`: a [`phantom_loop::MockSubstrateBackend`] so spawned
+///   agents return canned outcomes instead of hitting Claude.
+/// - `goal_sources`: a pre-built `Vec<Box<dyn GoalSource>>` with stub `gh`
+///   runners that return canned issues / CI failures. When `None`, the
+///   orchestrator builds the production sources via [`default_goal_sources`].
+/// - `skip_preflight`: when true, skip the `gh` binary / auth / runlock
+///   gates. Production sets this to false; tests set it to true so the
+///   smoke test does not require `gh` installed.
+#[derive(Default)]
+pub struct BuilderHooks {
+    pub substrate_backend: Option<Arc<dyn SubstrateBackend>>,
+    pub goal_sources: Option<Vec<Box<dyn GoalSource>>>,
+    pub skip_preflight: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Builder — top-level orchestrator
+// ---------------------------------------------------------------------------
+
+/// Top-level builder orchestrator.
+///
+/// Constructed from a [`BuilderConfig`] and consumed by one of:
+///
+/// - [`Builder::run`] — production path; blocks on Ctrl-C.
+/// - [`Builder::run_for_duration`] — test path; runs the runtime for a fixed
+///   duration then tears down.
+pub struct Builder {
+    config: BuilderConfig,
+    hooks: BuilderHooks,
+}
+
+impl Builder {
+    /// Build with production hooks.
+    #[must_use]
+    pub fn new(config: BuilderConfig) -> Self {
+        Self {
+            config,
+            hooks: BuilderHooks::default(),
+        }
+    }
+
+    /// Build with explicit hooks. Tests use this; the CLI calls [`Self::new`].
+    #[must_use]
+    pub fn with_hooks(config: BuilderConfig, hooks: BuilderHooks) -> Self {
+        Self { config, hooks }
+    }
+
+    /// Resolve a working-copy path for the target slug.
+    pub fn resolve_path(&self) -> Result<PathBuf, BuilderError> {
+        crate::clone::ensure_local_checkout(
+            &self.config.target_slug,
+            self.config.repo_path.as_deref(),
+        )
+    }
+
+    /// Seed default loop specs onto disk.
+    pub fn seed_specs(&self, repo_path: &std::path::Path) -> Result<Vec<PathBuf>, BuilderError> {
+        crate::templates::write_default_specs(repo_path, &self.config.target_slug)
+    }
+
+    /// Production entry-point. Resolves the checkout, seeds the specs, boots
+    /// the runtime + brain, and blocks on Ctrl-C.
+    pub fn run(self) -> Result<BuilderResult, BuilderError> {
+        let artifacts = self.run_inner()?;
+        let runtime = artifacts
+            .runtime
+            .as_ref()
+            .expect("runtime is None only after Drop runs");
+        runtime.block_on(async {
+            if let Err(e) = tokio::signal::ctrl_c().await {
+                tracing::warn!("ctrl-c handler error: {e}");
+            }
+        });
+        // Mirror what `RunArtifacts::Drop` would do, but capture the result
+        // before the artifacts are consumed.
+        let result_clone = BuilderResult {
+            repo_path: artifacts.result.repo_path.clone(),
+            seeded_specs: artifacts.result.seeded_specs.clone(),
+            started_loops: artifacts.result.started_loops,
+        };
+        artifacts.request_stop();
+        // artifacts dropped here → runtime shut down with timeout.
+        drop(artifacts);
+        Ok(result_clone)
+    }
+
+    /// Test entry-point. Runs the runtime for `duration` then tears down.
+    /// Returns ownership of the queue registry plus the runtime itself so
+    /// the test can poll queue depth before drop.
+    ///
+    /// This is the **synchronous** test entry-point: the call sleeps the
+    /// current thread for `duration` while the builder's internal runtime
+    /// drives the loop + brain on its own threads. Tests must invoke this
+    /// from a plain `#[test]` (not `#[tokio::test]`) so that the builder's
+    /// own multi-thread runtime is not nested inside an outer runtime.
+    pub fn run_for_duration(
+        self,
+        duration: std::time::Duration,
+    ) -> Result<RunArtifacts, BuilderError> {
+        let artifacts = self.run_inner()?;
+        // The runtime is alive on its own threads — sleep the caller and
+        // then issue an explicit teardown.
+        std::thread::sleep(duration);
+        for snap in artifacts.registry.list() {
+            let _ = artifacts.registry.stop(snap.id);
+        }
+        artifacts.driver_handle.abort();
+        Ok(artifacts)
+    }
+
+    /// Internal: build every runtime component and return them packaged in
+    /// [`RunArtifacts`] so either entry-point can tear them down on its own
+    /// terms.
+    fn run_inner(self) -> Result<RunArtifacts, BuilderError> {
+        let Builder { config, hooks } = self;
+        let BuilderHooks {
+            substrate_backend,
+            goal_sources: hook_goal_sources,
+            skip_preflight,
+        } = hooks;
+
+        // -- Phase 1: clone / attach ----------------------------------------
+        let repo_path = crate::clone::ensure_local_checkout(
+            &config.target_slug,
+            config.repo_path.as_deref(),
+        )?;
+        tracing::info!(path = %repo_path.display(), "builder resolved local checkout");
+
+        // -- Phase 2: seed specs --------------------------------------------
+        let seeded_specs =
+            crate::templates::write_default_specs(&repo_path, &config.target_slug)?;
+        tracing::info!(count = seeded_specs.len(), "builder seeded loop specs");
+
+        // -- Phase 3: preflight ---------------------------------------------
+        if !skip_preflight {
+            phantom_loop::check_gh_binary().map_err(|e| BuilderError::Preflight(e.to_string()))?;
+            phantom_loop::check_gh_auth().map_err(|e| BuilderError::Preflight(e.to_string()))?;
+            let no_mcp: Vec<&str> = Vec::new();
+            phantom_loop::check_mcp_collisions(no_mcp)
+                .map_err(|e| BuilderError::Preflight(e.to_string()))?;
+        }
+
+        // -- Phase 4: discover the seeded specs we plan to start ------------
+        let specs_dir = repo_path.join(".phantom").join("loops");
+        let all_specs = discover_specs(&specs_dir)?;
+        if all_specs.is_empty() {
+            return Err(BuilderError::Spec(format!(
+                "no loop specs at {} after seeding — \
+                 the templates module is likely misconfigured",
+                specs_dir.display()
+            )));
+        }
+
+        let mut targeted: Vec<(LoopSpec, Option<phantom_loop::ExitSchema>)> = Vec::new();
+        for name in &config.loops {
+            match all_specs.iter().find(|(s, _)| &s.id == name) {
+                Some((s, schema)) => {
+                    let mut spec = s.clone();
+                    let cap = config.safety.max_concurrent_agents;
+                    if spec.max_concurrent > cap {
+                        spec.max_concurrent = cap.max(1);
+                    }
+                    targeted.push((spec, schema.clone()));
+                }
+                None => {
+                    return Err(BuilderError::Spec(format!(
+                        "requested loop `{name}` not found among seeded specs (have: {})",
+                        all_specs
+                            .iter()
+                            .map(|(s, _)| s.id.as_str())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )));
+                }
+            }
+        }
+
+        // -- Phase 5: build the tokio runtime + loop runtime ----------------
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| BuilderError::Other(format!("tokio runtime build failed: {e}")))?;
+
+        let registry = Arc::new(LoopRegistry::new());
+        let queues = Arc::new(LoopQueueRegistry::new());
+        let spawn_queue = new_spawn_subagent_queue();
+        let dispatcher = Arc::new(SubstrateAgentDispatcher::with_default_parent(
+            spawn_queue.clone(),
+        ));
+
+        let backend: Arc<dyn SubstrateBackend> = substrate_backend.unwrap_or_else(|| {
+            Arc::new(ChatBackedSubstrateBackend::default()) as Arc<dyn SubstrateBackend>
+        });
+        let (event_tx, mut event_rx) =
+            tokio::sync::mpsc::channel::<phantom_protocol::Event>(64);
+        let driver = SubstrateDriver::new(spawn_queue.clone(), backend, event_tx);
+        let router = dispatcher.completion_router();
+
+        let registry_clone = Arc::clone(&registry);
+        let queues_clone = Arc::clone(&queues);
+        let dispatcher_clone: Arc<dyn phantom_loop::AgentDispatcher> = dispatcher.clone();
+        let driver_handle = runtime.block_on(async move {
+            let driver_join = driver.run();
+            tokio::spawn(async move {
+                while let Some(event) = event_rx.recv().await {
+                    router.on_completion(event);
+                }
+            });
+
+            for (spec, schema) in targeted {
+                let id = registry_clone.alloc_id();
+                let status = Arc::new(std::sync::Mutex::new(LoopStatus::Idle));
+                let spec_id = spec.id.clone();
+                let source = build_source(&spec, &queues_clone)?;
+                let runner = LoopRunner::new(
+                    Arc::new(spec),
+                    schema,
+                    source,
+                    Arc::clone(&queues_clone),
+                    Arc::clone(&dispatcher_clone),
+                );
+                let status_for_task = Arc::clone(&status);
+                let join_handle = tokio::spawn(async move {
+                    let reason = runner.run().await;
+                    if let Ok(mut s) = status_for_task.lock() {
+                        *s = LoopStatus::Stopped { reason };
+                    }
+                });
+                registry_clone.register(
+                    id,
+                    LoopHandle {
+                        spec_id,
+                        status,
+                        started_at: SystemTime::now(),
+                        join_handle: Some(join_handle),
+                    },
+                );
+            }
+            Result::<_, BuilderError>::Ok(driver_join)
+        })?;
+        let started_loops = registry.list().len();
+
+        // -- Phase 6: brain boot --------------------------------------------
+        let stop_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let dry_count = boot_brain(
+            &config,
+            hook_goal_sources,
+            &repo_path,
+            &runtime,
+            Arc::clone(&queues),
+            Arc::clone(&stop_flag),
+        )?;
+
+        Ok(RunArtifacts {
+            result: BuilderResult {
+                repo_path,
+                seeded_specs,
+                started_loops,
+            },
+            runtime: Some(runtime),
+            registry,
+            driver_handle,
+            queues,
+            dry_count,
+            stop_flag,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RunArtifacts — the test-visible bundle of running components
+// ---------------------------------------------------------------------------
+
+/// Bundle of everything `run_inner` constructs. The production path uses
+/// only the `result` + `runtime` (the rest is held to keep the runtime alive
+/// for the brain forwarder and substrate driver). Tests use every field.
+pub struct RunArtifacts {
+    /// Caller-visible summary.
+    pub result: BuilderResult,
+    /// The tokio runtime hosting every async task. Held by the caller so
+    /// the runtime is not dropped (which would abort the brain forwarder).
+    ///
+    /// Wrapped in `Option` so [`Self::drop`] can `take()` it and shut it
+    /// down with an explicit `shutdown_timeout` — otherwise the runtime's
+    /// own `Drop` waits for spawn_blocking tasks that loop forever.
+    pub runtime: Option<tokio::runtime::Runtime>,
+    /// The loop registry — tests inspect started_loops; production teardown
+    /// iterates this on Ctrl-C.
+    pub registry: Arc<LoopRegistry>,
+    /// Substrate driver tick task; aborted on teardown.
+    pub driver_handle: tokio::task::JoinHandle<()>,
+    /// Shared cross-loop queue registry. Tests assert what landed here.
+    pub queues: Arc<LoopQueueRegistry>,
+    /// When the brain was booted in dry-run mode, a shared counter the test
+    /// can use to assert that exactly N would-be-enqueue events fired.
+    /// `None` in normal mode.
+    pub dry_count: Option<Arc<std::sync::atomic::AtomicUsize>>,
+    /// Signal flag the brain action forwarder polls between
+    /// `try_recv_action` checks. Setting it to `true` (via
+    /// [`Self::request_stop`]) lets the forwarder loop exit cleanly so
+    /// the runtime can shut down without waiting for the spawn_blocking
+    /// task forever.
+    pub stop_flag: Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl RunArtifacts {
+    /// Signal the brain action forwarder to exit. Used by tests during
+    /// teardown — call this before dropping the artifacts to avoid the
+    /// runtime hanging on its spawn_blocking tasks.
+    pub fn request_stop(&self) {
+        self.stop_flag
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        self.driver_handle.abort();
+    }
+}
+
+impl Drop for RunArtifacts {
+    fn drop(&mut self) {
+        // Signal the forwarder, then shut down the runtime with a timeout
+        // so the test does not hang if the forwarder is currently inside
+        // a 50 ms sleep when stop_flag flips.
+        self.stop_flag
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        self.driver_handle.abort();
+        if let Some(rt) = self.runtime.take() {
+            rt.shutdown_timeout(std::time::Duration::from_millis(500));
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Brain boot — separate function so it consumes hooks cleanly
+// ---------------------------------------------------------------------------
+
+/// Build the brain handle and start the action forwarder.
+///
+/// Returns the dry-run counter when the safety config is in dry-run mode, or
+/// `None` otherwise.
+fn boot_brain(
+    config: &BuilderConfig,
+    hook_goal_sources: Option<Vec<Box<dyn GoalSource>>>,
+    repo_path: &std::path::Path,
+    runtime: &tokio::runtime::Runtime,
+    queues: Arc<LoopQueueRegistry>,
+    stop_flag: Arc<std::sync::atomic::AtomicBool>,
+) -> Result<Option<Arc<std::sync::atomic::AtomicUsize>>, BuilderError> {
+    if matches!(config.trust_band, crate::TrustBandConfig::SuggestionOnly) {
+        tracing::info!("trust band is SuggestionOnly — skipping brain boot");
+        return Ok(None);
+    }
+
+    let safety = &config.safety;
+    let si_config = SelfImprovementConfig {
+        enabled: true,
+        per_hour: safety.max_prs_per_hour,
+        ..Default::default()
+    };
+    let starting_budget = config.trust_band.starting_budget();
+    let state = SelfImprovementState::with_trust_budget(
+        si_config,
+        TrustBudget::from_score(starting_budget),
+    );
+
+    let goal_sources = hook_goal_sources.unwrap_or_else(|| {
+        default_goal_sources(&config.target_slug, config.label_filter.as_deref())
+    });
+
+    let brain: BrainHandle = spawn_brain(BrainConfig {
+        project_dir: repo_path.to_string_lossy().to_string(),
+        enable_suggestions: true,
+        enable_memory: true,
+        quiet_threshold: 0.5,
+        router: None,
+        catalog: None,
+        privacy_mode: false,
+        relay_inbound_rx: None,
+        history_context: Vec::new(),
+        self_improvement: Some(state),
+        goal_sources,
+    });
+
+    let dry_run = safety.dry_run;
+    let dry_counter = if dry_run {
+        Some(Arc::new(std::sync::atomic::AtomicUsize::new(0)))
+    } else {
+        None
+    };
+    let counter_clone = dry_counter.clone();
+    let queues_for_forwarder = Arc::clone(&queues);
+    let stop_for_forwarder = Arc::clone(&stop_flag);
+    runtime.spawn_blocking(move || {
+        run_action_forwarder(
+            brain,
+            queues_for_forwarder,
+            dry_run,
+            counter_clone,
+            stop_for_forwarder,
+        );
+    });
+
+    Ok(dry_counter)
+}
+
+/// Build the production set of goal sources for a target slug.
+///
+/// The brain's `GhIssueGoalSource` takes a single optional label; when
+/// `label_filter` is `None` no `--label` flag is passed to `gh issue list`
+/// and every open issue becomes a candidate. The builder's whole point is
+/// to eat every issue, so leaving this `None` is the recommended default.
+/// When set, the first entry is used as the gh CLI filter; further entries
+/// are ignored (a follow-up may extend `GhIssueGoalSource` to multi-label).
+fn default_goal_sources(
+    target_slug: &str,
+    label_filter: Option<&[String]>,
+) -> Vec<Box<dyn GoalSource>> {
+    let issue_label = label_filter.and_then(|l| l.first().cloned());
+    vec![
+        Box::new(GhIssueGoalSource::new(target_slug.to_string(), issue_label)),
+        Box::new(GhCiFailureGoalSource::new(target_slug.to_string(), None)),
+    ]
+}
+
+/// Forward brain actions to the loop queue registry until the brain's
+/// channel closes or `stop_flag` flips to `true`.
+fn run_action_forwarder(
+    brain: BrainHandle,
+    queues: Arc<LoopQueueRegistry>,
+    dry_run: bool,
+    counter: Option<Arc<std::sync::atomic::AtomicUsize>>,
+    stop_flag: Arc<std::sync::atomic::AtomicBool>,
+) {
+    if dry_run {
+        let mut handler = crate::safety::DryRunActionHandler::new();
+        // Share the same counter Arc so the test can assert from outside.
+        if let Some(ext) = counter {
+            handler.enqueue_count = ext;
+        }
+        while !stop_flag.load(std::sync::atomic::Ordering::Relaxed) {
+            match brain.try_recv_action() {
+                Some(action) => action.execute(&mut handler),
+                None => std::thread::sleep(std::time::Duration::from_millis(50)),
+            }
+        }
+    } else {
+        let mut handler = LoopQueueActionHandler::new(queues);
+        while !stop_flag.load(std::sync::atomic::Ordering::Relaxed) {
+            match brain.try_recv_action() {
+                Some(action) => action.execute(&mut handler),
+                None => std::thread::sleep(std::time::Duration::from_millis(50)),
+            }
+        }
+    }
+    tracing::info!("brain action forwarder stopping (stop_flag set)");
+    // `brain` is dropped here → BrainHandle::Drop sends Shutdown + joins
+    // the brain OS thread cleanly.
+}
+
+/// Local copy of `phantom::loop_cli::build_source` — the builder crate does
+/// not depend on the `phantom` binary crate.
+fn build_source(
+    spec: &LoopSpec,
+    queues: &Arc<LoopQueueRegistry>,
+) -> Result<Box<dyn LoopSource>, BuilderError> {
+    let source: Box<dyn LoopSource> = match &spec.source {
+        LoopSourceSpec::Cron { interval_seconds } => {
+            Box::new(phantom_loop::CronSource::from_seconds(*interval_seconds))
+        }
+        LoopSourceSpec::Queue { name } => {
+            Box::new(phantom_loop::LoopMessageQueueSource::new(queues, name))
+        }
+        LoopSourceSpec::GhIssues { repo, label, query } => Box::new(
+            phantom_loop::GhIssueQueueSource::new(repo.clone(), label.clone(), query.clone()),
+        ),
+        LoopSourceSpec::GhPr { repo, predicate } => Box::new(
+            phantom_loop::GhPrReviewQueueSource::new(repo.clone(), predicate.clone()),
+        ),
+    };
+    Ok(source)
+}
+
+/// Walk a directory for `*.toml` files and parse each as a loop spec.
+fn discover_specs(
+    dir: &std::path::Path,
+) -> Result<Vec<(LoopSpec, Option<phantom_loop::ExitSchema>)>, BuilderError> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(dir).map_err(|source| BuilderError::Io {
+        path: dir.to_path_buf(),
+        source,
+    })? {
+        let entry = entry.map_err(|source| BuilderError::Io {
+            path: dir.to_path_buf(),
+            source,
+        })?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("toml") {
+            continue;
+        }
+        match phantom_loop::load_spec(&path) {
+            Ok((spec, schema)) => out.push((spec, schema)),
+            Err(e) => {
+                tracing::warn!(
+                    "phantom-builder: failed to load {}: {e}",
+                    path.display()
+                );
+            }
+        }
+    }
+    out.sort_by(|a, b| a.0.id.cmp(&b.0.id));
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{BuilderSafetyConfig, TrustBandConfig};
+    use tempfile::tempdir;
+
+    #[test]
+    fn resolve_path_uses_override_when_supplied() {
+        let tmp = tempdir().unwrap();
+        let cfg = BuilderConfig {
+            target_slug: "foo/bar".into(),
+            repo_path: Some(tmp.path().to_path_buf()),
+            ..BuilderConfig::new("foo/bar")
+        };
+        let b = Builder::new(cfg);
+        let path = b.resolve_path().unwrap();
+        assert!(path.exists());
+        assert!(path.is_absolute());
+    }
+
+    #[test]
+    fn seed_specs_writes_all_four_with_target_slug() {
+        let tmp = tempdir().unwrap();
+        let b = Builder::new(BuilderConfig::new("alice/proj"));
+        let written = b.seed_specs(tmp.path()).unwrap();
+        assert_eq!(written.len(), 4);
+        for p in &written {
+            let body = std::fs::read_to_string(p).unwrap();
+            assert!(body.contains("alice/proj"));
+        }
+    }
+
+    #[test]
+    fn default_goal_sources_count_is_two() {
+        let v = default_goal_sources("o/r", Some(&["priority:high".to_string()]));
+        assert_eq!(v.len(), 2);
+    }
+
+    #[test]
+    fn discover_specs_handles_missing_dir() {
+        let tmp = tempdir().unwrap();
+        let specs = discover_specs(&tmp.path().join("missing")).unwrap();
+        assert!(specs.is_empty());
+    }
+
+    #[test]
+    fn discover_specs_finds_seeded_files() {
+        let tmp = tempdir().unwrap();
+        let b = Builder::new(BuilderConfig::new("o/r"));
+        let _ = b.seed_specs(tmp.path()).unwrap();
+        let dir = tmp.path().join(".phantom").join("loops");
+        let specs = discover_specs(&dir).unwrap();
+        assert_eq!(specs.len(), 4);
+    }
+
+    #[test]
+    fn config_clamps_max_concurrent_when_safety_cap_is_lower() {
+        let safety = BuilderSafetyConfig {
+            max_concurrent_agents: 2,
+            ..Default::default()
+        };
+        let cap = safety.max_concurrent_agents as u32;
+        let mut spec_max = 5u32;
+        if spec_max > cap {
+            spec_max = cap.max(1);
+        }
+        assert_eq!(spec_max, 2);
+    }
+
+    #[test]
+    fn trust_band_starting_budget_is_band_specific() {
+        assert_eq!(TrustBandConfig::SuggestionOnly.starting_budget(), 0);
+        assert!(TrustBandConfig::Conservative.starting_budget() <= 3);
+        assert!((4..=9).contains(&TrustBandConfig::Standard.starting_budget()));
+        assert!(TrustBandConfig::Aggressive.starting_budget() >= 10);
+    }
+}

--- a/crates/phantom-builder/src/safety.rs
+++ b/crates/phantom-builder/src/safety.rs
@@ -1,0 +1,192 @@
+//! Safety rails for the builder.
+//!
+//! Three knobs gate autonomy:
+//!
+//! 1. **`max_prs_per_hour`** — clamps the brain's per-hour rate-limiter cap.
+//!    The brain still applies its own band-adjusted multiplier on top, but
+//!    this is the absolute ceiling the builder enforces.
+//! 2. **`max_concurrent_agents`** — every seeded loop spec's `max_concurrent`
+//!    field is rewritten to this value. The default templates ship with 1;
+//!    the builder may override.
+//! 3. **`dry_run`** — when true, the brain still ticks (scoring, audit log,
+//!    rate-limit accounting), but the forwarder thread swaps the production
+//!    [`phantom_loop::LoopQueueActionHandler`] for a [`DryRunActionHandler`].
+//!    The substrate driver never sees a request — useful for "show me what
+//!    phantom would do" sanity-runs.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use phantom_brain::dispatch::ActionHandler;
+use phantom_brain::events::{ConnectionState, SuggestionOption};
+use phantom_agents::peer_routing::RemoteMessageContent;
+use phantom_agents::{AgentId, AgentTask};
+use phantom_agents::agent::PauseReason;
+use phantom_agents::dispatch::Disposition;
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// BuilderSafetyConfig
+// ---------------------------------------------------------------------------
+
+/// Tunable safety caps for the builder.
+///
+/// The defaults match the design intent of "active but rate-limited" — 5 PRs
+/// per hour, 2 concurrent agents, dry-run OFF. Operators tighten or loosen
+/// via CLI flags.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BuilderSafetyConfig {
+    /// Absolute ceiling on the brain's per-hour enqueue rate. Default: 5.
+    ///
+    /// The brain's internal [`phantom_brain::self_improvement::RateLimiter`]
+    /// applies band-adjusted multipliers (conservative halves, aggressive
+    /// doubles) on top of this value, so the effective cap can be 2–10 PRs/h
+    /// depending on the trust band.
+    pub max_prs_per_hour: u32,
+
+    /// Maximum simultaneous agent runs across every loop. Default: 2.
+    ///
+    /// Wired into the seeded loop specs' `max_concurrent` field. Per-spec
+    /// values higher than this cap are clamped down on write.
+    pub max_concurrent_agents: u8,
+
+    /// When true, the brain runs end-to-end (poll → score → gate → enqueue
+    /// decision) but the forwarder uses [`DryRunActionHandler`] so no
+    /// substrate spawn ever fires. Default: false.
+    pub dry_run: bool,
+}
+
+impl Default for BuilderSafetyConfig {
+    fn default() -> Self {
+        Self {
+            max_prs_per_hour: 5,
+            max_concurrent_agents: 2,
+            dry_run: false,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DryRunActionHandler
+// ---------------------------------------------------------------------------
+
+/// Drop-in replacement for [`phantom_loop::LoopQueueActionHandler`] that
+/// logs every would-be enqueue instead of pushing it onto the queue.
+///
+/// Tracks a counter for assertions in tests (`builder_smoke.rs --dry-run`
+/// variant) and emits a tracing event with the queue name + payload so the
+/// operator can audit the brain's choices without committing any PRs.
+#[derive(Debug, Default)]
+pub struct DryRunActionHandler {
+    /// Count of enqueue actions intercepted. Reads atomically — the brain
+    /// forwarder thread is the only writer, but assertions in tests run on
+    /// a separate thread.
+    pub enqueue_count: Arc<AtomicUsize>,
+}
+
+impl DryRunActionHandler {
+    /// Build a fresh handler with a zeroed counter.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Snapshot the current intercepted-enqueue count.
+    #[must_use]
+    pub fn count(&self) -> usize {
+        self.enqueue_count.load(Ordering::Relaxed)
+    }
+
+    /// Clone-share the counter Arc with a test.
+    #[must_use]
+    pub fn counter(&self) -> Arc<AtomicUsize> {
+        Arc::clone(&self.enqueue_count)
+    }
+}
+
+impl ActionHandler for DryRunActionHandler {
+    fn enqueue_loop_message(
+        &mut self,
+        queue: String,
+        from_source: String,
+        payload: serde_json::Value,
+    ) {
+        let count = self.enqueue_count.fetch_add(1, Ordering::Relaxed) + 1;
+        tracing::info!(
+            queue = %queue,
+            from_source = %from_source,
+            payload = %payload,
+            count = count,
+            "[dry-run] brain would enqueue loop message (no-op)",
+        );
+    }
+
+    // Every other ActionHandler method is a no-op. We do not inherit from
+    // NoopInner because that is a private-ish helper in phantom-loop and we
+    // do not want to take a hard dependency on its symbol exposure.
+    fn show_suggestion(&mut self, _text: String, _options: Vec<SuggestionOption>) {}
+    fn show_notification(&mut self, _msg: String) {}
+    fn update_memory(&mut self, _key: String, _value: String) {}
+    fn spawn_agent(
+        &mut self,
+        _task: AgentTask,
+        _spawn_tag: Option<u64>,
+        _disposition: Disposition,
+    ) {
+    }
+    fn console_reply(&mut self, _reply: String) {}
+    fn run_command(&mut self, _cmd: String) {}
+    fn dismiss_adapter(&mut self, _app_id: u32) {}
+    fn agent_flatlined(&mut self, _id: AgentId, _reason: String) {}
+    fn suggest(&mut self, _action: String, _rationale: String, _confidence: f32) {}
+    fn quarantine_agent(&mut self, _agent_id: AgentId, _denial_count: usize) {}
+    fn agent_quarantined(&mut self, _agent_id: AgentId, _denial_count: usize) {}
+    fn checkpoint_reached(&mut self, _step_idx: usize, _description: String) {}
+    fn pause_agent(&mut self, _agent_id: AgentId, _reason: PauseReason) {}
+    fn resume_agent(&mut self, _agent_id: AgentId) {}
+    fn update_connection_state(&mut self, _state: ConnectionState) {}
+    fn set_offline_mode(&mut self, _enabled: bool) {}
+    fn deliver_inbound_relay(&mut self, _agent_id: AgentId, _content: RemoteMessageContent) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use phantom_brain::events::AiAction;
+    use serde_json::json;
+
+    #[test]
+    fn default_caps_match_the_documented_intent() {
+        let s = BuilderSafetyConfig::default();
+        assert_eq!(s.max_prs_per_hour, 5);
+        assert_eq!(s.max_concurrent_agents, 2);
+        assert!(!s.dry_run);
+    }
+
+    #[test]
+    fn dry_run_handler_counts_enqueue_attempts_without_pushing() {
+        let mut h = DryRunActionHandler::new();
+        AiAction::EnqueueLoopMessage {
+            queue: "implementer-queue".into(),
+            from_source: "gh-issues".into(),
+            payload: json!({"external_id": "gh-issue:1"}),
+        }
+        .execute(&mut h);
+        AiAction::EnqueueLoopMessage {
+            queue: "implementer-queue".into(),
+            from_source: "gh-issues".into(),
+            payload: json!({"external_id": "gh-issue:2"}),
+        }
+        .execute(&mut h);
+        assert_eq!(h.count(), 2);
+    }
+
+    #[test]
+    fn dry_run_handler_ignores_non_enqueue_actions() {
+        let mut h = DryRunActionHandler::new();
+        AiAction::ShowNotification("noise".into()).execute(&mut h);
+        AiAction::ConsoleReply("noise".into()).execute(&mut h);
+        AiAction::DoNothing.execute(&mut h);
+        assert_eq!(h.count(), 0);
+    }
+}

--- a/crates/phantom-builder/src/templates.rs
+++ b/crates/phantom-builder/src/templates.rs
@@ -1,0 +1,169 @@
+//! Embedded loop spec templates.
+//!
+//! At build time the four canonical loop specs from `crates/phantom-builder/
+//! templates/` are baked into the binary via `include_str!`. At runtime the
+//! builder rewrites the `repo` field on every `gh_pr` / `gh_issues` source so
+//! the seeded specs target the user-supplied slug, then writes one TOML file
+//! per loop into `<repo>/.phantom/loops/`.
+//!
+//! Files that already exist on disk are skipped — the builder is idempotent;
+//! a second `phantom builder run` invocation does not overwrite a spec the
+//! operator has hand-customized.
+
+use std::path::{Path, PathBuf};
+
+use crate::BuilderError;
+
+/// Filename → embedded TOML body for every default spec.
+const TEMPLATES: &[(&str, &str)] = &[
+    (
+        "pr_finder_review.toml",
+        include_str!("../templates/pr_finder_review.toml"),
+    ),
+    (
+        "pr_finder_impl.toml",
+        include_str!("../templates/pr_finder_impl.toml"),
+    ),
+    (
+        "reviewer.toml",
+        include_str!("../templates/reviewer.toml"),
+    ),
+    (
+        "implementer.toml",
+        include_str!("../templates/implementer.toml"),
+    ),
+];
+
+/// Write the default four-loop pipeline into `<repo_path>/.phantom/loops/`.
+///
+/// Substitutes the target slug into every `repo = "jdmiranda/phantom"` line so
+/// the seeded specs poll the user's target rather than the upstream repo. The
+/// substitution is intentionally string-based — TOML round-tripping through a
+/// real parser would lose the careful comments in each template.
+///
+/// # Errors
+///
+/// - [`BuilderError::Io`] when the spec directory cannot be created or one of
+///   the TOML files cannot be written.
+pub fn write_default_specs(
+    repo_path: &Path,
+    target_slug: &str,
+) -> Result<Vec<PathBuf>, BuilderError> {
+    let dir = repo_path.join(".phantom").join("loops");
+    std::fs::create_dir_all(&dir).map_err(|source| BuilderError::Io {
+        path: dir.clone(),
+        source,
+    })?;
+
+    let mut written = Vec::with_capacity(TEMPLATES.len());
+    for (filename, body) in TEMPLATES {
+        let dst = dir.join(filename);
+        if dst.exists() {
+            tracing::info!(
+                file = %dst.display(),
+                "skipping existing loop spec (idempotent re-run)",
+            );
+            // Even when skipped we include the path in the return list so
+            // callers see the full set of seeded specs.
+            written.push(dst);
+            continue;
+        }
+        let rewritten = rewrite_repo_field(body, target_slug);
+        std::fs::write(&dst, rewritten).map_err(|source| BuilderError::Io {
+            path: dst.clone(),
+            source,
+        })?;
+        tracing::info!(file = %dst.display(), "seeded default loop spec");
+        written.push(dst);
+    }
+    Ok(written)
+}
+
+/// Substitute the upstream `jdmiranda/phantom` slug used by every template
+/// header for the user's `target_slug`.
+///
+/// Strategy: we look for the literal TOML lines that pin the upstream slug
+/// (`repo = "jdmiranda/phantom"` on a `[source]` table, and the comments that
+/// mention the same string) and rewrite them. The replacement uses
+/// `str::replace` rather than a full TOML parse because:
+///
+/// 1. Round-tripping through `toml_edit` would drop blank lines and comments.
+/// 2. Each template's commentary block intentionally documents the original
+///    upstream context; rewriting the slug everywhere (including comments)
+///    keeps the on-disk file self-explanatory for the new target.
+fn rewrite_repo_field(body: &str, target_slug: &str) -> String {
+    body.replace("jdmiranda/phantom", target_slug)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn templates_embed_at_compile_time() {
+        // Sanity: every template must have non-empty content and at least one
+        // `repo = "..."` line.
+        for (filename, body) in TEMPLATES {
+            assert!(!body.is_empty(), "{filename} is empty");
+            assert!(
+                body.contains("jdmiranda/phantom"),
+                "{filename} does not pin the upstream slug — the substitution will silently no-op",
+            );
+        }
+    }
+
+    #[test]
+    fn rewrite_substitutes_target_slug() {
+        let original = "[source]\nrepo = \"jdmiranda/phantom\"\n";
+        let out = rewrite_repo_field(original, "other/repo");
+        assert!(out.contains("other/repo"));
+        assert!(!out.contains("jdmiranda/phantom"));
+    }
+
+    #[test]
+    fn rewrite_preserves_comments_and_blank_lines() {
+        let original = "# heading\n\n[source]\nrepo = \"jdmiranda/phantom\"\n# trailer\n";
+        let out = rewrite_repo_field(original, "x/y");
+        assert!(out.contains("# heading"));
+        assert!(out.contains("# trailer"));
+        assert!(out.contains("\n\n[source]"));
+    }
+
+    #[test]
+    fn write_default_specs_seeds_all_four_files_when_missing() {
+        let tmp = tempdir().unwrap();
+        let written = write_default_specs(tmp.path(), "alice/proj").unwrap();
+        assert_eq!(written.len(), 4);
+        for path in &written {
+            assert!(path.exists(), "{} was not created", path.display());
+            let body = std::fs::read_to_string(path).unwrap();
+            assert!(body.contains("alice/proj"));
+            assert!(!body.contains("jdmiranda/phantom"));
+        }
+    }
+
+    #[test]
+    fn write_default_specs_skips_existing_files() {
+        let tmp = tempdir().unwrap();
+        let dir = tmp.path().join(".phantom").join("loops");
+        std::fs::create_dir_all(&dir).unwrap();
+        let preexisting = dir.join("reviewer.toml");
+        std::fs::write(&preexisting, "# hand-crafted, do not overwrite").unwrap();
+
+        let _ = write_default_specs(tmp.path(), "alice/proj").unwrap();
+
+        let body = std::fs::read_to_string(&preexisting).unwrap();
+        assert_eq!(body, "# hand-crafted, do not overwrite");
+    }
+
+    #[test]
+    fn write_default_specs_creates_parent_directories() {
+        let tmp = tempdir().unwrap();
+        let nested = tmp.path().join("nested").join("deeper");
+        std::fs::create_dir_all(&nested).unwrap();
+        let written = write_default_specs(&nested, "ax/by").unwrap();
+        assert_eq!(written.len(), 4);
+        assert!(nested.join(".phantom").join("loops").exists());
+    }
+}

--- a/crates/phantom-builder/templates/implementer.toml
+++ b/crates/phantom-builder/templates/implementer.toml
@@ -1,0 +1,60 @@
+# Implementer loop — drains implementer-queue and ships PRs.
+#
+# Role
+# ----
+# Spawns an Actor agent per issue. The agent reads the relevant code,
+# writes tests, implements the change, runs cargo test, pushes a branch,
+# and opens a PR via gh. The PR URL is forwarded to the review-queue via
+# the on_complete effect so the reviewer loop picks it up on its next
+# drain.
+#
+# Tool whitelist is wider than reviewer's: file mutation plus run_command
+# (for cargo / gh) plus the PR creation tool. Same gh_pr_* caveat as the
+# reviewer spec: C3 resolves these names.
+
+id = "implementer"
+max_concurrent = 1
+on_quarantine = "skip_and_continue"
+
+[agent]
+role = "Actor"
+allow_tools = ["read_file", "write_file", "edit_file", "run_command", "gh_pr_create"]
+system_prompt = """
+You are an implementation agent for the Phantom repo (jdmiranda/phantom).
+Pull the assigned issue. Read the relevant code. Write tests first. Implement the change. Run cargo test. Push a branch. Open a PR.
+You MUST call complete_task with {issue_number: <int>, pr_url: <string>, summary: <string>}.
+"""
+
+[agent.policy]
+auto_approve = true
+timeout_seconds = 1800
+
+[agent.exit_schema]
+type = "object"
+required = ["issue_number", "pr_url", "summary"]
+
+[agent.exit_schema.properties.issue_number]
+type = "integer"
+
+[agent.exit_schema.properties.pr_url]
+type = "string"
+format = "uri"
+
+[agent.exit_schema.properties.summary]
+type = "string"
+
+[source]
+kind = "queue"
+name = "implementer-queue"
+
+[[on_complete]]
+kind = "enqueue_to"
+queue = "review-queue"
+
+[[on_complete.fields]]
+from = "result.pr_url"
+to = "pr_url"
+
+[[on_complete.fields]]
+from = "result.issue_number"
+to = "issue_number"

--- a/crates/phantom-builder/templates/pr_finder_impl.toml
+++ b/crates/phantom-builder/templates/pr_finder_impl.toml
@@ -1,0 +1,36 @@
+# PR-finder (impl) loop — agentless watcher for PRs with failing CI.
+#
+# Role
+# ----
+# Polls `gh pr list` against jdmiranda/phantom with `failing_ci = true`
+# and enqueues each unseen PR onto `implementer-queue`. The implementer
+# loop drains that queue and re-rolls the failing change.
+#
+# Sister spec to `pr_finder_review.toml`. See that file's header for the
+# rationale behind the split from the original `pr_finder.toml`; the
+# short version is "agentless single-source, single-destination avoids
+# the three C1 schema gaps GAMMA surfaced in PR #662".
+
+id = "pr_finder_impl"
+max_concurrent = 1
+on_quarantine = "skip_and_continue"
+
+# The source polls `gh pr list -R jdmiranda/phantom --state open
+# --search status:failure` and emits one unseen PR per `next()` call.
+[source]
+kind = "gh_pr"
+repo = "jdmiranda/phantom"
+
+[source.predicate]
+state = "open"
+failing_ci = true
+
+# Forward the PR number to `implementer-queue`. See the field-map note
+# in `pr_finder_review.toml`.
+[[on_complete]]
+kind = "enqueue_to"
+queue = "implementer-queue"
+
+[[on_complete.fields]]
+from = "key"
+to = "pr_number"

--- a/crates/phantom-builder/templates/pr_finder_review.toml
+++ b/crates/phantom-builder/templates/pr_finder_review.toml
@@ -1,0 +1,52 @@
+# PR-finder (review) loop — agentless watcher for PRs awaiting review.
+#
+# Role
+# ----
+# Polls `gh pr list` against jdmiranda/phantom with `review_required = true`
+# and enqueues each unseen PR onto `review-queue`. The reviewer loop drains
+# that queue and decides on each PR.
+#
+# This is one half of the split that replaced the old `pr_finder.toml`. The
+# original spec was an agentless cron loop that fan-routed to two queues
+# based on per-PR predicates, which surfaced three C1 schema gaps GAMMA
+# documented in PR #662:
+#
+# 1. No `Poll` effect for an agentless cron loop to perform an external
+#    fetch.
+# 2. No predicate on `EnqueueTo` for conditional routing of a fan-out.
+# 3. Agentless loops cannot declare `exit_schema`.
+#
+# The split eliminates all three: each new loop uses the `gh_pr` source
+# (which post-#664 owns the `gh pr list` poll-and-dedup internally),
+# targets exactly one queue (no predicate-on-effect needed), and stays
+# agentless so the `exit_schema` gap is moot.
+
+id = "pr_finder_review"
+max_concurrent = 1
+on_quarantine = "skip_and_continue"
+
+# The source itself polls `gh pr list -R jdmiranda/phantom --state open
+# --search review:required` (see GhPrReviewQueueSource) and emits one
+# unseen, predicate-passing PR per `next()` call. No agent is needed —
+# the runner forwards each input straight through `on_complete`.
+[source]
+kind = "gh_pr"
+repo = "jdmiranda/phantom"
+
+[source.predicate]
+state = "open"
+review_required = true
+
+# Forward the PR number to `review-queue`. The `key` field on the
+# `LoopInput` produced by `GhPrReviewQueueSource` looks like
+# "jdmiranda/phantom#pr-N"; the consumer is `reviewer.toml`, whose agent
+# expects `pr_number` in scope. Mapping `key → pr_number` keeps the
+# downstream contract aligned even though it ships the full key string;
+# tightening to the numeric component is a future field-map extension.
+[[on_complete]]
+kind = "enqueue_to"
+queue = "review-queue"
+
+[[on_complete.fields]]
+from = "key"
+to = "pr_number"

--- a/crates/phantom-builder/templates/reviewer.toml
+++ b/crates/phantom-builder/templates/reviewer.toml
@@ -1,0 +1,51 @@
+# Reviewer loop — drains the review-queue and decides on open PRs.
+#
+# Role
+# ----
+# Spawns an Actor agent per PR pulled off `review-queue`. The agent reads
+# the diff, runs whatever sanity checks the system prompt instructs, and
+# emits a structured decision via complete_task. The exit schema gates
+# the payload — a malformed decision quarantines that PR rather than
+# halting the entire loop.
+#
+# Tool whitelist: read-only filesystem plus the two gh PR write
+# operations the reviewer is allowed to call. Per the issue #650
+# decision note, gh_pr_* tool names are not yet ToolType variants on
+# main; C3 will need to resolve those (likely via shelled RunCommand
+# with a tightened system prompt, or by extending ToolType).
+
+id = "reviewer"
+max_concurrent = 1
+on_quarantine = "skip_and_continue"
+
+[agent]
+role = "Actor"
+allow_tools = ["read_file", "gh_pr_review", "gh_pr_merge"]
+system_prompt = """
+You are a code reviewer for the Phantom repo (jdmiranda/phantom).
+Pull the assigned PR. Read the diff. Verify the change is sound, tested, and matches the issue scope.
+You MUST call complete_task with {pr_number: <int>, decision: "approved" | "changes_requested" | "merged"}.
+"""
+
+[agent.policy]
+auto_approve = true
+timeout_seconds = 1200
+
+[agent.exit_schema]
+type = "object"
+required = ["pr_number", "decision"]
+
+[agent.exit_schema.properties.pr_number]
+type = "integer"
+
+[agent.exit_schema.properties.decision]
+type = "string"
+enum = ["approved", "changes_requested", "merged"]
+
+[source]
+kind = "queue"
+name = "review-queue"
+
+[[on_complete]]
+kind = "log_to_bus"
+event_kind = "reviewer.decision"

--- a/crates/phantom-builder/tests/builder_smoke.rs
+++ b/crates/phantom-builder/tests/builder_smoke.rs
@@ -1,0 +1,273 @@
+//! End-to-end smoke test for `phantom-builder`.
+//!
+//! Validates the whole pipeline without any external dependencies:
+//!
+//! 1. Point the builder at a temp directory (no clone needed).
+//! 2. Inject a [`MockSubstrateBackend`] so any agent the dispatcher spawns
+//!    returns a canned outcome instead of hitting Claude.
+//! 3. Inject a stub `GhCommandRunner`-backed [`GhIssueGoalSource`] that
+//!    returns three canned issues.
+//! 4. Run the builder for a short duration and assert:
+//!    - Loop specs are templated into the temp repo's `.phantom/loops/`.
+//!    - The four loops are started.
+//!    - In normal mode, queues are wired up (the brain may or may not
+//!      accumulate messages within the brief test window; we accept either
+//!      outcome since the brain's 60-second self-improvement tick is far
+//!      longer than the test's runtime).
+//!    - In dry-run mode, the dry-run handler is in place so no enqueue ever
+//!      reaches the queue regardless of brain activity.
+//!
+//! The smoke test is deliberately tolerant about brain timing. The brain's
+//! self-improvement tick interval is 60 s and the goal-source initial idle
+//! before the first poll is the source's `poll_interval` (also 60 s by
+//! default). Cranking those down for a five-second test would require
+//! reaching into the brain's internals; instead we assert structural
+//! invariants — specs seeded, loops started, dry-run handler intercepts —
+//! rather than runtime timing.
+
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use phantom_brain::goal_source::{GhCiFailureGoalSource, GhIssueGoalSource, GoalSource, StubGhRunner};
+use phantom_builder::{
+    Builder, BuilderConfig, BuilderHooks, BuilderSafetyConfig, TrustBandConfig,
+};
+use phantom_loop::{MockSubstrateBackend, SubstrateBackend};
+use tempfile::tempdir;
+
+fn three_canned_issues() -> String {
+    // Hand-crafted matching the GhIssue deserializer in
+    // crates/phantom-brain/src/goal_source/gh_issues.rs.
+    serde_json::json!([
+        {
+            "number": 100,
+            "title": "fix the thing",
+            "body": "the thing is broken; please fix it",
+            "labels": [{"name": "priority:high"}, {"name": "good-first-issue"}],
+            "createdAt": "2025-01-01T00:00:00Z",
+            "url": "https://github.com/o/r/issues/100",
+            "author": {"login": "alice"},
+            "comments": []
+        },
+        {
+            "number": 101,
+            "title": "second issue",
+            "body": "more things",
+            "labels": [{"name": "priority:medium"}],
+            "createdAt": "2025-01-02T00:00:00Z",
+            "url": "https://github.com/o/r/issues/101",
+            "author": {"login": "bob"},
+            "comments": []
+        },
+        {
+            "number": 102,
+            "title": "third issue",
+            "body": "yet more things",
+            "labels": [{"name": "priority:critical"}],
+            "createdAt": "2025-01-03T00:00:00Z",
+            "url": "https://github.com/o/r/issues/102",
+            "author": {"login": "carol"},
+            "comments": []
+        }
+    ])
+    .to_string()
+}
+
+fn build_stub_goal_sources(target: &str) -> Vec<Box<dyn GoalSource>> {
+    let issues_runner = Box::new(StubGhRunner::new(vec![three_canned_issues()]));
+    let ci_runner = Box::new(StubGhRunner::new(vec!["[]".to_string()]));
+    vec![
+        Box::new(GhIssueGoalSource::with_runner(
+            target.to_string(),
+            None,
+            Duration::ZERO,
+            issues_runner,
+        )),
+        Box::new(GhCiFailureGoalSource::with_runner(
+            target.to_string(),
+            None,
+            Duration::ZERO,
+            24.0,
+            ci_runner,
+        )),
+    ]
+}
+
+/// Build the config the two end-to-end variants share.
+fn make_config(tmp_path: std::path::PathBuf, dry_run: bool) -> BuilderConfig {
+    BuilderConfig {
+        target_slug: "test/repo".into(),
+        repo_path: Some(tmp_path),
+        trust_band: TrustBandConfig::Conservative,
+        label_filter: None,
+        safety: BuilderSafetyConfig {
+            max_prs_per_hour: 5,
+            max_concurrent_agents: 2,
+            dry_run,
+        },
+        loops: vec![
+            "pr_finder_review".to_string(),
+            "pr_finder_impl".to_string(),
+            "reviewer".to_string(),
+            "implementer".to_string(),
+        ],
+    }
+}
+
+#[test]
+fn builder_seeds_specs_and_starts_loops_in_normal_mode() {
+    let tmp = tempdir().unwrap();
+    let cfg = make_config(tmp.path().to_path_buf(), false);
+
+    let backend: Arc<dyn SubstrateBackend> = Arc::new(MockSubstrateBackend::ok(
+        serde_json::json!({
+            "issue_number": 100,
+            "pr_url": "https://github.com/o/r/pull/200",
+            "summary": "fixed it"
+        }),
+    ));
+    let hooks = BuilderHooks {
+        substrate_backend: Some(backend),
+        goal_sources: Some(build_stub_goal_sources("test/repo")),
+        skip_preflight: true,
+    };
+
+    let builder = Builder::with_hooks(cfg, hooks);
+    // run_for_duration is synchronous from the caller's perspective: it
+    // builds an internal multi-thread runtime, sleeps the calling thread,
+    // and tears down before returning. This avoids nesting runtimes when
+    // the test itself is a plain #[test].
+    let artifacts = builder
+        .run_for_duration(Duration::from_millis(500))
+        .unwrap();
+
+    // Assertion 1: specs templated into the temp repo's .phantom/loops/.
+    let loops_dir = tmp.path().join(".phantom").join("loops");
+    assert!(loops_dir.is_dir(), "expected {}", loops_dir.display());
+    for name in [
+        "pr_finder_review.toml",
+        "pr_finder_impl.toml",
+        "reviewer.toml",
+        "implementer.toml",
+    ] {
+        let path = loops_dir.join(name);
+        assert!(path.exists(), "missing seeded spec: {}", path.display());
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            body.contains("test/repo"),
+            "{name} did not get its repo field rewritten:\n{body}"
+        );
+        assert!(
+            !body.contains("jdmiranda/phantom"),
+            "{name} still references upstream slug:\n{body}"
+        );
+    }
+
+    // Assertion 2: all four loops were started.
+    assert_eq!(artifacts.result.started_loops, 4);
+    assert_eq!(artifacts.result.seeded_specs.len(), 4);
+
+    // Assertion 3: dry-run counter is None in normal mode.
+    assert!(
+        artifacts.dry_count.is_none(),
+        "dry-run counter should be None in normal mode"
+    );
+
+    // Assertion 4: queue registry exists and accepts pushes.
+    artifacts.queues.push(
+        "implementer-queue",
+        phantom_loop::LoopMessage::new(
+            "manual-test",
+            serde_json::json!({"external_id": "manual-1"}),
+        ),
+    );
+    let popped = artifacts.queues.pop("implementer-queue");
+    assert!(popped.is_some());
+
+    // Drop the artifacts (and the builder's internal runtime) explicitly;
+    // the spawn_blocking workers join when the runtime drops.
+    drop(artifacts);
+}
+
+#[test]
+fn dry_run_mode_intercepts_enqueues_with_a_counter() {
+    let tmp = tempdir().unwrap();
+    let cfg = make_config(tmp.path().to_path_buf(), true);
+
+    let backend: Arc<dyn SubstrateBackend> = Arc::new(MockSubstrateBackend::ok(
+        serde_json::json!({"ok": true}),
+    ));
+    let hooks = BuilderHooks {
+        substrate_backend: Some(backend),
+        goal_sources: Some(build_stub_goal_sources("test/repo")),
+        skip_preflight: true,
+    };
+
+    let builder = Builder::with_hooks(cfg, hooks);
+    let artifacts = builder
+        .run_for_duration(Duration::from_millis(500))
+        .unwrap();
+
+    // Dry-run mode must expose a counter.
+    let counter = artifacts
+        .dry_count
+        .as_ref()
+        .expect("dry-run mode must produce a counter")
+        .clone();
+
+    // The brain's self-improvement tick fires every 60 s by default — far
+    // longer than our 500 ms test window. So the counter may be 0 even in
+    // a correctly wired dry-run; we assert only that:
+    // (a) the counter exists (already done above), and
+    // (b) no message reached the implementer-queue during the run, which
+    //     would have happened if the production handler ran instead of
+    //     DryRunActionHandler.
+    let queue_pop = artifacts.queues.pop("implementer-queue");
+    assert!(
+        queue_pop.is_none(),
+        "dry-run must not push to the implementer-queue (popped: {queue_pop:?})"
+    );
+
+    // Verify the wiring: the counter is the same Arc the handler holds,
+    // so an externally-driven increment is observable to the test.
+    counter.fetch_add(1, Ordering::Relaxed);
+    assert!(counter.load(Ordering::Relaxed) >= 1);
+
+    drop(artifacts);
+}
+
+#[test]
+fn suggestion_only_band_skips_brain_boot() {
+    // SuggestionOnly band is the safest possible mode; the brain isn't
+    // even spawned. The builder still seeds specs and starts loops, but
+    // no goal-source poll occurs and no auto-enqueue is possible.
+    let tmp = tempdir().unwrap();
+    let cfg = BuilderConfig {
+        target_slug: "test/repo".into(),
+        repo_path: Some(tmp.path().to_path_buf()),
+        trust_band: TrustBandConfig::SuggestionOnly,
+        label_filter: None,
+        safety: BuilderSafetyConfig::default(),
+        loops: vec!["pr_finder_review".to_string()],
+    };
+    let backend: Arc<dyn SubstrateBackend> =
+        Arc::new(MockSubstrateBackend::ok(serde_json::json!({})));
+    let hooks = BuilderHooks {
+        substrate_backend: Some(backend),
+        // SuggestionOnly skips brain boot entirely — goal sources are
+        // ignored, but we still pass empty stubs for symmetry with the
+        // other tests.
+        goal_sources: Some(Vec::new()),
+        skip_preflight: true,
+    };
+    let builder = Builder::with_hooks(cfg, hooks);
+    let artifacts = builder
+        .run_for_duration(Duration::from_millis(200))
+        .unwrap();
+
+    assert_eq!(artifacts.result.started_loops, 1);
+    assert!(artifacts.dry_count.is_none());
+
+    drop(artifacts);
+}

--- a/crates/phantom/Cargo.toml
+++ b/crates/phantom/Cargo.toml
@@ -31,6 +31,9 @@ phantom-nlp = { path = "../phantom-nlp" }
 phantom-loop = { path = "../phantom-loop" }
 # Fleet meta-orchestrator for the `phantom fleet ...` subcommand surface.
 phantom-fleet = { path = "../phantom-fleet" }
+# Builder orchestrator for `phantom builder run` subcommand — generalises
+# the self-improvement loop to any GitHub repo.
+phantom-builder = { path = "../phantom-builder" }
 
 # Hub registration: identity + credentials persistence (issue #563).
 phantom-net = { path = "../phantom-net" }

--- a/crates/phantom/src/builder_cli.rs
+++ b/crates/phantom/src/builder_cli.rs
@@ -1,0 +1,277 @@
+//! `phantom builder` CLI surface — production entry-point for pointing
+//! Phantom at any GitHub repo and having it eat the open issues
+//! autonomously.
+//!
+//! Mirrors the shape of [`crate::loop_cli`]:
+//!
+//! ```text
+//! phantom builder run <owner>/<repo> [--repo-path <path>]
+//!                                    [--trust-band 0|1|2|3]
+//!                                    [--loops <names>]
+//!                                    [--dry-run]
+//!                                    [--max-prs-per-hour N]
+//!                                    [--max-concurrent N]
+//!                                    [--label-filter L1,L2,...]
+//! phantom builder list
+//! phantom builder status <owner>/<repo>
+//! ```
+//!
+//! The heavy lifting lives in [`phantom_builder`]: this module is a thin
+//! shim that parses CLI flags, constructs a [`phantom_builder::BuilderConfig`],
+//! and hands it to [`phantom_builder::Builder::run`].
+
+use std::path::PathBuf;
+
+use anyhow::{Result, bail};
+use phantom_builder::{
+    Builder, BuilderConfig, BuilderSafetyConfig, TrustBandConfig,
+};
+
+/// Top-level dispatcher: `phantom builder <subcommand> ...`. Called from
+/// `main.rs` when `argv[1] == "builder"`.
+pub fn run_builder_subcommand(args: &[String]) -> Result<()> {
+    match args.get(2).map(String::as_str) {
+        Some("run") => run_command(&args[2..]),
+        Some("list") => list_command(),
+        Some("status") => status_command(&args[2..]),
+        _ => {
+            print_builder_help();
+            Ok(())
+        }
+    }
+}
+
+/// Print the human-readable usage banner.
+fn print_builder_help() {
+    eprintln!(
+        "phantom builder — point Phantom at any GitHub repo and eat all the issues\n\
+         \n\
+         USAGE:\n\
+             phantom builder run    <owner>/<repo> [flags]\n\
+             phantom builder list\n\
+             phantom builder status <owner>/<repo>\n\
+         \n\
+         FLAGS for `run`:\n\
+             --repo-path <path>          override local checkout (default: ~/.phantom/builds/<o>-<r>)\n\
+             --trust-band 0|1|2|3        0=suggestion-only, 1=conservative (default), 2=standard, 3=aggressive\n\
+             --loops a,b,c               comma-separated loop names (default: the canonical four)\n\
+             --dry-run                   score + log but never enqueue\n\
+             --max-prs-per-hour N        absolute per-hour cap (default 5)\n\
+             --max-concurrent N          max simultaneous agents (default 2)\n\
+             --label-filter L1,L2,...    only consider issues with these labels (default: ALL open issues)\n"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// `phantom builder run`
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, clap::Parser)]
+#[command(name = "phantom builder run")]
+struct RunArgs {
+    /// `owner/repo` slug of the target repository.
+    target: String,
+
+    /// Use an existing local checkout instead of cloning.
+    #[arg(long)]
+    repo_path: Option<PathBuf>,
+
+    /// Trust band the brain operates at. 0 = suggestion-only, 1 = conservative
+    /// (default), 2 = standard, 3 = aggressive.
+    #[arg(long, default_value_t = 1)]
+    trust_band: u8,
+
+    /// Comma-separated list of loop names to start. Defaults to the canonical
+    /// four-loop pipeline (pr_finder_review, pr_finder_impl, reviewer,
+    /// implementer).
+    #[arg(long)]
+    loops: Option<String>,
+
+    /// Dry-run mode: brain scores and logs but never enqueues.
+    #[arg(long)]
+    dry_run: bool,
+
+    /// Absolute per-hour cap on auto-enqueues.
+    #[arg(long, default_value_t = 5)]
+    max_prs_per_hour: u32,
+
+    /// Maximum simultaneous agents across every loop.
+    #[arg(long, default_value_t = 2)]
+    max_concurrent: u8,
+
+    /// Comma-separated GitHub issue labels to filter on (default: ALL open
+    /// issues).
+    #[arg(long)]
+    label_filter: Option<String>,
+}
+
+fn run_command(args: &[String]) -> Result<()> {
+    use clap::Parser;
+    let parsed = if args.first().map(String::as_str) == Some("run") {
+        RunArgs::parse_from(
+            std::iter::once("phantom builder run").chain(args[1..].iter().map(String::as_str)),
+        )
+    } else {
+        RunArgs::parse_from(
+            std::iter::once("phantom builder run").chain(args.iter().map(String::as_str)),
+        )
+    };
+
+    let trust_band = match parsed.trust_band {
+        0 => TrustBandConfig::SuggestionOnly,
+        1 => TrustBandConfig::Conservative,
+        2 => TrustBandConfig::Standard,
+        3 => TrustBandConfig::Aggressive,
+        other => bail!("invalid --trust-band {other}; expected 0, 1, 2, or 3"),
+    };
+
+    let loops = parsed
+        .loops
+        .map(|s| {
+            s.split(',')
+                .map(str::trim)
+                .filter(|t| !t.is_empty())
+                .map(String::from)
+                .collect::<Vec<_>>()
+        })
+        .filter(|v: &Vec<String>| !v.is_empty())
+        .unwrap_or_else(|| {
+            vec![
+                "pr_finder_review".to_string(),
+                "pr_finder_impl".to_string(),
+                "reviewer".to_string(),
+                "implementer".to_string(),
+            ]
+        });
+
+    let label_filter = parsed.label_filter.map(|s| {
+        s.split(',')
+            .map(str::trim)
+            .filter(|t| !t.is_empty())
+            .map(String::from)
+            .collect::<Vec<_>>()
+    });
+
+    let cfg = BuilderConfig {
+        target_slug: parsed.target.clone(),
+        repo_path: parsed.repo_path,
+        trust_band,
+        label_filter,
+        safety: BuilderSafetyConfig {
+            max_prs_per_hour: parsed.max_prs_per_hour,
+            max_concurrent_agents: parsed.max_concurrent,
+            dry_run: parsed.dry_run,
+        },
+        loops,
+    };
+
+    eprintln!(
+        "phantom builder run: target={} band={:?} dry-run={} max-prs/h={} max-concurrent={}",
+        cfg.target_slug,
+        cfg.trust_band,
+        cfg.safety.dry_run,
+        cfg.safety.max_prs_per_hour,
+        cfg.safety.max_concurrent_agents,
+    );
+
+    let result = Builder::new(cfg).run().map_err(|e| anyhow::anyhow!(e))?;
+    eprintln!(
+        "phantom builder run: done. checkout={} seeded={} started={}",
+        result.repo_path.display(),
+        result.seeded_specs.len(),
+        result.started_loops,
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// `phantom builder list`
+// ---------------------------------------------------------------------------
+
+fn list_command() -> Result<()> {
+    let home = match dirs::home_dir() {
+        Some(h) => h,
+        None => bail!("could not resolve $HOME"),
+    };
+    let builds = home.join(".phantom").join("builds");
+    if !builds.exists() {
+        eprintln!("phantom builder list: no builds yet ({} missing)", builds.display());
+        return Ok(());
+    }
+    eprintln!("phantom builder list: builds under {}:", builds.display());
+    let mut found_any = false;
+    for entry in std::fs::read_dir(&builds)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("?");
+        let lock = path.join(".phantom").join("loops").join(".runlock");
+        let live = if lock.exists() { "[runlock present]" } else { "" };
+        println!("  {name:<40} {live}");
+        found_any = true;
+    }
+    if !found_any {
+        eprintln!("  (no build directories found)");
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// `phantom builder status`
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, clap::Parser)]
+#[command(name = "phantom builder status")]
+struct StatusArgs {
+    /// `owner/repo` slug to check.
+    target: String,
+}
+
+fn status_command(args: &[String]) -> Result<()> {
+    use clap::Parser;
+    let parsed = if args.first().map(String::as_str) == Some("status") {
+        StatusArgs::parse_from(
+            std::iter::once("phantom builder status").chain(args[1..].iter().map(String::as_str)),
+        )
+    } else {
+        StatusArgs::parse_from(
+            std::iter::once("phantom builder status").chain(args.iter().map(String::as_str)),
+        )
+    };
+
+    let (owner, repo) = match parsed.target.split_once('/') {
+        Some(p) => p,
+        None => bail!("invalid slug `{}` — expected owner/repo", parsed.target),
+    };
+    let home = match dirs::home_dir() {
+        Some(h) => h,
+        None => bail!("could not resolve $HOME"),
+    };
+    let dir = home.join(".phantom").join("builds").join(format!("{owner}-{repo}"));
+    if !dir.exists() {
+        eprintln!(
+            "phantom builder status: no build directory at {} — run `phantom builder run {}` first",
+            dir.display(),
+            parsed.target
+        );
+        return Ok(());
+    }
+    let lock = dir.join(".phantom").join("loops").join(".runlock");
+    let live = lock.exists();
+    eprintln!("phantom builder status: {}", parsed.target);
+    eprintln!("  checkout: {}", dir.display());
+    eprintln!(
+        "  runlock:  {} {}",
+        lock.display(),
+        if live { "(present — a builder run may be active)" } else { "(absent)" }
+    );
+    // Cross-process status is not implemented; mirror loop_cli's behavior.
+    eprintln!(
+        "  note: cross-process status reporting is not yet implemented. \
+         Inspect the running `phantom builder run` process's stderr for \
+         per-tick status lines."
+    );
+    Ok(())
+}

--- a/crates/phantom/src/main.rs
+++ b/crates/phantom/src/main.rs
@@ -15,6 +15,7 @@ use winit::{
 };
 
 mod auth_cli;
+mod builder_cli;
 mod fleet_cli;
 mod headless;
 mod loop_cli;
@@ -666,6 +667,14 @@ fn main() -> Result<()> {
     // which owns its own clap parsing and runtime construction.
     if args.get(1).map(String::as_str) == Some("loop") {
         return loop_cli::run_loop_subcommand(&args);
+    }
+
+    // `phantom builder` subcommand routing — higher-level orchestration
+    // that points the loop pipeline at any GitHub repo. The CLI surface
+    // mirrors `phantom loop run` but adds clone-or-attach, default-spec
+    // seeding, and an aggressive brain config.
+    if args.get(1).map(String::as_str) == Some("builder") {
+        return builder_cli::run_builder_subcommand(&args);
     }
 
     // `phantom fleet` subcommand routing — the "app of apps" meta-


### PR DESCRIPTION
## Summary

Generalises the brain self-improvement loop from `jdmiranda/phantom` specifically to **any GitHub repo Phantom can authenticate against**. Adds a new `phantom-builder` crate that orchestrates `phantom-loop` + `phantom-brain` behind a single CLI subcommand:

```bash
phantom builder run jdmiranda/phantom
phantom builder run rust-lang/cargo --trust-band 1 --max-prs-per-hour 3
phantom builder run my-org/my-app --dry-run
```

The builder clones the target repo to `~/.phantom/builds/<owner>-<repo>/` (or attaches to a `--repo-path` override), seeds four default loop specs into `<repo>/.phantom/loops/`, then boots the existing `phantom-loop` + `phantom-brain` machinery with the target slug.

## Topology

```
phantom builder run owner/repo
  └── ensure_local_checkout    → clone or fetch+checkout origin/main
  └── write_default_specs      → seed pr_finder_review, pr_finder_impl,
                                  reviewer, implementer .toml templates
                                  (substitutes target slug into every
                                  gh_pr / gh_issues source's repo field)
  └── boot phantom-loop runtime
        ├── LoopRegistry          (reused 1:1, no reimpl)
        ├── LoopQueueRegistry     (reused 1:1)
        ├── SubstrateAgentDispatcher
        ├── SubstrateDriver       (with ChatBackedSubstrateBackend)
        └── one LoopRunner per requested spec
  └── boot phantom-brain
        ├── SelfImprovementState (seeded from --trust-band 0|1|2|3)
        ├── GhIssueGoalSource    (label_filter = None → ALL open issues)
        ├── GhCiFailureGoalSource
        └── action forwarder → LoopQueueActionHandler OR DryRunActionHandler
```

Every primitive comes from the existing `phantom-loop` / `phantom-brain` crates. The builder only owns: clone/attach, default-spec seeding, brain config wiring, dry-run handler, trust-band knob, and the CLI surface.

## CLI surface

```bash
phantom builder run <owner>/<repo> [flags]
phantom builder list
phantom builder status <owner>/<repo>
```

`run` flags:
- `--repo-path <path>` — override local checkout (default `~/.phantom/builds/<o>-<r>`)
- `--trust-band 0|1|2|3` — 0=suggestion-only, 1=conservative (default), 2=standard, 3=aggressive
- `--loops a,b,c` — comma-separated loop names (default: the canonical four)
- `--dry-run` — score + log but never enqueue
- `--max-prs-per-hour N` — absolute per-hour cap (default 5)
- `--max-concurrent N` — max simultaneous agents (default 2)
- `--label-filter L1,L2,...` — only consider issues with these labels (default: ALL open issues)

## BuilderConfig knobs

| field | type | default | effect |
|---|---|---|---|
| `target_slug` | `String` | required | `owner/repo` slug |
| `repo_path` | `Option<PathBuf>` | `None` | override clone location |
| `trust_band` | `TrustBandConfig` | `Conservative` | seeds brain's `TrustBudget` |
| `label_filter` | `Option<Vec<String>>` | `None` | None = all open issues |
| `safety.max_prs_per_hour` | `u32` | 5 | brain's `RateLimiter` cap |
| `safety.max_concurrent_agents` | `u8` | 2 | every spec's `max_concurrent` |
| `safety.dry_run` | `bool` | false | swap queue handler for `DryRunActionHandler` |
| `loops` | `Vec<String>` | the canonical four | which seeded specs to start |

## Safety rails

1. **Trust band default = 1 (Conservative)** — score threshold 0.85, per-hour cap halved. Operators ramp up explicitly via `--trust-band 2` or `--trust-band 3`.
2. **`--dry-run`** — the brain still ticks (poll, score, gate, audit), but every `AiAction::EnqueueLoopMessage` is intercepted by `DryRunActionHandler` and logged via `tracing::info!`. The substrate driver never sees a request. Useful for "show me what phantom would do" sanity runs.
3. **Rate limit** — `--max-prs-per-hour N` clamps the brain's `RateLimiter` cap; the brain's band-adjusted multiplier still applies.
4. **Concurrency** — `--max-concurrent N` rewrites every seeded spec's `max_concurrent` field on disk.
5. **Hard exclusions** — the brain's existing `HardExclusions` (security label, draft, self-authored, opt-out labels, body markers) apply unchanged.

## Example invocation

```bash
phantom builder run jdmiranda/phantom
# phantom builder run: target=jdmiranda/phantom band=Conservative dry-run=false max-prs/h=5 max-concurrent=2
# phantom builder run: preflight checks
#   ok   gh binary present
#   ok   gh authenticated
#   ok   no MCP collisions on reserved tool names
#   ok   acquired /Users/me/.phantom/builds/jdmiranda-phantom/.phantom/loops/.runlock
# phantom builder run: starting 4 loop(s): pr_finder_review, pr_finder_impl, reviewer, implementer
# phantom builder run: booting brain with self-improvement against jdmiranda/phantom
# phantom builder run: all loops started. Press Ctrl-C to stop.
```

## Surprises from existing crate APIs

- `phantom-brain::self_improvement::SelfImprovementState::new` always opens at `TRUST_BUDGET_START = 4` (standard band) — there was no public way to start at conservative (band 1). Added an additive `with_trust_budget(config, budget)` constructor; the existing `new` is unchanged in behaviour (delegates). No call sites needed to migrate.
- `GhIssueGoalSource::new(repo, label_filter)` already accepts `Option<String>` for the label filter — `None` means no `--label` flag is passed to `gh issue list`, which returns every open issue. So the builder's "eat all the issues" default needed **zero changes** to the brain's goal source; just passing `None` was sufficient. The brief's contingency about adding a "no filter mode" turned out to be unnecessary.
- The brain runs on its own OS thread (not a tokio task). Action forwarding lives in `spawn_blocking`, which the existing `phantom loop run` already does. The builder reuses that pattern but adds a `stop_flag: AtomicBool` so the forwarder loop exits cleanly on `RunArtifacts::Drop` — necessary for tests because spawn_blocking tasks aren't aborted by `Runtime::shutdown_timeout` otherwise.

## Test plan
- [x] `cargo test -p phantom-builder` → **32 passed** (29 unit + 3 smoke)
- [x] `cargo test -p phantom-brain --lib` → **506 passed** (no regressions from `with_trust_budget` additive constructor)
- [x] `cargo test -p phantom` → **6 passed**
- [x] `./scripts/pre-pr-check.sh phantom-builder` → **all 3 gates PASS** (build, test, clippy)
- [x] `./scripts/pre-pr-check.sh phantom-brain` → **all 3 gates PASS**
- [x] `cargo build -p phantom` → PASS (CLI compiles and `phantom builder` help works)
- [x] Baseline comparison: `./scripts/pre-pr-check.sh phantom` clippy gate fails on **preexisting** warnings in `phantom-renderer`/`phantom-terminal`/`phantom/src/main.rs` (line 266 — pre-existing collapsible-if) — confirmed by stashing my changes and re-running clippy on the baseline. New code introduces zero new clippy warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)