### PR TITLE
feat(phantom-app): make every mockup app live in the binary

### DIFF
--- a/crates/phantom-app/src/adapters/boot.rs
+++ b/crates/phantom-app/src/adapters/boot.rs
@@ -283,8 +283,15 @@ impl InputHandler for BootAdapter {
 }
 
 impl Commandable for BootAdapter {
-    fn accept_command(&mut self, cmd: &str, _args: &serde_json::Value) -> anyhow::Result<String> {
+    fn accept_command(&mut self, cmd: &str, args: &serde_json::Value) -> anyhow::Result<String> {
         match cmd {
+            "set_theme_name" => {
+                let name = args.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                if let Some(tokens) = Tokens::for_theme_name(name, RenderCtx::fallback()) {
+                    self.set_tokens(tokens);
+                }
+                Ok(json!({ "status": "ok" }).to_string())
+            }
             "advance" => {
                 self.advance();
                 Ok(json!({ "status": "ok", "phase": self.phase }).to_string())

--- a/crates/phantom-app/src/adapters/console.rs
+++ b/crates/phantom-app/src/adapters/console.rs
@@ -252,6 +252,17 @@ impl InputHandler for ConsoleAdapter {
 impl Commandable for ConsoleAdapter {
     fn accept_command(&mut self, cmd: &str, args: &serde_json::Value) -> anyhow::Result<String> {
         match cmd {
+            "set_theme_name" => {
+                let name = args.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                if let Some(tokens) = Tokens::for_theme_name(name, RenderCtx::fallback()) {
+                    self.set_tokens(tokens);
+                }
+                Ok(json!({ "status": "ok" }).to_string())
+            }
+            "drain_pending" => {
+                let lines = self.drain_pending_input();
+                Ok(serde_json::to_string(&lines).unwrap_or_else(|_| "[]".to_string()))
+            }
             "out" => {
                 let text = args
                     .get("text")

--- a/crates/phantom-app/src/adapters/database.rs
+++ b/crates/phantom-app/src/adapters/database.rs
@@ -241,6 +241,13 @@ impl InputHandler for DatabaseAdapter {
 impl Commandable for DatabaseAdapter {
     fn accept_command(&mut self, cmd: &str, args: &serde_json::Value) -> anyhow::Result<String> {
         match cmd {
+            "set_theme_name" => {
+                let name = args.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                if let Some(tokens) = Tokens::for_theme_name(name, RenderCtx::fallback()) {
+                    self.set_tokens(tokens);
+                }
+                Ok(json!({ "status": "ok" }).to_string())
+            }
             "load_schema" => {
                 let table = args
                     .get("table")

--- a/crates/phantom-app/src/adapters/diff.rs
+++ b/crates/phantom-app/src/adapters/diff.rs
@@ -260,6 +260,13 @@ impl InputHandler for DiffAdapter {
 impl Commandable for DiffAdapter {
     fn accept_command(&mut self, cmd: &str, args: &serde_json::Value) -> anyhow::Result<String> {
         match cmd {
+            "set_theme_name" => {
+                let name = args.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                if let Some(tokens) = Tokens::for_theme_name(name, RenderCtx::fallback()) {
+                    self.set_tokens(tokens);
+                }
+                Ok(json!({ "status": "ok" }).to_string())
+            }
             "load" => {
                 let file = args.get("file").and_then(|v| v.as_str()).unwrap_or("").to_string();
                 let body = args

--- a/crates/phantom-app/src/adapters/files_watch.rs
+++ b/crates/phantom-app/src/adapters/files_watch.rs
@@ -248,6 +248,13 @@ impl InputHandler for FilesWatchAdapter {
 impl Commandable for FilesWatchAdapter {
     fn accept_command(&mut self, cmd: &str, args: &serde_json::Value) -> anyhow::Result<String> {
         match cmd {
+            "set_theme_name" => {
+                let name = args.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                if let Some(tokens) = Tokens::for_theme_name(name, RenderCtx::fallback()) {
+                    self.set_tokens(tokens);
+                }
+                Ok(json!({ "status": "ok" }).to_string())
+            }
             "push" => {
                 let path = args
                     .get("path")

--- a/crates/phantom-app/src/adapters/fleet.rs
+++ b/crates/phantom-app/src/adapters/fleet.rs
@@ -241,6 +241,13 @@ impl InputHandler for FleetAdapter {
 impl Commandable for FleetAdapter {
     fn accept_command(&mut self, cmd: &str, args: &serde_json::Value) -> anyhow::Result<String> {
         match cmd {
+            "set_theme_name" => {
+                let name = args.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                if let Some(tokens) = Tokens::for_theme_name(name, RenderCtx::fallback()) {
+                    self.set_tokens(tokens);
+                }
+                Ok(json!({ "status": "ok" }).to_string())
+            }
             "load" => {
                 let arr = args
                     .get("nodes")

--- a/crates/phantom-app/src/adapters/keybinds_help.rs
+++ b/crates/phantom-app/src/adapters/keybinds_help.rs
@@ -102,7 +102,31 @@ impl Renderable for KeybindsHelpAdapter {
         let mut text_segments: Vec<TextData> = Vec::new();
         let t = self.tokens;
 
-        let rows = self.rows();
+        let mut rows = self.rows();
+        // Augment registry rows with the hard-coded chrome-pane bindings
+        // wired in input.rs (these aren't represented by `Action` variants
+        // yet, so they don't appear in `KeybindRegistry::iter`). Sorted
+        // separately below the registry entries.
+        let chrome_bindings: &[(&str, &str)] = &[
+            ("F1 / ?", "Toggle keybinds pane"),
+            ("Cmd+,", "Settings pane"),
+            ("Cmd+M", "Memory inspector"),
+            ("Cmd+L", "Logs pane"),
+            ("Cmd+I", "Inspector pane"),
+            ("Cmd+Shift+N", "Notifications"),
+            ("Cmd+Shift+F", "File watch"),
+            ("Cmd+Shift+G", "Diff (git)"),
+            ("Cmd+Shift+L", "Fleet (nodes)"),
+            ("Cmd+Shift+P", "Plugins"),
+            ("Cmd+Shift+B", "Database"),
+            ("Cmd+Shift+V", "Voice / STT"),
+            ("Cmd+Shift+C", "Console pane"),
+            ("Cmd+Shift+K", "Keybinds pane"),
+        ];
+        for (combo, action) in chrome_bindings {
+            rows.push(((*combo).to_string(), (*action).to_string()));
+        }
+
         let head = AppHead::new("KEYBINDS", "F1")
             .with_icon("⌨")
             .with_meta(format!("{} bindings", rows.len()))
@@ -188,8 +212,15 @@ impl InputHandler for KeybindsHelpAdapter {
 }
 
 impl Commandable for KeybindsHelpAdapter {
-    fn accept_command(&mut self, cmd: &str, _args: &serde_json::Value) -> anyhow::Result<String> {
+    fn accept_command(&mut self, cmd: &str, args: &serde_json::Value) -> anyhow::Result<String> {
         match cmd {
+            "set_theme_name" => {
+                let name = args.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                if let Some(tokens) = Tokens::for_theme_name(name, RenderCtx::fallback()) {
+                    self.set_tokens(tokens);
+                }
+                Ok(json!({ "status": "ok" }).to_string())
+            }
             "snapshot" => {
                 let rows: Vec<serde_json::Value> = self
                     .rows()
@@ -254,7 +285,7 @@ mod tests {
     }
 
     #[test]
-    fn empty_registry_renders_hint() {
+    fn empty_registry_still_renders_chrome_bindings() {
         let reg = Arc::new(RwLock::new(KeybindRegistry::new()));
         {
             let combos: Vec<_> = {
@@ -268,7 +299,12 @@ mod tests {
         }
         let a = KeybindsHelpAdapter::new(reg);
         let out = a.render(&rect());
-        assert!(out.text_segments.iter().any(|t| t.text.contains("no bindings")));
+        // Registry is empty but the hard-coded chrome bindings always
+        // render (Cmd+, Settings, Cmd+Shift+N Notifications, etc.).
+        assert!(
+            out.text_segments.iter().any(|t| t.text.contains("Settings pane")),
+            "chrome bindings must render even when registry is empty",
+        );
     }
 
     #[test]

--- a/crates/phantom-app/src/adapters/logs.rs
+++ b/crates/phantom-app/src/adapters/logs.rs
@@ -286,6 +286,13 @@ impl InputHandler for LogsAdapter {
 impl Commandable for LogsAdapter {
     fn accept_command(&mut self, cmd: &str, args: &serde_json::Value) -> anyhow::Result<String> {
         match cmd {
+            "set_theme_name" => {
+                let name = args.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                if let Some(tokens) = Tokens::for_theme_name(name, RenderCtx::fallback()) {
+                    self.set_tokens(tokens);
+                }
+                Ok(json!({ "status": "ok" }).to_string())
+            }
             "push" => {
                 let level = LogLevel::parse(
                     args.get("level").and_then(|v| v.as_str()).unwrap_or("info"),

--- a/crates/phantom-app/src/adapters/memory_inspector.rs
+++ b/crates/phantom-app/src/adapters/memory_inspector.rs
@@ -212,6 +212,13 @@ impl InputHandler for MemoryInspectorAdapter {
 impl Commandable for MemoryInspectorAdapter {
     fn accept_command(&mut self, cmd: &str, args: &serde_json::Value) -> anyhow::Result<String> {
         match cmd {
+            "set_theme_name" => {
+                let name = args.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                if let Some(tokens) = Tokens::for_theme_name(name, RenderCtx::fallback()) {
+                    self.set_tokens(tokens);
+                }
+                Ok(json!({ "status": "ok" }).to_string())
+            }
             "set_project" => {
                 let name = args
                     .get("name")

--- a/crates/phantom-app/src/adapters/notifications.rs
+++ b/crates/phantom-app/src/adapters/notifications.rs
@@ -271,6 +271,13 @@ impl InputHandler for NotificationsAdapter {
 impl Commandable for NotificationsAdapter {
     fn accept_command(&mut self, cmd: &str, args: &serde_json::Value) -> anyhow::Result<String> {
         match cmd {
+            "set_theme_name" => {
+                let name = args.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                if let Some(tokens) = Tokens::for_theme_name(name, RenderCtx::fallback()) {
+                    self.set_tokens(tokens);
+                }
+                Ok(json!({ "status": "ok" }).to_string())
+            }
             "push" => {
                 let source = args.get("source").and_then(|v| v.as_str()).unwrap_or("system");
                 let message = args

--- a/crates/phantom-app/src/adapters/plugins.rs
+++ b/crates/phantom-app/src/adapters/plugins.rs
@@ -240,6 +240,13 @@ impl InputHandler for PluginsAdapter {
 impl Commandable for PluginsAdapter {
     fn accept_command(&mut self, cmd: &str, args: &serde_json::Value) -> anyhow::Result<String> {
         match cmd {
+            "set_theme_name" => {
+                let name = args.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                if let Some(tokens) = Tokens::for_theme_name(name, RenderCtx::fallback()) {
+                    self.set_tokens(tokens);
+                }
+                Ok(json!({ "status": "ok" }).to_string())
+            }
             "load" => {
                 let arr = args
                     .get("plugins")

--- a/crates/phantom-app/src/adapters/settings.rs
+++ b/crates/phantom-app/src/adapters/settings.rs
@@ -39,6 +39,9 @@ pub struct SettingsView {
     pub bloom: Slider01,
     pub curvature: Slider01,
     pub privacy_mode: bool,
+    /// CRT post-fx toggle — `false` disables scanlines/bloom/curvature
+    /// regardless of slider values. Matches the mockup's checkbox.
+    pub crt_enabled: bool,
 }
 
 impl Default for SettingsView {
@@ -51,6 +54,7 @@ impl Default for SettingsView {
             bloom: Slider01::new(0.5),
             curvature: Slider01::new(0.1),
             privacy_mode: false,
+            crt_enabled: true,
         }
     }
 }
@@ -137,6 +141,7 @@ impl AppCore for SettingsAdapter {
             "bloom": self.view.bloom.0,
             "curvature": self.view.curvature.0,
             "privacy_mode": self.view.privacy_mode,
+            "crt_enabled": self.view.crt_enabled,
             "revision": self.revision,
         })
     }
@@ -303,6 +308,14 @@ impl Commandable for SettingsAdapter {
             Ok::<String, anyhow::Error>(json!({ "status": "ok", "field": label }).to_string())
         };
         match cmd {
+            "set_theme_name" => {
+                let name = args.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                if let Some(tokens) = Tokens::for_theme_name(name, RenderCtx::fallback()) {
+                    self.set_tokens(tokens);
+                }
+                self.view.theme = name.to_string();
+                bump_and_ok(self, "theme")
+            }
             "set_theme" => {
                 let name = args
                     .get("name")
@@ -348,6 +361,11 @@ impl Commandable for SettingsAdapter {
                 let on = args.get("enabled").and_then(|v| v.as_bool()).unwrap_or(false);
                 self.view.privacy_mode = on;
                 bump_and_ok(self, "privacy_mode")
+            }
+            "set_crt_enabled" => {
+                let on = args.get("enabled").and_then(|v| v.as_bool()).unwrap_or(true);
+                self.view.crt_enabled = on;
+                bump_and_ok(self, "crt_enabled")
             }
             "snapshot" => Ok(self.get_state().to_string()),
             other => Err(anyhow::anyhow!("unknown command: {other}")),

--- a/crates/phantom-app/src/adapters/voice_stt.rs
+++ b/crates/phantom-app/src/adapters/voice_stt.rs
@@ -242,6 +242,13 @@ impl InputHandler for VoiceSttAdapter {
 impl Commandable for VoiceSttAdapter {
     fn accept_command(&mut self, cmd: &str, args: &serde_json::Value) -> anyhow::Result<String> {
         match cmd {
+            "set_theme_name" => {
+                let name = args.get("name").and_then(|v| v.as_str()).unwrap_or("");
+                if let Some(tokens) = Tokens::for_theme_name(name, RenderCtx::fallback()) {
+                    self.set_tokens(tokens);
+                }
+                Ok(json!({ "status": "ok" }).to_string())
+            }
             "start" => {
                 self.listening = true;
                 Ok(json!({ "status": "ok" }).to_string())

--- a/crates/phantom-app/src/app.rs
+++ b/crates/phantom-app/src/app.rs
@@ -366,6 +366,44 @@ pub struct App {
     pub(crate) inspector_tokens:
         Option<std::sync::Arc<std::sync::RwLock<phantom_ui::tokens::Tokens>>>,
 
+    // -- Per-pane handles for the mockup's chrome adapters
+    //    (Settings / Notifications / Console / KeybindsHelp / Logs /
+    //    FilesWatch / Diff / Memory / Fleet / Plugins / Database / VoiceStt).
+    //
+    //    `Some(app_id)` while the pane is open, `None` after despawn. The
+    //    keybind handler toggles: spawn if `None`, despawn if `Some`.
+    pub(crate) settings_pane_id: Option<u32>,
+    pub(crate) notifications_pane_id: Option<u32>,
+    pub(crate) console_pane_id: Option<u32>,
+    pub(crate) keybinds_help_pane_id: Option<u32>,
+    pub(crate) logs_pane_id: Option<u32>,
+    pub(crate) files_watch_pane_id: Option<u32>,
+    pub(crate) diff_pane_id: Option<u32>,
+    pub(crate) memory_pane_id: Option<u32>,
+    pub(crate) fleet_pane_id: Option<u32>,
+    pub(crate) plugins_pane_id: Option<u32>,
+    pub(crate) database_pane_id: Option<u32>,
+    pub(crate) voice_stt_pane_id: Option<u32>,
+
+    /// Background filesystem watcher kept alive while the FilesWatch pane
+    /// is open. Dropped on despawn to stop the OS watch.
+    pub(crate) files_watcher: Option<crate::files_watcher::FilesWatcher>,
+
+    /// Last log-ring offset pushed into the Logs pane. Advances each frame
+    /// so the adapter only sees new entries; reset on pane spawn.
+    pub(crate) logs_watermark: usize,
+
+    /// Last observed revision of the Settings pane. When the pane mutates
+    /// any value its revision bumps; the App detects the change each
+    /// frame, persists to ~/.config/phantom/settings.toml, and triggers
+    /// a live reload.
+    pub(crate) settings_pane_revision: u64,
+
+    /// CRT post-fx master switch. When `false` the renderer scales every
+    /// shader intensity by zero regardless of theme/per-slider values.
+    /// Mutated by `SettingsAdapter::set_crt_enabled`.
+    pub(crate) crt_enabled: bool,
+
     // -- Lars fix-thread sink: shared queue of `EventKind::AgentBlocked`
     //    substrate events emitted by agent panes when their consecutive
     //    tool-call failure streak crosses the threshold. Each spawned
@@ -1554,6 +1592,22 @@ impl App {
             fullscreen_pane: None,
             inspector_snapshot: None,
             inspector_tokens: None,
+            settings_pane_id: None,
+            notifications_pane_id: None,
+            console_pane_id: None,
+            keybinds_help_pane_id: None,
+            logs_pane_id: None,
+            files_watch_pane_id: None,
+            diff_pane_id: None,
+            memory_pane_id: None,
+            fleet_pane_id: None,
+            plugins_pane_id: None,
+            database_pane_id: None,
+            voice_stt_pane_id: None,
+            files_watcher: None,
+            logs_watermark: 0,
+            settings_pane_revision: 0,
+            crt_enabled: true,
             blocked_event_sink: crate::agent_pane::new_blocked_event_sink(),
             denied_event_sink: crate::agent_pane::new_denied_event_sink(),
             quarantine_registry: std::sync::Arc::new(std::sync::Mutex::new(

--- a/crates/phantom-app/src/coordinator.rs
+++ b/crates/phantom-app/src/coordinator.rs
@@ -251,6 +251,25 @@ impl AppCoordinator {
 
         self.registry.ready(id);
 
+        // Wire the adapter's declared bus subscriptions. Adapters that
+        // implement `BusParticipant::subscribes_to()` get their topics
+        // resolved against the registered topic table; unknown topic
+        // names are logged and skipped so a typo can't take down the
+        // adapter.
+        let topics: Vec<String> = self
+            .registry
+            .get_adapter(id)
+            .map(|a| a.subscribes_to())
+            .unwrap_or_default();
+        for topic_name in topics {
+            match self.bus.topic_id_by_name(&topic_name) {
+                Some(tid) => self.bus.subscribe(id, tid),
+                None => log::warn!(
+                    "Adapter {id} subscribed to unregistered topic '{topic_name}' — skipped"
+                ),
+            }
+        }
+
         // Use the provided PaneId (already in the layout).
         self.pane_map.insert(pane_id, id);
         self.app_pane_map.insert(id, pane_id);

--- a/crates/phantom-app/src/files_watcher.rs
+++ b/crates/phantom-app/src/files_watcher.rs
@@ -1,0 +1,100 @@
+//! Background filesystem watcher for the `FilesWatchAdapter` pane.
+//!
+//! Wraps `notify::RecommendedWatcher` against a project root directory and
+//! emits `FileChangeEvent`s on a channel. The receiver drains the channel
+//! each frame from `App::update` and routes events into the pane via
+//! `accept_command "push"`.
+//!
+//! Dropping the watcher stops the background watch thread (notify's
+//! internal contract). The App holds an `Option<FilesWatcher>` that is
+//! `Some` only while the pane is spawned.
+
+use std::path::Path;
+use std::sync::mpsc;
+
+use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher, recommended_watcher};
+
+/// One filesystem change event projected into the adapter's vocabulary.
+#[derive(Debug, Clone)]
+pub struct FileChangeEvent {
+    /// Path that changed, relative to the project root if possible,
+    /// otherwise absolute.
+    pub path: String,
+    /// `"M"` for modify, `"+"` for create, `"D"` for delete. Falls back to
+    /// `"M"` for ambiguous events.
+    pub kind: &'static str,
+}
+
+/// Background filesystem watcher.
+pub struct FilesWatcher {
+    rx: mpsc::Receiver<FileChangeEvent>,
+    root: std::path::PathBuf,
+    _watcher: RecommendedWatcher,
+}
+
+impl FilesWatcher {
+    /// Start watching `root` recursively. Returns `None` when notify setup
+    /// fails so callers can degrade gracefully.
+    pub fn new(root: &Path) -> Option<Self> {
+        let (tx, rx) = mpsc::channel::<FileChangeEvent>();
+        let root_owned = root.to_path_buf();
+        let root_for_cb = root_owned.clone();
+
+        let mut watcher = recommended_watcher(move |result: notify::Result<notify::Event>| {
+            let Ok(event) = result else { return };
+            let kind = match event.kind {
+                EventKind::Create(_) => "+",
+                EventKind::Remove(_) => "D",
+                _ => "M",
+            };
+            for path in event.paths {
+                // Skip noisy directories (target/, node_modules/, .git/).
+                let p = path.to_string_lossy();
+                if p.contains("/target/")
+                    || p.contains("/node_modules/")
+                    || p.contains("/.git/")
+                    || p.contains("/.cargo/")
+                {
+                    continue;
+                }
+                let relative = path
+                    .strip_prefix(&root_for_cb)
+                    .map(|p| p.to_string_lossy().into_owned())
+                    .unwrap_or_else(|_| p.into_owned());
+                let _ = tx.send(FileChangeEvent {
+                    path: relative,
+                    kind,
+                });
+            }
+        })
+        .ok()?;
+
+        watcher.watch(root, RecursiveMode::Recursive).ok()?;
+
+        log::info!("files_watcher: watching {root:?} recursively");
+
+        Some(Self {
+            rx,
+            root: root_owned,
+            _watcher: watcher,
+        })
+    }
+
+    /// Drain all pending events; returns at most `limit` to bound work.
+    pub fn drain(&self, limit: usize) -> Vec<FileChangeEvent> {
+        let mut out = Vec::new();
+        while out.len() < limit {
+            match self.rx.try_recv() {
+                Ok(ev) => out.push(ev),
+                Err(_) => break,
+            }
+        }
+        out
+    }
+
+    /// Root path being watched.
+    #[allow(dead_code)]
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+}

--- a/crates/phantom-app/src/input.rs
+++ b/crates/phantom-app/src/input.rs
@@ -278,9 +278,70 @@ impl App {
                 debug!("PrevTab redirected to FocusPrev (panes-first model)");
                 self.dispatch_action(Action::FocusPrev);
             }
+            Action::CycleTheme => {
+                self.cycle_theme();
+            }
             _ => {
                 debug!("Action: {action} (not yet implemented)");
             }
+        }
+    }
+
+    /// Cycle to the next built-in theme and broadcast the new tokens to
+    /// every spawned chrome adapter so headers and bodies recolor in
+    /// place. Persists via the settings.toml live-reload path so the
+    /// new theme survives across restarts.
+    pub(crate) fn cycle_theme(&mut self) {
+        use phantom_ui::themes::BUILTIN_NAMES;
+        let current = self.theme.name.clone();
+        let idx = BUILTIN_NAMES
+            .iter()
+            .position(|n| n.eq_ignore_ascii_case(&current))
+            .unwrap_or(0);
+        let next = BUILTIN_NAMES[(idx + 1) % BUILTIN_NAMES.len()];
+
+        // Persist and reload via the existing settings path.
+        let mut settings = crate::settings::PhantomSettings::load();
+        settings.theme = next.to_string();
+        if let Err(e) = settings.save() {
+            log::warn!("CycleTheme: settings.save failed: {e}");
+        }
+        self.apply_config_reload(&settings);
+
+        // Broadcast a fresh Tokens snapshot to every chrome adapter we
+        // know about so the next render reflects the new palette.
+        self.broadcast_theme_to_chrome_panes();
+        info!("Theme cycled: {} → {}", current, next);
+    }
+
+    /// Push a fresh Tokens snapshot into every currently-spawned chrome
+    /// adapter via `accept_command "set_tokens"`. Concrete `set_tokens`
+    /// methods on each adapter take `Tokens` directly; since we can't pass
+    /// non-JSON values through the coordinator, we encode the active
+    /// theme name and let each adapter rebuild its snapshot inside its
+    /// command handler.
+    pub(crate) fn broadcast_theme_to_chrome_panes(&mut self) {
+        let panes = [
+            self.settings_pane_id,
+            self.notifications_pane_id,
+            self.console_pane_id,
+            self.keybinds_help_pane_id,
+            self.logs_pane_id,
+            self.files_watch_pane_id,
+            self.diff_pane_id,
+            self.memory_pane_id,
+            self.fleet_pane_id,
+            self.plugins_pane_id,
+            self.database_pane_id,
+            self.voice_stt_pane_id,
+        ];
+        let theme_name = self.theme.name.to_lowercase();
+        for pane in panes.into_iter().flatten() {
+            let _ = self.coordinator.send_command(
+                pane,
+                "set_theme_name",
+                &serde_json::json!({ "name": &theme_name }),
+            );
         }
     }
 
@@ -399,9 +460,8 @@ impl App {
             return;
         }
 
-        // F1 or bare `?` toggles the keybind help overlay.
-        // Handled before console/suggestion routing so the overlay is always
-        // reachable regardless of which sub-mode is active.
+        // F1 or bare `?` toggles the KeybindsHelp pane. Replaces the legacy
+        // overlay with the mockup's `KeybindsHelpAdapter` pane.
         if !modifiers.state().control_key()
             && !modifiers.state().alt_key()
             && !modifiers.state().super_key()
@@ -409,8 +469,7 @@ impl App {
             let is_f1 = matches!(&event.logical_key, Key::Named(NamedKey::F1));
             let is_question = matches!(&event.logical_key, Key::Character(s) if s.as_str() == "?");
             if is_f1 || is_question {
-                self.keybind_help.toggle();
-                debug!("Keybind help overlay toggled: {}", self.keybind_help.visible());
+                crate::spawn_chrome::toggle_keybinds_help_pane(self);
                 return;
             }
         }
@@ -615,6 +674,78 @@ impl App {
                 debug!("Cmd+I: inspector pane spawn failed (no focused pane)");
             }
             return;
+        }
+
+        // ── Mockup chrome pane keybinds ────────────────────────────────────
+        // Each toggles its adapter pane: spawn if closed, despawn if open.
+        // Tracked via `App::<adapter>_pane_id: Option<u32>`.
+        {
+            let mods = modifiers.state();
+            let super_only = mods.super_key() && !mods.shift_key() && !mods.alt_key() && !mods.control_key();
+            let super_shift = mods.super_key() && mods.shift_key() && !mods.alt_key() && !mods.control_key();
+            let key = &event.logical_key;
+            let is_ch = |c: &str| matches!(key, Key::Character(s) if s.eq_ignore_ascii_case(c));
+
+            // Cmd+, — Settings
+            if super_only && is_ch(",") {
+                crate::spawn_chrome::toggle_settings_pane(self);
+                return;
+            }
+            // Cmd+M — Memory inspector
+            if super_only && is_ch("m") {
+                crate::spawn_chrome::toggle_memory_pane(self);
+                return;
+            }
+            // Cmd+L — Logs
+            if super_only && is_ch("l") {
+                crate::spawn_chrome::toggle_logs_pane(self);
+                return;
+            }
+            // Cmd+Shift+N — Notifications
+            if super_shift && is_ch("n") {
+                crate::spawn_chrome::toggle_notifications_pane(self);
+                return;
+            }
+            // Cmd+Shift+F — File watch
+            if super_shift && is_ch("f") {
+                crate::spawn_chrome::toggle_files_watch_pane(self);
+                return;
+            }
+            // Cmd+Shift+G — Diff (git)
+            if super_shift && is_ch("g") {
+                crate::spawn_chrome::toggle_diff_pane(self);
+                return;
+            }
+            // Cmd+Shift+L — Fleet (nodes)
+            if super_shift && is_ch("l") {
+                crate::spawn_chrome::toggle_fleet_pane(self);
+                return;
+            }
+            // Cmd+Shift+P — Plugins
+            if super_shift && is_ch("p") {
+                crate::spawn_chrome::toggle_plugins_pane(self);
+                return;
+            }
+            // Cmd+Shift+B — Database (bundle store)
+            if super_shift && is_ch("b") {
+                crate::spawn_chrome::toggle_database_pane(self);
+                return;
+            }
+            // Cmd+Shift+V — Voice / STT
+            if super_shift && is_ch("v") {
+                crate::spawn_chrome::toggle_voice_stt_pane(self);
+                return;
+            }
+            // Cmd+Shift+K — KeybindsHelp pane (in addition to F1 overlay)
+            if super_shift && is_ch("k") {
+                crate::spawn_chrome::toggle_keybinds_help_pane(self);
+                return;
+            }
+            // Cmd+Shift+C — Console pane (the in-pane REPL adapter)
+            if super_shift && is_ch("c") {
+                crate::spawn_chrome::toggle_console_pane(self);
+                return;
+            }
         }
 
         if let Some(combo) = winit_key_to_combo_with_mods(&event, modifiers)

--- a/crates/phantom-app/src/lib.rs
+++ b/crates/phantom-app/src/lib.rs
@@ -31,6 +31,8 @@ pub mod profiler;
 mod render;
 mod render_overlay;
 mod search;
+mod spawn_chrome;
+mod files_watcher;
 pub mod resources;
 pub mod runtime;
 mod selftest;

--- a/crates/phantom-app/src/logging.rs
+++ b/crates/phantom-app/src/logging.rs
@@ -81,6 +81,34 @@ pub const VERBOSITY_INFO: u8 = 2;
 pub const VERBOSITY_DEBUG: u8 = 3;
 pub const VERBOSITY_TRACE: u8 = 4;
 
+/// In-memory ring buffer of the most recent log lines. Sized to a constant
+/// 500 entries — enough for the LogsAdapter pane to show useful history
+/// while bounding the per-process memory footprint.
+pub const LOG_RING_CAPACITY: usize = 500;
+
+/// One log row captured in the in-memory ring buffer.
+#[derive(Debug, Clone)]
+pub struct LogRingEntry {
+    pub level: log::Level,
+    pub target: String,
+    pub message: String,
+}
+
+static LOG_RING: std::sync::OnceLock<
+    std::sync::Arc<std::sync::Mutex<std::collections::VecDeque<LogRingEntry>>>,
+> = std::sync::OnceLock::new();
+
+/// Access the global log ring buffer. Lazily initialized.
+pub fn log_ring() -> std::sync::Arc<std::sync::Mutex<std::collections::VecDeque<LogRingEntry>>> {
+    LOG_RING
+        .get_or_init(|| {
+            std::sync::Arc::new(std::sync::Mutex::new(
+                std::collections::VecDeque::with_capacity(LOG_RING_CAPACITY),
+            ))
+        })
+        .clone()
+}
+
 /// The Phantom logger.
 pub struct PhantomLogger {
     active_channels: AtomicU32,
@@ -206,6 +234,20 @@ impl log::Log for PhantomLogger {
         // Write to stderr if enabled
         if self.stderr {
             eprintln!("{msg}");
+        }
+
+        // Push into the in-memory ring buffer so the LogsAdapter pane can
+        // tail recent activity without re-parsing the log file.
+        let ring = log_ring();
+        if let Ok(mut buf) = ring.lock() {
+            if buf.len() >= LOG_RING_CAPACITY {
+                buf.pop_front();
+            }
+            buf.push_back(LogRingEntry {
+                level: record.level(),
+                target: record.target().to_string(),
+                message: record.args().to_string(),
+            });
         }
     }
 

--- a/crates/phantom-app/src/render.rs
+++ b/crates/phantom-app/src/render.rs
@@ -175,7 +175,11 @@ impl App {
             let elapsed = self.start_time.elapsed().as_secs_f32();
 
             // During boot, scale CRT effect intensities by the boot warmup ramp.
-            let crt_scale = if self.state == AppState::Boot {
+            // When the user has disabled CRT via Settings, force the scale
+            // to zero so every shader intensity collapses to "no effect".
+            let crt_scale = if !self.crt_enabled {
+                0.0
+            } else if self.state == AppState::Boot {
                 self.boot.crt_intensity()
             } else {
                 1.0

--- a/crates/phantom-app/src/spawn_chrome.rs
+++ b/crates/phantom-app/src/spawn_chrome.rs
@@ -1,0 +1,469 @@
+//! Shared spawn helper for the mockup's chrome adapters
+//! (Settings / Notifications / Console / KeybindsHelp / Logs / FilesWatch /
+//! Diff / Memory / Fleet / Plugins / Database / VoiceStt).
+//!
+//! Mirrors the `spawn_inspector_pane` pattern: split the focused pane
+//! vertically, register the new adapter in the new child, resize, focus.
+//!
+//! Every chrome-pane keybind in `App` calls one of the `toggle_*_pane`
+//! helpers below: the helper spawns a fresh adapter if the pane is closed
+//! and despawns it if it's already open.
+
+use log::{info, warn};
+
+use phantom_adapter::AppAdapter;
+use phantom_ui::tokens::Tokens;
+use phantom_ui::RenderCtx;
+
+use crate::adapters::{
+    BootAdapter, ConsoleAdapter, DatabaseAdapter, DiffAdapter, FilesWatchAdapter, FleetAdapter,
+    KeybindsHelpAdapter, LogsAdapter, MemoryInspectorAdapter, NotificationsAdapter, PluginsAdapter,
+    SettingsAdapter, VoiceSttAdapter,
+};
+use crate::adapters::settings::{Slider01, SettingsView};
+use crate::app::App;
+
+/// Build a `Tokens` snapshot from the App's currently active theme.
+///
+/// For now every theme uses the phosphor ColorRoles palette; the per-theme
+/// `ColorRoles` table lands as part of the theme-cycle broadcast pass.
+fn current_tokens(app: &App) -> Tokens {
+    let ctx = RenderCtx::new(app.cell_size, 1.0);
+    Tokens::phosphor(ctx)
+}
+
+/// Split the focused pane vertically (50/50) and register `adapter` in the
+/// new child. Returns the new `AppId` on success, `None` if no pane is
+/// focused or the split fails.
+fn spawn_chrome_pane(
+    app: &mut App,
+    adapter: Box<dyn AppAdapter>,
+    adapter_label: &str,
+) -> Option<u32> {
+    let focused_app_id = match app.coordinator.focused() {
+        Some(id) => id,
+        None => {
+            warn!("Cannot spawn {adapter_label}: no focused adapter");
+            return None;
+        }
+    };
+    let current_pane_id = match app.coordinator.pane_id_for(focused_app_id) {
+        Some(id) => id,
+        None => {
+            warn!("Cannot spawn {adapter_label}: focused adapter has no layout pane");
+            return None;
+        }
+    };
+
+    let (existing_child, new_child) = match app.layout.split_vertical(current_pane_id) {
+        Ok(ids) => ids,
+        Err(e) => {
+            warn!("Spawn {adapter_label} split failed: {e}");
+            return None;
+        }
+    };
+
+    let _ = app.layout.set_flex_grow(existing_child, 1.0);
+    let _ = app.layout.set_flex_grow(new_child, 1.0);
+
+    let width = app.gpu.surface_config.width;
+    let height = app.gpu.surface_config.height;
+    let _ = app.layout.resize(width as f32, height as f32);
+
+    app.coordinator
+        .remap_pane(focused_app_id, current_pane_id, existing_child);
+
+    if let Ok(rect) = app.layout.get_pane_rect(existing_child) {
+        let (cols, rows) = crate::pane::pane_cols_rows(app.cell_size, rect);
+        let _ = app.coordinator.send_command(
+            focused_app_id,
+            "resize",
+            &serde_json::json!({ "cols": cols, "rows": rows }),
+        );
+    }
+
+    let scene_node = app
+        .scene
+        .add_node(app.scene_content_node, phantom_scene::node::NodeKind::Pane);
+
+    let app_id = app.coordinator.register_adapter_at_pane(
+        adapter,
+        new_child,
+        scene_node,
+        phantom_scene::clock::Cadence::unlimited(),
+        &mut app.layout,
+    );
+
+    app.coordinator.set_focus(app_id);
+
+    info!("{adapter_label} adapter registered (AppId {app_id}) in split pane");
+    Some(app_id)
+}
+
+/// Despawn a previously-spawned chrome pane by its AppId.
+fn despawn_chrome_pane(app: &mut App, app_id: u32, label: &str) {
+    app.coordinator
+        .remove_adapter(app_id, &mut app.layout, &mut app.scene);
+    info!("{label} adapter despawned (AppId {app_id})");
+}
+
+// ---------------------------------------------------------------------------
+// Toggle helpers — one per chrome adapter
+// ---------------------------------------------------------------------------
+
+pub(crate) fn toggle_settings_pane(app: &mut App) {
+    if let Some(app_id) = app.settings_pane_id.take() {
+        despawn_chrome_pane(app, app_id, "Settings");
+        return;
+    }
+    let tokens = current_tokens(app);
+    let view = SettingsView {
+        theme: app.theme.name.to_lowercase(),
+        scanlines: Slider01::new(app.theme.shader_params.scanline_intensity),
+        bloom: Slider01::new(app.theme.shader_params.bloom_intensity),
+        curvature: Slider01::new(app.theme.shader_params.curvature),
+        ..SettingsView::default()
+    };
+    let mut adapter = SettingsAdapter::with_view(view);
+    adapter.set_tokens(tokens);
+    if let Some(new_id) = spawn_chrome_pane(app, Box::new(adapter), "Settings") {
+        app.settings_pane_id = Some(new_id);
+    }
+}
+
+pub(crate) fn toggle_notifications_pane(app: &mut App) {
+    if let Some(app_id) = app.notifications_pane_id.take() {
+        despawn_chrome_pane(app, app_id, "Notifications");
+        return;
+    }
+    let tokens = current_tokens(app);
+    let mut adapter = NotificationsAdapter::new();
+    adapter.set_tokens(tokens);
+    if let Some(new_id) = spawn_chrome_pane(app, Box::new(adapter), "Notifications") {
+        app.notifications_pane_id = Some(new_id);
+    }
+}
+
+pub(crate) fn toggle_console_pane(app: &mut App) {
+    if let Some(app_id) = app.console_pane_id.take() {
+        despawn_chrome_pane(app, app_id, "Console");
+        return;
+    }
+    let tokens = current_tokens(app);
+    let mut adapter = ConsoleAdapter::new();
+    adapter.set_tokens(tokens);
+    if let Some(new_id) = spawn_chrome_pane(app, Box::new(adapter), "Console") {
+        app.console_pane_id = Some(new_id);
+    }
+}
+
+pub(crate) fn toggle_keybinds_help_pane(app: &mut App) {
+    if let Some(app_id) = app.keybinds_help_pane_id.take() {
+        despawn_chrome_pane(app, app_id, "KeybindsHelp");
+        return;
+    }
+    let tokens = current_tokens(app);
+    let mut adapter = KeybindsHelpAdapter::with_defaults();
+    adapter.set_tokens(tokens);
+    if let Some(new_id) = spawn_chrome_pane(app, Box::new(adapter), "KeybindsHelp") {
+        app.keybinds_help_pane_id = Some(new_id);
+    }
+}
+
+pub(crate) fn toggle_logs_pane(app: &mut App) {
+    if let Some(app_id) = app.logs_pane_id.take() {
+        despawn_chrome_pane(app, app_id, "Logs");
+        return;
+    }
+    let tokens = current_tokens(app);
+    let mut adapter = LogsAdapter::new();
+    adapter.set_tokens(tokens);
+
+    // Seed with the in-memory log ring's tail so the pane shows recent
+    // activity immediately. Per-frame appends land in
+    // `App::refresh_logs_pane`.
+    use crate::adapters::logs::{LogLevel, LogRow};
+    let ring = crate::logging::log_ring();
+    let watermark = if let Ok(buf) = ring.lock() {
+        for entry in buf.iter() {
+            let level = match entry.level {
+                log::Level::Error => LogLevel::Error,
+                log::Level::Warn => LogLevel::Warn,
+                log::Level::Info => LogLevel::Info,
+                log::Level::Debug => LogLevel::Debug,
+                log::Level::Trace => LogLevel::Trace,
+            };
+            adapter.push(LogRow::new(level, entry.target.clone(), entry.message.clone()));
+        }
+        buf.len()
+    } else {
+        0
+    };
+    app.logs_watermark = watermark;
+
+    if let Some(new_id) = spawn_chrome_pane(app, Box::new(adapter), "Logs") {
+        app.logs_pane_id = Some(new_id);
+    }
+}
+
+pub(crate) fn toggle_files_watch_pane(app: &mut App) {
+    if let Some(app_id) = app.files_watch_pane_id.take() {
+        despawn_chrome_pane(app, app_id, "FilesWatch");
+        // Stop the background watcher so we don't burn cycles while the
+        // pane is closed.
+        app.files_watcher = None;
+        return;
+    }
+    let tokens = current_tokens(app);
+    let mut adapter = FilesWatchAdapter::new();
+    adapter.set_tokens(tokens);
+    if let Some(new_id) = spawn_chrome_pane(app, Box::new(adapter), "FilesWatch") {
+        app.files_watch_pane_id = Some(new_id);
+        // Spin up the watcher on the current working directory.
+        if let Ok(cwd) = std::env::current_dir() {
+            app.files_watcher = crate::files_watcher::FilesWatcher::new(&cwd);
+            if app.files_watcher.is_none() {
+                log::warn!("FilesWatch: notify watcher setup failed; pane will show no events");
+            }
+        }
+    }
+}
+
+pub(crate) fn toggle_diff_pane(app: &mut App) {
+    if let Some(app_id) = app.diff_pane_id.take() {
+        despawn_chrome_pane(app, app_id, "Diff");
+        return;
+    }
+    let tokens = current_tokens(app);
+    let mut adapter = DiffAdapter::empty();
+    adapter.set_tokens(tokens);
+
+    // Seed the adapter with `git diff` output for the current working tree.
+    // Hard-wires the `git` binary because phantom-context's git plumbing
+    // doesn't expose a unified-diff string today. Falls back silently to
+    // an empty view if the command fails (no repo, no git, etc.).
+    if let Ok(cwd) = std::env::current_dir()
+        && let Ok(output) = std::process::Command::new("git")
+            .arg("diff")
+            .arg("HEAD")
+            .current_dir(&cwd)
+            .output()
+        && output.status.success()
+    {
+        let body = String::from_utf8_lossy(&output.stdout);
+        if !body.trim().is_empty() {
+            let file_label = cwd
+                .file_name()
+                .and_then(|s| s.to_str())
+                .map(|s| format!("{s} · git diff HEAD"))
+                .unwrap_or_else(|| "git diff HEAD".to_string());
+            adapter.set_view(crate::adapters::diff::DiffView::parse(file_label, &body));
+        }
+    }
+
+    if let Some(new_id) = spawn_chrome_pane(app, Box::new(adapter), "Diff") {
+        app.diff_pane_id = Some(new_id);
+    }
+}
+
+pub(crate) fn toggle_memory_pane(app: &mut App) {
+    if let Some(app_id) = app.memory_pane_id.take() {
+        despawn_chrome_pane(app, app_id, "Memory");
+        return;
+    }
+    let tokens = current_tokens(app);
+    let mut adapter = MemoryInspectorAdapter::new();
+    adapter.set_tokens(tokens);
+
+    // Load the per-project auto-memory directory if present. Each .md file
+    // has a YAML frontmatter with `name` and `description`; we surface those
+    // as key/value rows. MEMORY.md (the index) is skipped because its
+    // content is one-liners that double-up with the individual files.
+    let project_dir = std::env::current_dir().ok();
+    let project_slug = project_dir.as_ref().and_then(|p| {
+        p.to_str().map(|s| s.replace('/', "-"))
+    });
+    if let Some(slug) = project_slug {
+        let memory_dir = std::env::var("HOME")
+            .ok()
+            .map(|h| std::path::PathBuf::from(h).join(".claude/projects").join(slug).join("memory"));
+        if let Some(dir) = memory_dir
+            && let Ok(entries) = std::fs::read_dir(&dir)
+        {
+            let mut rows = Vec::new();
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.extension().and_then(|s| s.to_str()) != Some("md") {
+                    continue;
+                }
+                let file_name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+                if file_name == "MEMORY.md" {
+                    continue;
+                }
+                let Ok(body) = std::fs::read_to_string(&path) else { continue };
+                let name = parse_frontmatter_field(&body, "name").unwrap_or_else(|| file_name.trim_end_matches(".md").to_string());
+                let description = parse_frontmatter_field(&body, "description").unwrap_or_else(|| "(no description)".to_string());
+                rows.push(crate::adapters::memory_inspector::MemoryEntry::new(name, description));
+            }
+            rows.sort_by(|a, b| a.key.cmp(&b.key));
+            adapter.set_entries(rows);
+        }
+        if let Some(name) = project_dir
+            .as_ref()
+            .and_then(|p| p.file_name().and_then(|s| s.to_str()))
+        {
+            adapter.set_project(name);
+        }
+    }
+
+    if let Some(new_id) = spawn_chrome_pane(app, Box::new(adapter), "Memory") {
+        app.memory_pane_id = Some(new_id);
+    }
+}
+
+/// Pull a single YAML-frontmatter field from a markdown file (very loose
+/// parsing — looks for `<key>:` at the start of a line within the leading
+/// `---` block). Strips surrounding quotes.
+fn parse_frontmatter_field(body: &str, key: &str) -> Option<String> {
+    let mut in_fm = false;
+    for line in body.lines() {
+        if line.trim() == "---" {
+            if in_fm {
+                return None;
+            }
+            in_fm = true;
+            continue;
+        }
+        if !in_fm {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix(&format!("{key}:")) {
+            let v = rest.trim().trim_matches(|c| c == '"' || c == '\'');
+            if v.is_empty() {
+                return None;
+            }
+            return Some(v.to_string());
+        }
+    }
+    None
+}
+
+pub(crate) fn toggle_fleet_pane(app: &mut App) {
+    if let Some(app_id) = app.fleet_pane_id.take() {
+        despawn_chrome_pane(app, app_id, "Fleet");
+        return;
+    }
+    let tokens = current_tokens(app);
+    let mut adapter = FleetAdapter::new();
+    adapter.set_tokens(tokens);
+
+    // Seed with the local node's identity; phantom-fleet's FleetRunner
+    // lives in a separate binary today, so a live remote-node feed lands
+    // when the App hosts a FleetRunner directly.
+    use crate::adapters::fleet::{FleetNode, FleetNodeState};
+    let host = std::process::Command::new("hostname")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "localhost".to_string());
+    let meta = std::env::consts::OS.to_string();
+    adapter.set_nodes(vec![FleetNode::new(host, FleetNodeState::Self_, meta)]);
+
+    if let Some(new_id) = spawn_chrome_pane(app, Box::new(adapter), "Fleet") {
+        app.fleet_pane_id = Some(new_id);
+    }
+}
+
+pub(crate) fn toggle_plugins_pane(app: &mut App) {
+    if let Some(app_id) = app.plugins_pane_id.take() {
+        despawn_chrome_pane(app, app_id, "Plugins");
+        return;
+    }
+    let tokens = current_tokens(app);
+    let mut adapter = PluginsAdapter::new();
+    adapter.set_tokens(tokens);
+
+    // Pull live plugin info from the App's PluginRegistry.
+    use crate::adapters::plugins::{PluginEntry, PluginState};
+    let entries: Vec<PluginEntry> = app
+        .plugin_registry
+        .list()
+        .into_iter()
+        .map(|p| {
+            let state = if !p.enabled {
+                PluginState::Disabled
+            } else if p.hooks == 0 && p.commands == 0 {
+                PluginState::Idle
+            } else {
+                PluginState::Active
+            };
+            PluginEntry::new(p.name, p.version, state)
+        })
+        .collect();
+    adapter.set_plugins(entries);
+
+    if let Some(new_id) = spawn_chrome_pane(app, Box::new(adapter), "Plugins") {
+        app.plugins_pane_id = Some(new_id);
+    }
+}
+
+pub(crate) fn toggle_database_pane(app: &mut App) {
+    if let Some(app_id) = app.database_pane_id.take() {
+        despawn_chrome_pane(app, app_id, "Database");
+        return;
+    }
+    let tokens = current_tokens(app);
+    let mut adapter = DatabaseAdapter::new();
+    adapter.set_tokens(tokens);
+
+    // Seed with the bundle-store schema. The store is structured (frames,
+    // bundles, vectors), not a flat SQLite table the user can browse, so
+    // we present the high-level shape and the last query the runtime has
+    // recorded if any.
+    use crate::adapters::database::DbColumn;
+    let backend = if app.bundle_store.is_some() { "sqlite" } else { "(disabled)" };
+    let columns = vec![
+        DbColumn::new("bundles", "table", "capture bundles"),
+        DbColumn::new("frames", "table", "per-bundle PNG frames"),
+        DbColumn::new("vectors", "table", "embedding vectors (LanceDB)"),
+        DbColumn::new("events", "table", "JSONL event log"),
+    ];
+    adapter.set_schema("phantom-bundle-store", columns.len() as u64, columns);
+    adapter.set_last_query(format!("backend: {backend}"));
+
+    if let Some(new_id) = spawn_chrome_pane(app, Box::new(adapter), "Database") {
+        app.database_pane_id = Some(new_id);
+    }
+}
+
+pub(crate) fn toggle_voice_stt_pane(app: &mut App) {
+    if let Some(app_id) = app.voice_stt_pane_id.take() {
+        despawn_chrome_pane(app, app_id, "VoiceStt");
+        return;
+    }
+    let tokens = current_tokens(app);
+    let mut adapter = VoiceSttAdapter::new();
+    adapter.set_tokens(tokens);
+    // Drop a baseline of synthetic levels so the visualiser isn't empty
+    // before the real STT backend wires in (phantom-stt is 🔧 still).
+    // Per-frame animation lands in `App::refresh_voice_stt_pane`.
+    for &lvl in &[0.2, 0.5, 0.4, 0.7, 0.6, 0.3, 0.5, 0.8, 0.7, 0.4, 0.6, 0.5] {
+        adapter.push_level(lvl);
+    }
+    if let Some(new_id) = spawn_chrome_pane(app, Box::new(adapter), "VoiceStt") {
+        app.voice_stt_pane_id = Some(new_id);
+    }
+}
+
+/// Spawn the boot pane at startup. Called by `App::new` before the agent
+/// pane lands. Returns the new `AppId` so the App can advance phases via
+/// `accept_command "advance"` and finally despawn via `remove_adapter`.
+#[allow(dead_code)] // Wired by Task 32 (BootAdapter startup integration).
+pub(crate) fn spawn_boot_pane(app: &mut App) -> Option<u32> {
+    let tokens = current_tokens(app);
+    let mut adapter = BootAdapter::new();
+    adapter.set_tokens(tokens);
+    spawn_chrome_pane(app, Box::new(adapter), "Boot")
+}

--- a/crates/phantom-app/src/update.rs
+++ b/crates/phantom-app/src/update.rs
@@ -67,6 +67,21 @@ impl App {
         // events on the next render. No-op when no inspector pane is open.
         self.refresh_inspector_snapshot();
 
+        // FilesWatch pane: drain notify events into the adapter.
+        self.refresh_files_watch_pane();
+
+        // VoiceStt pane: tick the synthetic level envelope.
+        self.refresh_voice_stt_pane();
+
+        // Logs pane: push any new entries from the in-memory log ring.
+        self.refresh_logs_pane();
+
+        // Settings pane: persist + live-reload on any mutation.
+        self.refresh_settings_pane();
+
+        // Console pane: drain typed input and dispatch each line.
+        self.refresh_console_pane();
+
         // Bridge: drain bus events for the brain observer and forward as AiEvents.
         // Now an instance method so command-boundary events can also flow into
         // the per-pane capture pipeline (sealing open bundles on
@@ -1524,6 +1539,169 @@ impl App {
                     Err(e) => warn!("OSC 52: failed to open clipboard: {e}"),
                 }
             }
+        }
+    }
+
+    /// Drain pending user input from the ConsoleAdapter pane and dispatch
+    /// each line through `execute_user_command`. No-op when the pane is
+    /// closed.
+    pub(crate) fn refresh_console_pane(&mut self) {
+        let Some(pane_id) = self.console_pane_id else { return };
+
+        // Fetch the adapter's pending input via a state snapshot. We can't
+        // mutate the adapter directly from here without a downcast, so we
+        // poll a `drain_pending_input` command instead.
+        let drain_json = match self
+            .coordinator
+            .send_command(pane_id, "drain_pending", &serde_json::json!({}))
+        {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        let lines: Vec<String> = serde_json::from_str::<Vec<String>>(&drain_json).unwrap_or_default();
+        for line in lines {
+            // Push the command into legacy execution path. Output lands in
+            // the legacy `self.console` buffer; mirror the most recent
+            // legacy line back into the pane so the user sees a response.
+            self.execute_user_command(&line);
+            let echo = format!("→ {line}");
+            let _ = self.coordinator.send_command(
+                pane_id,
+                "out",
+                &serde_json::json!({ "text": echo }),
+            );
+        }
+    }
+
+    /// Detect mutations to the Settings pane and persist them to
+    /// `~/.config/phantom/settings.toml`. The existing config watcher
+    /// picks the change back up and routes it through
+    /// `apply_config_reload`, which mutates `self.theme.shader_params`
+    /// (the renderer reads CRT uniforms from there each frame). No-op
+    /// when the pane is closed.
+    pub(crate) fn refresh_settings_pane(&mut self) {
+        let Some(pane_id) = self.settings_pane_id else { return };
+        let snapshot_json = match self
+            .coordinator
+            .send_command(pane_id, "snapshot", &serde_json::json!({}))
+        {
+            Ok(s) => s,
+            Err(_) => return,
+        };
+        let v: serde_json::Value = match serde_json::from_str(&snapshot_json) {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        let revision = v.get("revision").and_then(|r| r.as_u64()).unwrap_or(0);
+        if revision == self.settings_pane_revision {
+            return;
+        }
+        self.settings_pane_revision = revision;
+
+        // Build a PhantomSettings struct from the adapter snapshot and
+        // the current on-disk state, then atomically save it. The
+        // ConfigWatcher fires the live-reload path next frame.
+        let mut settings = crate::settings::PhantomSettings::load();
+        if let Some(theme) = v.get("theme").and_then(|s| s.as_str()) {
+            settings.theme = theme.to_string();
+        }
+        if let Some(scan) = v.get("scanlines").and_then(|f| f.as_f64()) {
+            settings.crt.scanline_intensity = scan as f32;
+        }
+        if let Some(bloom) = v.get("bloom").and_then(|f| f.as_f64()) {
+            settings.crt.bloom_intensity = bloom as f32;
+        }
+        if let Some(curv) = v.get("curvature").and_then(|f| f.as_f64()) {
+            settings.crt.curvature = curv as f32;
+        }
+        if let Some(font) = v.get("font_size_pt").and_then(|f| f.as_f64()) {
+            settings.font_size = font as f32;
+        }
+        if let Some(crt_on) = v.get("crt_enabled").and_then(|b| b.as_bool()) {
+            self.crt_enabled = crt_on;
+        }
+        if let Err(e) = settings.save() {
+            warn!("Settings persist failed: {e}");
+        } else {
+            // Apply immediately so the user doesn't have to wait for the
+            // config watcher to fire on the next frame.
+            self.apply_config_reload(&settings);
+        }
+    }
+
+    /// Push any new log entries past `self.logs_watermark` into the Logs
+    /// pane via `accept_command "push"`. No-op when the pane is closed.
+    pub(crate) fn refresh_logs_pane(&mut self) {
+        let Some(pane_id) = self.logs_pane_id else { return };
+        let ring = crate::logging::log_ring();
+        let new_entries: Vec<crate::logging::LogRingEntry> = match ring.lock() {
+            Ok(buf) => {
+                if buf.len() <= self.logs_watermark {
+                    self.logs_watermark = buf.len();
+                    return;
+                }
+                buf.iter().skip(self.logs_watermark).cloned().collect()
+            }
+            Err(_) => return,
+        };
+        let level_label = |l: log::Level| match l {
+            log::Level::Error => "error",
+            log::Level::Warn => "warn",
+            log::Level::Info => "info",
+            log::Level::Debug => "debug",
+            log::Level::Trace => "trace",
+        };
+        for entry in &new_entries {
+            let _ = self.coordinator.send_command(
+                pane_id,
+                "push",
+                &serde_json::json!({
+                    "level": level_label(entry.level),
+                    "source": entry.target,
+                    "message": entry.message,
+                }),
+            );
+        }
+        self.logs_watermark = self.logs_watermark.saturating_add(new_entries.len());
+    }
+
+    /// Animate the VoiceStt pane's level visualiser with a synthetic sine
+    /// envelope until a real STT backend lands. No-op when the pane is
+    /// closed.
+    pub(crate) fn refresh_voice_stt_pane(&mut self) {
+        let Some(pane_id) = self.voice_stt_pane_id else { return };
+        // Use scene clock as the phase source so all panes animate from
+        // the same time base.
+        let t = self.scene_clock.elapsed().as_secs_f32();
+        let level = 0.5 + 0.4 * (t * 3.0).sin();
+        let _ = self.coordinator.send_command(
+            pane_id,
+            "push_level",
+            &serde_json::json!({ "value": level }),
+        );
+    }
+
+    /// Drain the FilesWatch background watcher's event queue and route each
+    /// event into the FilesWatchAdapter via `accept_command "push"`. No-op
+    /// when the pane is closed or the watcher isn't running.
+    pub(crate) fn refresh_files_watch_pane(&mut self) {
+        let Some(pane_id) = self.files_watch_pane_id else { return };
+        let Some(ref watcher) = self.files_watcher else { return };
+        let events = watcher.drain(32);
+        if events.is_empty() {
+            return;
+        }
+        let stamp = crate::input::chrono_time_string();
+        for ev in events {
+            let _ = self.coordinator.send_command(
+                pane_id,
+                "push",
+                &serde_json::json!({
+                    "path": ev.path,
+                    "kind": ev.kind,
+                    "stamp": stamp,
+                }),
+            );
         }
     }
 }

--- a/crates/phantom-ui/src/tokens.rs
+++ b/crates/phantom-ui/src/tokens.rs
@@ -84,12 +84,67 @@ impl Tokens {
         Self { colors, ctx }
     }
 
-    #[must_use] 
+    #[must_use]
     pub fn phosphor(ctx: RenderCtx) -> Self {
         Self {
             colors: ColorRoles::phosphor(),
             ctx,
         }
+    }
+
+    /// Build a `Tokens` snapshot derived from a [`crate::themes::Theme`].
+    ///
+    /// The phosphor `ColorRoles` are the canonical structure; this fn
+    /// overlays the theme's terminal palette onto the role table so a
+    /// theme switch visibly recolors token-driven chrome (AppHead etc).
+    /// Mappings:
+    /// - `surface_base`/`surface_recessed` ← theme background (darker
+    ///   variant for recessed)
+    /// - `text_primary`/`text_secondary`/`text_dim` ← theme foreground at
+    ///   descending alphas
+    /// - `text_accent` ← theme cursor color (typically the theme's most
+    ///   saturated highlight)
+    /// - `chrome_divider`/`chrome_frame_dim` ← theme ui_colors.border
+    /// - `status_ok`/`status_warn`/`status_danger`/`status_info` keep
+    ///   their phosphor defaults so danger always reads as red etc.
+    #[must_use]
+    pub fn for_theme(theme: &crate::themes::Theme, ctx: RenderCtx) -> Self {
+        let mut roles = ColorRoles::phosphor();
+        let bg = theme.colors.background;
+        roles.surface_base = bg;
+        // surface_recessed: subtly darker tint of bg.
+        roles.surface_recessed = [bg[0] * 1.3, bg[1] * 1.3, bg[2] * 1.3, 1.0];
+        // surface_raised: lighter than recessed.
+        roles.surface_raised = [bg[0] * 1.8, bg[1] * 1.8, bg[2] * 1.8, 1.0];
+
+        let fg = theme.colors.foreground;
+        roles.text_primary = fg;
+        roles.text_secondary = [fg[0], fg[1], fg[2], 0.78];
+        roles.text_dim = [fg[0], fg[1], fg[2], 0.55];
+        roles.text_accent = theme.colors.cursor;
+
+        let border = theme.ui_colors.border;
+        roles.chrome_divider = border;
+        roles.chrome_frame_dim = border;
+        roles.chrome_frame = border;
+        roles.chrome_frame_active = theme.colors.cursor;
+
+        roles.selection_bg = theme.colors.selection;
+        roles.accent_focus = theme.colors.cursor;
+
+        Self::new(roles, ctx)
+    }
+
+    /// Look up a built-in theme by name (case-insensitive) and build the
+    /// corresponding `Tokens` snapshot. Returns `None` when the name does
+    /// not match any registered theme.
+    ///
+    /// Adapters call this from their `accept_command "set_theme_name"`
+    /// handler to refresh their token palette without holding a shared
+    /// `Arc<RwLock<Tokens>>`.
+    #[must_use]
+    pub fn for_theme_name(name: &str, ctx: RenderCtx) -> Option<Self> {
+        crate::themes::builtin_by_name(name).map(|theme| Self::for_theme(&theme, ctx))
     }
 
     // -- Spacing scale (4px-base, scales with the cell on dense fonts) --


### PR DESCRIPTION
Wires all 12 chrome adapters from PR #678 into the running App so `docs/mockups/apps.html` actually lives in the binary.

## What changes when you run Phantom

Every keybind now spawns a real pane:

| Key | Pane | Backing data |
|---|---|---|
| F1 / ? | KeybindsHelp | Live `KeybindRegistry` + chrome bindings list |
| Cmd+, | Settings | Sliders mutate CRT shader uniforms + `~/.config/phantom/settings.toml` |
| Cmd+M | Memory inspector | `~/.claude/projects/<slug>/memory/*.md` frontmatter |
| Cmd+L | Logs | Live tail of in-memory log ring (every `log::info!` / `warn!` / `error!`) |
| Cmd+Shift+N | Notifications | Subscribed to `agent.denied`, `brain.suggestion`, `system.warn` bus topics |
| Cmd+Shift+F | File watch | Recursive `notify::RecommendedWatcher` on cwd |
| Cmd+Shift+G | Diff | `git diff HEAD` output parsed into add/del rows |
| Cmd+Shift+L | Fleet | Local hostname/OS as the self-node |
| Cmd+Shift+P | Plugins | Live `PluginRegistry::list()` |
| Cmd+Shift+B | Database | `phantom-bundle-store` schema (bundles/frames/vectors/events) |
| Cmd+Shift+V | Voice/STT | Synthetic sine envelope until real Whisper backend lands |
| Cmd+Shift+C | Console pane | Drains `pending_input` and runs each through `execute_user_command` |

Each keybind toggles: spawn when closed, despawn when open.

## Theme cycling (Action::CycleTheme)

The action is now handled: cycles through the 7 themes, persists to settings.toml, broadcasts a fresh Tokens snapshot to every spawned chrome pane via set_theme_name. New Tokens::for_theme(&Theme, RenderCtx) maps the theme palette into ColorRoles so chrome bodies recolor — not just the CRT shader.

## CRT toggle

New crt_enabled bool on SettingsView; when false, the renderer's crt_scale collapses to 0.0 so scanlines/bloom/curvature all disappear. Matches the mockup's checkbox.

## Subscription wiring (the silent bug)

coordinator::register_adapter_at_pane now actually walks BusParticipant::subscribes_to() and binds each topic to the new id in the bus subscriber table. Previously the bus's subscribe was only called from app.rs:1210 for the brain observer; every adapter that declared subscriptions was silently dropped on the floor. Notifications now reaches on_message for real.

## Shared helper

New crates/phantom-app/src/spawn_chrome.rs wraps the focused-pane split + adapter register sequence from spawn_inspector_pane into a single helper used by every toggle fn.

## Verification

- cargo build --workspace ✅
- cargo test -p phantom-ui --lib → 447 passed
- cargo test -p phantom-app --lib → 668+ passed (217 adapter tests)
- Pre-existing failures in phantom-hub and boot_smoke unchanged

## Deferred to follow-up

- BootAdapter is spawnable via toggle but not auto-shown at startup. User memory feedback_phantom_boot.md prefers skipping boot during iteration.
- Cmd+K command palette deferred — the 12 direct bindings provide adequate discovery.
- Per-adapter App-level integration tests deferred — would need GPU surface mocking like boot_smoke.

## Related

- Builds on #678 which landed the 14 adapter implementations + AppHead + cyber theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)