### PR TITLE
Fix graphify rebuild pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,12 @@
 .phantom/tmp/
 docs/html/
 
+# Local graphify staging output
+.graphify-tmp/
+graphify-out/cache/
+**/graphify-out/cache/
+__pycache__/
+
 # Reference material (copyrighted / bulky)
 docs/references/*.pdf
 

--- a/.graphifyignore
+++ b/.graphifyignore
@@ -1,0 +1,3 @@
+target/
+crates/graphify-out/
+.graphify-tmp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -456,4 +456,4 @@ This project has a graphify knowledge graph at graphify-out/.
 Rules:
 - Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
 - If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
-- After modifying code files in this session, run `python3 -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"` to keep the graph current
+- After modifying code files in this session, run `python3 scripts/graphify_rebuild.py` to keep the graph current

--- a/README.md
+++ b/README.md
@@ -222,6 +222,27 @@ phantom-protocol         # protocol: supervisor socket communication
 phantom-scene            # performance: retained scene graph, dirty tracking
 ```
 
+## Knowledge Graph
+
+Phantom keeps a repo-local Graphify build in `graphify-out/`, but the raw package rebuild path is not trustworthy enough for this repo because repeated filenames like `main.rs` and `openai.rs` collide.
+
+Use the repo wrapper instead:
+
+```bash
+python3 scripts/graphify_rebuild.py
+```
+
+What this does:
+- stages the build outside `graphify-out/`
+- rewrites duplicate Graphify IDs with path-scoped IDs before graph construction
+- exports a directed graph so `calls` edges preserve direction
+- validates the staged graph before publishing it over `graphify-out/`
+
+The wrapper publishes:
+- `graphify-out/graph.json`
+- `graphify-out/GRAPH_REPORT.md`
+- `graphify-out/graphify-metadata.json`
+
 ## Keybinds
 
 | Key | Action |

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,718 +1,548 @@
-# Graph Report - .  (2026-04-30)
+# Graph Report - phantom  (2026-04-30)
 
 ## Corpus Check
-- 282 files · ~498,044 words
-- Verdict: corpus is large enough that graph structure adds value.
+- Large corpus: 312 files · ~506,305 words. Semantic extraction will be expensive (many Claude tokens). Consider running on a subfolder, or use --no-semantic to run AST-only.
 
 ## Summary
-- 7323 nodes · 15153 edges · 162 communities detected
-- Extraction: 100% EXTRACTED · 0% INFERRED · 0% AMBIGUOUS
+- 7477 nodes · 23048 edges · 107 communities detected
+- Extraction: 98% EXTRACTED · 2% INFERRED · 0% AMBIGUOUS · INFERRED: 398 edges (avg confidence: 0.5)
 - Token cost: 0 input · 0 output
 
+
+## Crate Dependency Map
+
+| Tier | Crates | Dependencies |
+|------|--------|-------------|
+| 0 | `phantom-audio` | (none) |
+| 0 | `phantom-bundles` | (none) |
+| 0 | `phantom-context` | (none) |
+| 0 | `phantom-dag` | (none) |
+| 0 | `phantom-embeddings` | (none) |
+| 0 | `phantom-mcp` | (none) |
+| 0 | `phantom-memory` | (none) |
+| 0 | `phantom-net` | (none) |
+| 0 | `phantom-plugins` | (none) |
+| 0 | `phantom-protocol` | (none) |
+| 0 | `phantom-relay` | (none) |
+| 0 | `phantom-renderer` | (none) |
+| 0 | `phantom-scene` | (none) |
+| 0 | `phantom-semantic` | (none) |
+| 0 | `phantom-stt` | (none) |
+| 0 | `phantom-terminal` | (none) |
+| 0 | `phantom-vision` | (none) |
+| 0 | `phantom-voice` | (none) |
+| 1 | `phantom-adapter` | phantom-protocol |
+| 1 | `phantom-agents` | phantom-memory, phantom-protocol, phantom-semantic |
+| 1 | `phantom-bundle-store` | phantom-bundle-store, phantom-bundles, phantom-embeddings, phantom-vision |
+| 1 | `phantom-history` | phantom-semantic |
+| 1 | `phantom-nlp` | phantom-context |
+| 1 | `phantom-recall` | phantom-bundles |
+| 1 | `phantom-supervisor` | phantom-protocol |
+| 2 | `phantom-brain` | phantom-adapter, phantom-agents, phantom-context, phantom-history, phantom-memory, phantom-semantic |
+| 2 | `phantom-session` | phantom-agents, phantom-context |
+| 2 | `phantom-ui` | phantom-adapter, phantom-renderer |
+| 3 | `phantom-app` | phantom-adapter, phantom-agents, phantom-brain, phantom-bundle-store, phantom-bundle-store, phantom-bundles, phantom-context, phantom-context, phantom-dag, phantom-embeddings, phantom-history, phantom-mcp, phantom-memory, phantom-nlp, phantom-nlp, phantom-plugins, phantom-protocol, phantom-renderer, phantom-scene, phantom-semantic, phantom-session, phantom-stt, phantom-stt, phantom-terminal, phantom-ui, phantom-ui, phantom-vision |
+| 4 | `phantom` | phantom-agents, phantom-app, phantom-brain, phantom-context, phantom-history, phantom-memory, phantom-nlp, phantom-protocol, phantom-renderer, phantom-semantic, phantom-terminal, phantom-ui |
+
+
+## Cross-Crate Coupling (most imported types)
+
+| Entity | Imported by N files |
+|--------|--------------------|
+| `AgentTask` | 15 |
+| `QuadInstance` | 13 |
+| `ProjectContext` | 11 |
+| `MemoryStore` | 9 |
+| `Disposition` | 6 |
+| `Bundle` | 6 |
+| `FrameRef` | 6 |
+| `TranscriptWord` | 6 |
+| `Rect` | 5 |
+| `EventLog` | 5 |
+| `ParsedOutput` | 5 |
+| `Event` | 4 |
+| `SceneTree` | 4 |
+| `AgentRole` | 4 |
+| `CapabilityClass` | 4 |
+
+
+## Test Coverage Summary
+
+- 3911 production entities, 3536 test entities
+- Test nodes are tagged `is_test: true` in graph.json but excluded from community detection
+
 ## God Nodes (most connected - your core abstractions)
-1. `AppCoordinator` - 47 edges
-2. `parse_agent_command()` - 43 edges
-3. `Agent` - 38 edges
-4. `BootSequence` - 35 edges
-5. `register_mock()` - 30 edges
-6. `agent_with_handle()` - 30 edges
-7. `rust_ctx()` - 30 edges
-8. `TerminalAdapter` - 29 edges
-9. `tmp()` - 29 edges
-10. `PhantomTerminal` - 28 edges
+1. `AppCoordinator` - 46 edges
+2. `Agent` - 39 edges
+3. `BootSequence` - 35 edges
+4. `PhantomTerminal` - 31 edges
+5. `TerminalAdapter` - 29 edges
+6. `LayoutEngine` - 22 edges
+7. `SemanticParser` - 21 edges
+8. `Supervisor` - 21 edges
+9. `SceneTree` - 21 edges
+10. `AgentJournal` - 21 edges
 
 ## Surprising Connections (you probably didn't know these)
-- `from_env_succeeds_with_key()` --calls--> `set_env()`  [EXTRACTED]
-  crates/phantom-embeddings/src/openai.rs → crates/phantom-voice/src/openai.rs
-- `main()` --calls--> `print_banner()`  [EXTRACTED]
-  crates/phantom/src/main.rs → crates/phantom-supervisor/src/main.rs
-- `main()` --calls--> `parse_config_flag()`  [EXTRACTED]
-  crates/phantom/src/main.rs → crates/phantom-relay/src/main.rs
-- `from_env_returns_not_configured_when_missing()` --calls--> `env_lock()`  [EXTRACTED]
-  crates/phantom-embeddings/src/openai.rs → crates/phantom-voice/src/openai.rs
-- `from_env_succeeds_with_key()` --calls--> `env_lock()`  [EXTRACTED]
-  crates/phantom-embeddings/src/openai.rs → crates/phantom-voice/src/openai.rs
+- `crate:phantom` --contains_entity--> `parses_shell_path_from_output()`  [EXTRACTED]
+  crates/phantom/Cargo.toml → crates/phantom/src/path_resolver.rs
+- `crate:phantom` --contains_entity--> `merges_shell_path_before_current()`  [EXTRACTED]
+  crates/phantom/Cargo.toml → crates/phantom/src/path_resolver.rs
+- `crate:phantom` --contains_entity--> `timeout_kills_hung_process()`  [EXTRACTED]
+  crates/phantom/Cargo.toml → crates/phantom/src/path_resolver.rs
+- `crate:phantom` --contains_entity--> `corrupt_output_without_slash_is_rejected()`  [EXTRACTED]
+  crates/phantom/Cargo.toml → crates/phantom/src/path_resolver.rs
+- `crate:phantom` --contains_entity--> `empty_shell_path_is_handled()`  [EXTRACTED]
+  crates/phantom/Cargo.toml → crates/phantom/src/path_resolver.rs
 
 ## Communities
 
-### Community 0 - "Community 0"
+### Community 0 - "AgentTask (phantom-agents, phantom-session)"
 Cohesion: 0.01
-Nodes (243): DagEdge, EdgeKind, adapter_event_adapter_id_all_variants(), adapter_id_is_copy_at_registration_boundary(), add_edge_increments_count(), add_methods_preserve_insertion_order(), add_node_stores_and_retrieves(), app_core_adapter_id_default_is_sentinel() (+235 more)
+Nodes (321): AppActionHandler, AgentMessage, AgentSpawnOpts, AgentTask, AgentOutputCapture, AgentRecord, CapturedAgent, default_data_dir() (+313 more)
 
-### Community 1 - "Community 1"
+### Community 1 - "TerminalAdapter (phantom-app, phantom-scene)"
+Cohesion: 0.01
+Nodes (303): AppAdapter, AppCore, BusParticipant, Commandable, CursorData, CursorShape, GridData, InputHandler (+295 more)
+
+### Community 2 - "InspectorAdapter (phantom-ui)"
+Cohesion: 0.01
+Nodes (402): ShaderOverrides, CursorBlink, Divider, Orientation, FocusRing, InputBar, InputKey, AgentRow (+394 more)
+
+### Community 3 - "MemoryStore (phantom-brain)"
+Cohesion: 0.01
+Nodes (266): action_name(), brain_loop(), brain_supervised(), BrainConfig, BrainHandle, diagnose_build_failure(), enhance_with_claude(), enhance_with_investigation() (+258 more)
+
+### Community 4 - "PluginRegistry (phantom-renderer)"
 Cohesion: 0.02
-Nodes (99): Agent, agent_adapter_accepts_input(), agent_adapter_app_type_is_agent(), agent_adapter_is_visual(), agent_adapter_render_stays_within_rect(), agent_adapter_scroll_offset_starts_at_zero(), agent_adapter_with_spawn_tag_stores_tag(), agent_get_state_exposes_history_size() (+91 more)
+Nodes (138): App, AppState, build_ticket_dispatcher(), FloatInteraction, NlpTranslateResult, open_bundle_store(), ResizeEdge, SuggestionOverlay (+130 more)
 
-### Community 2 - "Community 2"
+### Community 5 - "EventLog (phantom-agents)"
 Cohesion: 0.02
-Nodes (69): args_hash_is_deterministic(), AuditOutcome, AuditWriter, emit_before_init_does_not_panic(), emit_tool_call(), hash_args(), init(), init_then_emit_writes_record_and_drop_flushes() (+61 more)
+Nodes (247): check_capability(), class_for(), agent_is_quarantined(), collect_source_chain(), quarantine_registry_blocks(), source_agent_id_from_envelope(), taint_from_source_chain(), append_speak_to_log() (+239 more)
 
-### Community 3 - "Community 3"
-Cohesion: 0.04
-Nodes (79): add_and_query_facts(), approve_checkpoint_makes_step_eligible(), approve_checkpoint_wrong_step_returns_err(), assess_complete_when_all_done(), assess_not_complete_with_pending(), checkpoint_step_is_not_eligible_until_approved(), detect_loop_on_repeated_outputs(), dispatch_next_step_is_idempotent() (+71 more)
-
-### Community 4 - "Community 4"
+### Community 6 - "Bundle (phantom-bundle-store, phantom-bundles)"
 Cohesion: 0.02
-Nodes (56): AppAdapter, AppCore, BusParticipant, Commandable, CursorData, CursorShape, GridData, InputHandler (+48 more)
+Nodes (188): AssemblerError, BundleAssembler, Embedding, Modality, Modality, InMemoryVectorIndex, ModalityTable, VectorHit (+180 more)
 
-### Community 5 - "Community 5"
+### Community 7 - "PhantomTerminal (phantom-terminal, phantom-app)"
+Cohesion: 0.02
+Nodes (122): ContextMenu, MenuAction, MenuItem, LayoutEngine, PaneId, Rect, App, pixel_to_cell() (+114 more)
+
+### Community 8 - "AgentJournal (phantom-memory)"
 Cohesion: 0.03
-Nodes (70): ActionClass, bds_idle_wins_when_no_errors(), bds_momentum_prevents_thrashing(), bds_picks_highest_scorer(), Behavior, behavior_additive_composition(), behavior_clamped_to_class_range(), BehaviorDecisionSystem (+62 more)
+Nodes (105): McpError, HandoffEntry, HandoffError, HandoffLog, new_entry(), now_unix_ms(), AgentJournal, entry_from_envelope() (+97 more)
 
-### Community 6 - "Community 6"
+### Community 9 - "HeadlessActionHandler (phantom-nlp, phantom-agents)"
+Cohesion: 0.01
+Nodes (251): AgentStatus, AgentCommand, execute_agent_command(), format_agent_detail(), format_agent_list(), format_capability(), format_duration(), format_model() (+243 more)
+
+### Community 10 - "AgentManager (phantom-agents)"
+Cohesion: 0.01
+Nodes (230): ApiEvent, ApiHandle, build_messages_with_ids(), build_request_body(), build_tools(), ClaudeConfig, parse_response(), send_message() (+222 more)
+
+### Community 11 - "OpenAiBackend (phantom-stt)"
 Cohesion: 0.03
-Nodes (74): api_handle_detects_disconnected_sender(), api_handle_marks_done_on_done_event(), api_handle_marks_done_on_error_event(), api_handle_returns_none_after_done(), ApiEvent, ApiHandle, build_messages(), build_messages_consecutive_tool_calls_grouped() (+66 more)
+Nodes (124): MockStream, stream(), MockStream, stream(), bincode_config(), CaptureEvent, decode_event(), encode_event() (+116 more)
 
-### Community 7 - "Community 7"
-Cohesion: 0.05
-Nodes (67): agent_context_empty(), agent_context_formatting(), all_returns_every_entry(), append_increments_count(), by_category_filters_correctly(), by_session_filters_entries(), by_time_range_filters_correctly(), corrupt_lines_skipped() (+59 more)
-
-### Community 8 - "Community 8"
-Cohesion: 0.05
-Nodes (40): adapter_render_height_excludes_title_strip(), adapter_render_y_starts_below_title_strip(), AppCoordinator, arbiter_allocation_constrains_taffy_pane(), coordinator_passes_inner_rect_to_adapter(), LayeredRenderOutputs, LayoutPlan, MockAdapter (+32 more)
-
-### Community 9 - "Community 9"
-Cohesion: 0.04
-Nodes (63): agent_ref(), agent_row_excerpt_truncates_to_80_chars(), agent_row_serializes_with_flattened_agent_ref_fields(), agent_row_spawned_minutes_ago_saturates_when_clock_goes_backward(), agent_row_spawned_minutes_ago_uses_injected_now(), AgentRow, build_view_with_agents(), builder_caps_denials_dropping_oldest() (+55 more)
-
-### Community 10 - "Community 10"
-Cohesion: 0.04
-Nodes (58): agent_is_quarantined(), quarantine_registry_blocks(), source_agent_id_from_envelope(), taint_from_source_chain(), defender_challenge_loop_smoke(), make_agent(), new_spawn_queue(), offender_cannot_call_challenge_agent() (+50 more)
-
-### Community 11 - "Community 11"
-Cohesion: 0.05
-Nodes (69): capture_frame_accessors_return_correct_values(), CaptureFrame, CaptureSession, cleanup_deletes_old_sessions(), cleanup_returns_zero_when_nothing_to_delete(), consecutive_duplicate_phash_frames_are_deduplicated(), crash_and_restart_recovers_last_saved_layout(), different_projects_get_different_hashes() (+61 more)
-
-### Community 12 - "Community 12"
+### Community 12 - "MockRuntime (phantom-plugins)"
 Cohesion: 0.03
-Nodes (50): GlyphAtlas, GlyphEntry, default_grid_cell_has_transparent_bg(), grid_cell_to_terminal_cell(), GridCell, GridRenderData, GridRenderer, is_default_bg() (+42 more)
+Nodes (125): api_inspector(), docker_dashboard(), get_official(), git_enhanced(), github_notifications(), official_plugins(), spotify_controls(), hook_type_key() (+117 more)
 
-### Community 13 - "Community 13"
-Cohesion: 0.04
-Nodes (37): AgentPane, AgentPaneStatus, bar_rect(), ConnectionIndicator, dispatch_tool(), result(), status_bar_defaults(), status_bar_renders_background_quad() (+29 more)
-
-### Community 14 - "Community 14"
-Cohesion: 0.05
-Nodes (59): defender_spawn_rule(), defender_spawn_rule_does_not_fire_on_agent_blocked(), defender_spawn_rule_does_not_fire_on_pane_opened(), defender_spawn_rule_fires_on_capability_denied(), defender_spawn_rule_uses_spawn_if_not_running(), ev(), ev(), fixer_deadline_payload() (+51 more)
-
-### Community 15 - "Community 15"
+### Community 13 - "SemanticParser (phantom-semantic, phantom-agents)"
 Cohesion: 0.03
-Nodes (64): agent_pane_starts_working(), agent_with_handle(), audit_denied_outcome_emitted_alongside_event(), blocked_event_payload_has_agent_id_and_reason(), blocked_payload_reflects_actual_role_and_capability(), build_ctx(), build_dispatch_context_passes_quarantine_registry_to_dispatch(), capability_denied_source_chain_propagates_taint() (+56 more)
+Nodes (120): ErrorHighlighter, HighlightRegion, HighlightStyle, SourceReference, SemanticParser, ScoredAction, UtilityScorer, append_content_summary() (+112 more)
 
-### Community 16 - "Community 16"
-Cohesion: 0.04
-Nodes (40): AppActionHandler, Console, console_with_3_commands(), ConsoleLine, duplicate_adjacent_commands_deduplicated(), history_down_moves_forward(), history_down_to_end_restores_draft(), history_down_when_not_navigating_is_no_op() (+32 more)
-
-### Community 17 - "Community 17"
-Cohesion: 0.04
-Nodes (81): AgentCommand, duplicate_capability_flag_last_value_wins_with_warning(), duplicate_model_flag_last_value_wins_with_warning(), duplicate_role_flag_last_value_wins_with_warning(), duplicate_ttl_flag_last_value_wins_with_warning(), execute_agent_command(), execute_help_shows_usage(), execute_kill_all_kills_all_active() (+73 more)
-
-### Community 18 - "Community 18"
-Cohesion: 0.05
-Nodes (50): hook_context_command_builder(), hook_context_error_builder(), hook_context_output_builder(), hook_type_key(), HookContext, HookEvent, HookResponse, mock_runtime_command() (+42 more)
-
-### Community 19 - "Community 19"
+### Community 14 - "PersistentSkillRegistry (phantom-brain, phantom-agents)"
 Cohesion: 0.03
-Nodes (40): App, AppState, build_ticket_dispatcher(), FloatInteraction, NlpTranslateResult, open_bundle_store(), ResizeEdge, SuggestionOverlay (+32 more)
+Nodes (76): AuditOutcome, AuditWriter, emit_tool_call(), hash_args(), init(), now_ts(), defender_spawn_rule(), AgentPane (+68 more)
 
-### Community 20 - "Community 20"
+### Community 15 - "AgentRuntime (phantom-agents, phantom-app)"
 Cohesion: 0.04
-Nodes (59): handshake(), make_send(), rate_limiter_trips_on_burst_without_disconnect(), recv_json(), spawn_relay(), two_peers_rendezvous_round_trip(), at_in_middle_is_not_a_mention(), at_label_no_body_returns_empty_body() (+51 more)
+Nodes (67): build_error_analysis_prompt(), ContentBlock, generate(), investigate(), is_available(), Message, MessagesRequest, MessagesResponse (+59 more)
 
-### Community 21 - "Community 21"
+### Community 16 - "KeybindRegistry (phantom-ui, phantom-app)"
+Cohesion: 0.03
+Nodes (85): ImageHandler, DecodedImage, ImageInstance, ImageManager, ImagePlacement, Uniforms, App, chrono_time_string() (+77 more)
+
+### Community 17 - "Screenshot (phantom-vision)"
 Cohesion: 0.05
-Nodes (53): ContextMenu, hide_clears_state(), hit_test_below_items(), hit_test_inside_first_item(), hit_test_inside_second_item(), hit_test_outside_x(), hit_test_when_hidden(), MenuAction (+45 more)
+Nodes (81): Analysis, ChatRequest, ChatResponse, Choice, ContentPart, ImageUrl, Message, OpenAiVisionBackend (+73 more)
 
-### Community 22 - "Community 22"
+### Community 18 - "Supervisor (phantom-supervisor, phantom-app)"
+Cohesion: 0.08
+Nodes (36): install_signal_handlers(), main(), find_swift_runtime_path(), inject_dyld_fallback(), print_banner(), Supervisor, delete_pid_file(), pid_file_path() (+28 more)
+
+### Community 19 - "TextRenderer (phantom-renderer)"
 Cohesion: 0.05
-Nodes (37): active_is_demoted_to_pending_on_restore(), active_step(), active_step_demoted_on_restore(), atomic_write_creates_no_temp_file_after_success(), done_is_preserved_on_restore(), done_step(), done_step_count_correct(), done_steps_remain_done_after_restore() (+29 more)
+Nodes (28): GlyphAtlas, GlyphEntry, GridCell, GridRenderData, is_default_bg(), Uniforms, GlitchCell, KeystrokeFx (+20 more)
 
-### Community 23 - "Community 23"
+### Community 20 - "AppCoordinator (phantom-app)"
 Cohesion: 0.06
-Nodes (38): AppRegistry, dirs_or_default(), empty_registry_invoke_returns_unknown_tool(), empty_registry_resolve_returns_none(), handle_call_response_error_propagates_mcp_error(), handle_call_response_success(), invoke_known_tool_returns_ok(), invoke_unknown_tool_returns_mcp_error() (+30 more)
+Nodes (36): AppCoordinator, register_mock(), test_register_adapter_assigns_unique_id(), test_register_adapter_transitions_to_running(), test_remove_adapter_transitions_to_dead(), test_update_all_calls_adapter_update(), test_render_all_returns_outputs_for_visual_adapters(), test_route_input_to_focused_adapter() (+28 more)
 
-### Community 24 - "Community 24"
-Cohesion: 0.03
-Nodes (16): convert_cursor(), convert_cursor_shape(), default_is_not_alt_screen(), default_mouse_mode_is_none(), key_name_to_bytes(), last_read_buf_empty_before_any_read(), last_read_buf_returns_only_valid_bytes_after_would_block(), MouseMode (+8 more)
+### Community 21 - "BootSequence (phantom-app)"
+Cohesion: 0.07
+Nodes (37): BootPhase, BootSequence, BootTextLine, build_syscheck_text(), lerp_color(), LineStyle, noise_char_from_hash(), noise_hash() (+29 more)
 
-### Community 25 - "Community 25"
-Cohesion: 0.05
-Nodes (68): args_hash_deterministic(), available_tools(), available_tools_returns_all_eight(), DispatchError, edit_file_fails_on_multiple_matches(), edit_file_fails_on_no_match(), edit_file_rejects_traversal(), edit_file_replaces_unique_match() (+60 more)
+### Community 22 - "CodeDag (phantom-dag, phantom-app)"
+Cohesion: 0.08
+Nodes (43): NodeKind, DagViewerState, DagEdge, EdgeKind, CodeDag, DagNode, build_overlay(), extract_crate_names() (+35 more)
 
-### Community 26 - "Community 26"
-Cohesion: 0.05
-Nodes (49): alice(), bob(), canonical_bytes(), ClientMessage, deserialize(), Engine, Envelope, envelope_nonce_increments() (+41 more)
+### Community 23 - "Agent (phantom-agents)"
+Cohesion: 0.04
+Nodes (55): Agent, truncate(), push_message_appends(), log_appends_output(), complete_success_sets_done(), complete_failure_sets_failed(), elapsed_returns_duration(), system_prompt_fix_error_includes_summary() (+47 more)
 
-### Community 27 - "Community 27"
+### Community 24 - "RelayClient (phantom-net)"
+Cohesion: 0.1
+Nodes (29): NonceCounter, PeerId, RelayClient, Envelope, canonical_bytes(), deserialize(), Engine, serialize() (+21 more)
+
+### Community 25 - "InterventionEngine (phantom-brain)"
 Cohesion: 0.06
-Nodes (50): acceptance_rate_tracks_feedback(), build_error_does_not_fire_on_success(), build_error_fires_on_cargo_build_failure(), build_error_suggest_contains_action_and_rationale(), confidence_is_clamped_to_unit_range(), context_change_does_not_fire_on_file_changed(), context_change_fires_on_git_state_changed(), cooldown_expires_after_configured_ms() (+42 more)
+Nodes (50): EnvSignal, EnvState, InterventionDecision, InterventionEngine, InterventionKind, is_build_command(), is_test_command(), NeedEstimate (+42 more)
 
-### Community 28 - "Community 28"
+### Community 26 - "ClaudeBackend (phantom-brain)"
 Cohesion: 0.05
-Nodes (53): App, intent_to_translate_result(), config_path(), default_skip_boot_is_false(), nlp_llm_enabled_defaults_to_true(), parse_empty_config_yields_defaults(), parse_ignores_comments_and_blank_lines(), parse_nlp_llm_false_disables_it() (+45 more)
+Nodes (30): ChatBackend, ChatOptions, ChatResponse, ClaudeBackend, Message, OllamaBackend, OpenAiBackend, OpenAiChoice (+22 more)
 
-### Community 29 - "Community 29"
+### Community 27 - "GhTicketDispatcher (phantom-agents)"
 Cohesion: 0.06
-Nodes (38): append(), append_hex(), append_usize(), Config, dirs_or_home(), find_swift_runtime_path(), inject_dyld_fallback(), install_atexit() (+30 more)
+Nodes (39): capability_matches_label(), ClaimedSet, DispatcherTool, DispatcherToolContext, gh_issue_to_ticket(), GhIssue, GhIssueSource, GhLabel (+31 more)
+
+### Community 28 - "TaskLedger (phantom-brain)"
+Cohesion: 0.05
+Nodes (40): Orchestrator, PlanStep, TaskLedger, add_and_query_facts(), verify_fact_promotes_guess(), set_plan_resets_stall(), replan_archives_old_plan(), next_pending_step_skips_done() (+32 more)
+
+### Community 29 - "PhantomConfig (phantom, phantom-app)"
+Cohesion: 0.09
+Nodes (18): config_path(), PhantomConfig, install_signal_handlers(), main(), GpuContext, App, append(), append_hex() (+10 more)
 
 ### Community 30 - "Community 30"
-Cohesion: 0.08
-Nodes (45): DagNode, NodeKind, RenderLayer, SceneNode, Transform, WorldTransform, add_multiple_children(), add_nested_children() (+37 more)
-
-### Community 31 - "Community 31"
-Cohesion: 0.06
-Nodes (44): assembled_bundle_json_round_trips(), AssemblerError, BundleAssembler, finish_audio_only_bundle_is_valid(), finish_frame_only_bundle_is_valid(), finish_importance_is_clamped(), finish_on_empty_assembler_errors(), finish_preserves_insertion_order_across_all_modalities() (+36 more)
-
-### Community 32 - "Community 32"
-Cohesion: 0.04
-Nodes (37): App, bracketed_paste(), bracketed_paste_empty(), bracketed_paste_multiline(), ctrl_alt_char(), encode_arrow(), encode_char(), encode_function_key() (+29 more)
-
-### Community 33 - "Community 33"
-Cohesion: 0.07
-Nodes (33): BootPhase, BootSequence, BootTextLine, build_syscheck_text(), crt_intensity_ramps_during_warmup(), default_is_new(), done_phase_does_not_advance(), initial_state() (+25 more)
-
-### Community 34 - "Community 34"
-Cohesion: 0.06
-Nodes (35): all_fields_accessible_via_getters(), all_returns_every_notification_in_insertion_order(), Banner, by_kind_filters_correctly(), count_tracks_push_and_remove(), different_projects_are_isolated(), does_not_trigger_below_threshold(), get_existing_id_returns_some() (+27 more)
-
-### Community 35 - "Community 35"
-Cohesion: 0.05
-Nodes (36): clear_env(), dimension_for_text_returns_default_3072(), embed_hello_world_returns_two_3072_dim_vectors(), embed_image_returns_unsupported_modality(), EmbeddingData, EmbeddingsRequest, EmbeddingsResponse, env_lock() (+28 more)
-
-### Community 36 - "Community 36"
-Cohesion: 0.05
-Nodes (41): build_openai_embeddings(), capture_pipeline_command_boundary_seals_bundle(), capture_pipeline_dedup_hits_skip_writes(), capture_pipeline_skips_when_bundle_store_missing(), capture_state_advances_frame_counter_per_pane(), CaptureState, crate::app::App, EmbeddingBackendKind (+33 more)
-
-### Community 37 - "Community 37"
-Cohesion: 0.05
-Nodes (36): ErrorHighlighter, extract_refs_deduplicates(), extract_refs_from_cargo_error(), highlight_produces_regions_for_errors(), highlight_warning_uses_yellow(), HighlightRegion, HighlightStyle, scan_file_line_no_col() (+28 more)
-
-### Community 38 - "Community 38"
-Cohesion: 0.06
-Nodes (42): activate_deactivate_commands(), app_type_returns_monitor(), does_not_accept_input(), fake_handle(), fake_stats(), get_state_reflects_active_flag(), is_always_alive(), is_not_visual() (+34 more)
-
-### Community 39 - "Community 39"
-Cohesion: 0.06
-Nodes (59): agent_context_contains_key_fields(), collect_git_info(), DispatchContext, extract_name_falls_back_to_dir(), extract_name_from_package_json(), extract_project_name(), git_info_in_real_repo(), GitInfo (+51 more)
-
-### Community 40 - "Community 40"
-Cohesion: 0.05
-Nodes (30): AlwaysAvailableBackend, chat_options_default_values(), ChatBackend, ChatOptions, ChatResponse, claude_backend_availability_reflects_env_var(), claude_backend_is_cloud(), claude_backend_provider_name() (+22 more)
-
-### Community 41 - "Community 41"
-Cohesion: 0.06
-Nodes (44): adapter_event_adapter_id_consistent_across_all_variants(), adapter_event_clone_and_equality(), adapter_event_closed_variant(), adapter_event_content_changed_variant(), adapter_event_debug_format(), adapter_event_focused_variant(), adapter_event_spawned_variant(), adapter_id_copy_semantics() (+36 more)
-
-### Community 42 - "Community 42"
-Cohesion: 0.06
-Nodes (32): build_and_start_stream(), enumerate_succeeds_or_permission_denied(), MacOsSckCapture, map_sc_error(), map_sc_error_with_context(), non_app_stream_open_returns_unsupported(), permission_status_returns_a_known_variant(), sample_buffer_to_audio_frame() (+24 more)
-
-### Community 43 - "Community 43"
-Cohesion: 0.08
-Nodes (39): AgentSnapshot, AgentStateFile, AgentStatePersister, atomic_write_creates_no_temp_file_after_success(), awaiting_approval_normalised_to_queued(), completed_tool_pair_is_preserved(), conversation_depth_excludes_system_messages(), discard_nonexistent_is_ok() (+31 more)
-
-### Community 44 - "Community 44"
 Cohesion: 0.09
-Nodes (30): AgentJournal, append_pre_built_entry_preserves_all_fields(), each_file_line_is_valid_journal_entry_json(), entry_from_envelope(), filter_by_agent_and_phase_intersection(), filter_by_agent_isolates_per_agent(), filter_by_level_returns_matching(), filter_by_phase_returns_only_matching() (+22 more)
+Nodes (36): add_crate_summary_nodes(), assign_excluded_nodes(), build_clustering_subgraph(), build_directed_graph(), _build_test_line_ranges(), BuildArtifacts, enhance_report(), export_graph() (+28 more)
 
-### Community 45 - "Community 45"
-Cohesion: 0.06
-Nodes (30): all_blocked_returns_none(), blocked_ticket_is_not_returned(), capability_matches_label(), ClaimedSet, concurrent_requests_get_distinct_tickets(), dispatcher_tool_api_name_round_trip(), dispatcher_with(), DispatcherTool (+22 more)
+### Community 31 - "GoalPursuit (phantom-brain)"
+Cohesion: 0.09
+Nodes (24): BrainTask, build_prioritization_prompt(), build_reflection_prompt(), build_task_creation_prompt(), GoalPursuit, inject_reflections(), load_reflexion(), parse_task_list() (+16 more)
 
-### Community 46 - "Community 46"
-Cohesion: 0.07
-Nodes (42): ambiguous_input_clarifies(), build_maps_to_node_command(), build_system_prompt(), build_the_project_runs_cargo_build(), clarify_accessors(), claude_backend_name_is_claude(), ClaudeLlmBackend, empty_backend_reply_maps_to_clarify() (+34 more)
-
-### Community 47 - "Community 47"
-Cohesion: 0.06
-Nodes (46): absolute_path_passes_through(), bare_deploy_is_ambiguous(), build_resolves_to_node_command(), build_resolves_to_rust_command(), ci_status_shows_info(), deploy_production_normalizes_prod(), deploy_staging_resolves(), empty_input_passes_through() (+38 more)
-
-### Community 48 - "Community 48"
+### Community 32 - "AgentSnapshot (phantom-session)"
 Cohesion: 0.08
-Nodes (36): append_challenge_to_log(), challenge_agent(), challenge_agent_appends_envelope_to_log_when_configured(), challenge_agent_delivers_message_to_target_inbox(), challenge_agent_denied_for_role_lacking_coordinate(), challenge_agent_full_inbox_returns_err_not_panic(), challenge_agent_round_trip_defender_sends_target_replies(), challenge_agent_unknown_target_returns_err() (+28 more)
+Nodes (40): AgentSnapshot, AgentStateFile, AgentStatePersister, partial_restore(), RestoreOutcome, SavedMessage, ToolCall, free_agent() (+32 more)
 
-### Community 49 - "Community 49"
-Cohesion: 0.08
-Nodes (23): AgentRef, default_skills_path(), dirs_home(), file_persistence_survives_reload(), lookup_unknown_returns_none(), PersistentSkillRegistry, record_outcome_unknown_id_is_noop(), record_outcome_updates_counts() (+15 more)
-
-### Community 50 - "Community 50"
-Cohesion: 0.08
-Nodes (44): append_speak_to_log(), broadcast_to_role(), broadcast_to_role_returns_recipient_count(), broadcast_to_role_unknown_role_returns_err(), broadcast_to_role_with_no_matches_returns_zero(), BroadcastArgs, build_ctx(), chat_tool_api_name_round_trip() (+36 more)
-
-### Community 51 - "Community 51"
-Cohesion: 0.1
-Nodes (39): accent_bar_is_at_strip_bottom(), accent_bar_uses_accent_focus_token(), active_tab_bg_uses_surface_raised(), active_tab_text_uses_text_primary(), badge_count_updates_when_tab_receives_event(), badge_renders_as_additional_segment_in_status_warn(), badge_zero_is_distinct_from_no_badge(), click_does_not_change_other_tab_badges() (+31 more)
-
-### Community 52 - "Community 52"
-Cohesion: 0.07
-Nodes (23): build_call_tool_request(), build_call_tool_request_correct_shape(), build_initialize_produces_valid_request(), build_initialize_request(), build_list_tools_request(), build_list_tools_request_correct_method(), builder_ids_are_unique(), call_tool_add_round_trip() (+15 more)
-
-### Community 53 - "Community 53"
-Cohesion: 0.08
-Nodes (46): chunked_transfer_assembles_correctly(), delete_clears_pending_chunks(), ImageHandler, make_cmd(), png_format_decoding(), rgb_format_decoding(), single_rgba_transmit(), base64_decode() (+38 more)
-
-### Community 54 - "Community 54"
-Cohesion: 0.1
-Nodes (35): background_quad_uses_surface_recessed(), backspace_at_start_is_no_op(), backspace_removes_char_before_cursor(), bare_bar(), buffer_text_uses_text_primary(), cursor_in_middle_inserts_at_cursor(), cursor_quad_uses_text_primary_when_visible(), delete_at_end_is_no_op() (+27 more)
-
-### Community 55 - "Community 55"
-Cohesion: 0.06
-Nodes (27): all_templates_are_distinct(), Analysis, analysis_embedding_storable_as_vec_f32(), ChatRequest, ChatResponse, Choice, ContentPart, ImageUrl (+19 more)
-
-### Community 56 - "Community 56"
-Cohesion: 0.07
-Nodes (23): assert_duration_approx(), Cadence, cadence_fires_at_target_hz(), cadence_skips_when_too_soon(), cadence_unlimited_always_ticks(), cadence_zero_hz_never_ticks(), Clock, clock_advances_monotonic() (+15 more)
-
-### Community 57 - "Community 57"
+### Community 33 - "DebugDrawManager (phantom-renderer)"
 Cohesion: 0.13
-Nodes (36): agent_error_none_spawn_tag_is_not_coerced_to_zero(), agent_error_with_none_spawn_tag_is_noop(), auto_approve_disposition_skips_awaiting_approval(), connection_state_for_reason(), dag_aware_dispatch_skips_blocked_step(), dag_dispatch_is_idempotent_for_active_steps(), dag_dispatch_unblocks_after_dep_done(), dispatch_and_capture_tag() (+28 more)
+Nodes (12): DebugDrawManager, DebugPrimitive, DrawOptions, QueuedPrimitive, Vec2, disabled_manager_ignores_adds(), enabled_manager_queues_primitives(), flush_returns_all_and_decays() (+4 more)
 
-### Community 58 - "Community 58"
+### Community 34 - "SysmonHandle (phantom-app)"
+Cohesion: 0.1
+Nodes (29): build_monitor_lines(), build_resource_bar(), DiskIoCounters, extract_temp(), format_throughput(), NetCounters, num_cpus_cached(), read_battery() (+21 more)
+
+### Community 35 - "Attention (phantom-adapter, phantom-brain)"
+Cohesion: 0.06
+Nodes (52): Attention, PaneSnapshot, AdapterEvent, AdapterId, AdapterIdGen, EventStream, adapter_id_new_stores_raw_value(), adapter_id_equality_by_value() (+44 more)
+
+### Community 36 - "HistoryStore (phantom-history)"
+Cohesion: 0.14
+Nodes (30): HistoryEntryBuilder, default_data_dir(), HistoryStore, lock_path_for(), CommandType, temp_store(), entry(), entry_with_exit() (+22 more)
+
+### Community 37 - "MockVoiceSynth (phantom-voice)"
 Cohesion: 0.11
-Nodes (32): click_above_track_clamps_to_max(), click_below_track_clamps_to_zero(), click_bottom_gives_zero_offset(), click_middle_gives_half_offset(), click_top_gives_max_offset(), click_zero_height_always_zero(), click_zero_history_always_zero(), no_quads_when_not_scrollable() (+24 more)
+Nodes (32): CachingVoiceSynth, CachingVoiceSynth<B>, MockVoiceSynth, OpenAiVoice, single_chunk_stream(), SingleChunkStream, SynthAudioChunk, VoiceError (+24 more)
 
-### Community 59 - "Community 59"
+### Community 38 - "ProviderCatalog (phantom-brain)"
 Cohesion: 0.09
-Nodes (26): catalog_custom_profile_overrides_builtin(), catalog_default_profile_has_sonnet(), catalog_get_builtin_fast_profile(), catalog_get_missing_profile_returns_none(), default_equals_with_builtins(), empty_catalog_has_no_profiles(), empty_catalog_resolve_returns_none_for_unknown(), insert_adds_new_profile() (+18 more)
+Nodes (26): ProviderCatalog, ProviderProfile, profile_new_stores_fields(), profile_auto_appends_default_model_if_missing(), profile_no_duplicate_when_default_already_present(), profile_supports_model_true(), profile_supports_model_false_for_unknown(), empty_catalog_has_no_profiles() (+18 more)
 
-### Community 60 - "Community 60"
-Cohesion: 0.08
-Nodes (31): all_official_plugins_have_wasm_entry_point(), api_inspector_hooks_on_output(), docker_dashboard_has_status_bar(), get_official(), get_official_finds_existing_plugin(), git_enhanced_has_correct_hooks_and_commands(), github_notifications_has_all_three_permissions(), official_plugin_names_are_unique() (+23 more)
-
-### Community 61 - "Community 61"
+### Community 39 - "SessionManager (phantom-session)"
 Cohesion: 0.09
-Nodes (30): build_decomposition_prompt(), ChatBackend, ClaudeChatBackend, decompose(), decompose_all_steps_are_pending_initially(), decompose_error_on_backend_failure(), decompose_error_when_no_steps_parsed(), decompose_produces_task_ledger_matching_plan() (+22 more)
+Nodes (52): is_session_restore(), is_session_restore_with_env(), PaneState, project_hash(), SavedShaderParams, session_dir_path(), SessionManager, SessionState (+44 more)
 
-### Community 62 - "Community 62"
-Cohesion: 0.09
-Nodes (27): bootstrap_proposes_first_task(), bootstrap_skips_completed_tasks(), build_prompt_includes_project_name(), CurriculumGenerator, CurriculumHook, next_difficulty_clamps_at_ten(), next_difficulty_from_one(), next_difficulty_increments_by_one() (+19 more)
-
-### Community 63 - "Community 63"
-Cohesion: 0.09
-Nodes (21): BrainTask, build_reflection_prompt(), build_task_creation_prompt(), goal_pursuit_lifecycle(), goal_pursuit_summary(), GoalPursuit, inject_reflections(), parse_task_list() (+13 more)
-
-### Community 64 - "Community 64"
-Cohesion: 0.1
-Nodes (36): allocate_subagent_id(), append(), build_critique_body(), build_critique_body_contains_all_required_tokens(), completion_kinds_for(), composer_ref(), composer_tool_api_name_round_trip(), ComposerTool (+28 more)
-
-### Community 65 - "Community 65"
-Cohesion: 0.17
-Nodes (30): agent_role_color_matches_text_accent(), all_role_colors_are_distinct(), avatar_and_label_use_role_color(), avatar_segment_uses_role_initial(), body_exactly_cols_wide_fits_one_line(), body_one_over_cols_wraps_to_two_lines(), body_segments_use_text_primary_color(), body_text_is_offset_past_avatar_column() (+22 more)
-
-### Community 66 - "Community 66"
-Cohesion: 0.13
-Nodes (24): achievability_check_true_when_steps_exist(), all_steps_have_valid_fields(), cost_estimation_is_sum_of_step_costs(), decompose_and_replan_installs_plan_on_trigger(), decompose_and_replan_returns_none_when_steady(), DecompositionResult, DecompositionStep, default_world() (+16 more)
-
-### Community 67 - "Community 67"
-Cohesion: 0.13
-Nodes (26): all_empty_slots_produce_no_text(), all_three_slots_render_when_content_fits(), background_color_is_surface_recessed_token(), center_slot_x_is_within_center_third(), default_has_empty_slots(), empty_slots_are_omitted(), left_slot_x_position(), medium_width_short_labels_not_truncated() (+18 more)
-
-### Community 68 - "Community 68"
-Cohesion: 0.14
-Nodes (27): CorpusEntry, cosine(), empty_corpus_returns_empty_results(), InMemoryRecallEngine, long_corpus_embedding_is_truncated(), meta(), min_score_boundary_inclusive(), min_score_filters_low_similarity_entries() (+19 more)
-
-### Community 69 - "Community 69"
-Cohesion: 0.16
-Nodes (26): body_rect_is_strictly_inside_outer_rect_titled(), body_rect_is_strictly_inside_outer_rect_untitled(), border_quads_use_chrome_frame_token(), border_thickness_equals_frame_token(), bottom_border_positioned_at_outer_bottom(), default_is_untitled(), degenerate_rect_body_clamped_to_zero(), divider_uses_chrome_divider_token() (+18 more)
-
-### Community 70 - "Community 70"
-Cohesion: 0.15
-Nodes (28): always_emits_four_quads(), clear_focus_leaves_no_pane_focused(), clear_focused_sets_none(), cycling_focus_between_panes(), default_matches_new(), focus_pane_b_is_reported(), focus_ring_is_object_safe(), focus_transfers_from_a_to_c() (+20 more)
-
-### Community 71 - "Community 71"
-Cohesion: 0.1
-Nodes (17): Action, bare_key_no_modifiers(), bind_override(), default_bindings_present(), display_key_combo(), iter_yields_all_bindings(), Key, key_combo_equality() (+9 more)
-
-### Community 72 - "Community 72"
-Cohesion: 0.1
-Nodes (25): b1_cooldown_blocks_rapid_actions(), b1_dedup_suppresses_identical_suggestion(), b1_suggestions_since_input_dampens(), b1_watcher_score_zero_without_active_process(), b226_command_complete_with_real_output_yields_nonzero_fix_score(), error_output(), test_memory(), TestAdapter (+17 more)
-
-### Community 73 - "Community 73"
-Cohesion: 0.13
-Nodes (20): additional_taints_on_quarantined_agent_return_false(), AgentRuntime, AgentSlot, AutoQuarantinePolicy, clean_taint_resets_consecutive_counter(), custom_threshold_one_quarantines_immediately(), denial_counter_resets_after_release(), n_minus_one_taints_do_not_quarantine() (+12 more)
-
-### Community 74 - "Community 74"
-Cohesion: 0.16
-Nodes (15): chrome_regions_fill_window(), LayoutEngine, PaneId, Rect, remove_pane_decreases_count(), resize_updates_layout(), set_pane_size_constraints_clear_restores_auto(), set_pane_size_constraints_updates_taffy_style() (+7 more)
-
-### Community 75 - "Community 75"
-Cohesion: 0.13
-Nodes (12): clear_empties_queue(), DebugDrawManager, DebugPrimitive, disabled_flush_clears_queue(), disabled_manager_ignores_adds(), draw_options_builders(), DrawOptions, enabled_manager_queues_primitives() (+4 more)
-
-### Community 76 - "Community 76"
-Cohesion: 0.16
-Nodes (23): call_missing_export_returns_err_not_panic(), host(), load_and_call_add_returns_correct_result(), load_invalid_bytes_returns_err(), load_with_different_arg_values(), module_with_no_imports_loads_successfully(), plugin_runtime_call_hook_returns_none_when_no_export(), plugin_runtime_call_hook_returns_none_when_ph_on_hook_returns_zero() (+15 more)
-
-### Community 77 - "Community 77"
-Cohesion: 0.08
-Nodes (22): embedding(), reopen_after_clean_write_does_not_error(), sweep_cleans_orphaned_vectors_and_leaked_rows_table(), sweep_drops_unknown_vector_entries(), sweep_leaked_rows(), sweep_with_orphaned_vector_drops_it(), all_bundle_ids(), check_schema_version() (+14 more)
-
-### Community 78 - "Community 78"
-Cohesion: 0.13
-Nodes (22): default_is_horizontal(), Divider, divider_is_object_safe(), h_rect(), horizontal_color_matches_chrome_divider_token(), horizontal_constructor_sets_orientation_and_hair_thickness(), horizontal_emits_no_text(), horizontal_preferred_size_is_height_of_divider() (+14 more)
-
-### Community 79 - "Community 79"
-Cohesion: 0.14
-Nodes (19): attach_same_key_returns_shared_block(), Block, block_key_distinguishes_namespace_and_label(), BlockError, BlockHandle, BlockKey, drop_block_removes_and_get_returns_none(), get_on_missing_key_returns_none() (+11 more)
-
-### Community 80 - "Community 80"
-Cohesion: 0.11
-Nodes (14): AgentOutputCapture, AgentRecord, append_increments_count(), by_agent_filters_correctly(), CapturedAgent, corrupt_lines_skipped(), default_data_dir(), empty_capture_is_safe() (+6 more)
-
-### Community 81 - "Community 81"
-Cohesion: 0.13
-Nodes (17): async_load_flow(), failed_load(), gc_keeps_referenced(), load_returns_handle(), LoadStatus, make_test_resource(), memory_usage_sums(), release_and_gc() (+9 more)
-
-### Community 82 - "Community 82"
-Cohesion: 0.17
-Nodes (17): builder_adds_failed_attempts_batch(), builder_adds_failed_attempts_one_by_one(), builder_adds_memory_refs(), builder_adds_memory_refs_batch(), builder_correlation_id_absent_by_default(), builder_empty_failed_attempts(), builder_sets_correlation_id(), builder_sets_required_fields() (+9 more)
-
-### Community 83 - "Community 83"
-Cohesion: 0.15
-Nodes (24): composed_chrome_reserves_title_and_footer(), layout_box_is_copy_clone_debug(), LayoutBox, pad_clamps_to_zero_when_excessive(), pad_insets_all_four_sides(), pad_zero_is_noop(), parent(), reserve_bottom_carves_strip_and_remainder() (+16 more)
-
-### Community 84 - "Community 84"
-Cohesion: 0.14
-Nodes (31): ansi_color_table(), ansi_palette_override_applied(), ansi_palette_override_only_affects_0_to_15(), background_uses_theme_color_not_transparent(), bright_foreground_uses_theme_color(), cell_flags_all_underline_variants(), cell_flags_from_alac_round_trips(), cell_flags_wide_char() (+23 more)
-
-### Community 85 - "Community 85"
-Cohesion: 0.12
-Nodes (29): AgentSuggestion, build_context(), build_error_summary(), build_error_summary_includes_code_and_location(), build_error_summary_without_code_or_column(), build_task(), build_task_context_includes_command_and_dir(), build_task_falls_back_to_first_error_without_file() (+21 more)
-
-### Community 86 - "Community 86"
-Cohesion: 0.15
-Nodes (28): actor_does_not_have_broadcast_tool(), actor_gets_all_tools_including_act(), all_mcp_tools(), all_mcp_tools_covers_every_advertised_method(), capturer_does_not_have_broadcast_tool(), capturer_gets_sense_and_reflect_tools(), composer_also_has_broadcast_tool(), conversational_gets_all_minus_act() (+20 more)
-
-### Community 87 - "Community 87"
-Cohesion: 0.13
-Nodes (15): agent_complete_triggers_notification(), custom_high_threshold_suppresses_action(), default_loop(), error_world(), high_score_action_is_dispatched(), low_score_action_is_skipped(), metrics_record_last_winner(), metrics_tick_counter_increments() (+7 more)
-
-### Community 88 - "Community 88"
-Cohesion: 0.14
-Nodes (22): backward_time_does_not_toggle(), carry_over_is_preserved_after_toggle(), color_passes_through_base_when_visible(), color_zeroes_alpha_when_hidden(), CursorBlink, custom_period_toggles_at_custom_boundary(), default_period_is_530ms(), default_starts_visible() (+14 more)
-
-### Community 89 - "Community 89"
-Cohesion: 0.16
-Nodes (16): accessors_expose_all_fields(), agents_do_not_bleed_into_each_other(), by_agent_returns_only_matching_records(), clear_agent_removes_failures_for_that_agent(), default_produces_empty_store(), FailureRecord, FailureStore, free_form_task() (+8 more)
-
-### Community 90 - "Community 90"
-Cohesion: 0.22
-Nodes (18): active_count_tracks_working_agents(), AgentManager, agents_returns_all(), by_status_filters(), cleanup_keeps_active_agents(), cleanup_promotes_queued_to_working(), cleanup_removes_old_completed_agents(), free_task() (+10 more)
-
-### Community 91 - "Community 91"
-Cohesion: 0.13
-Nodes (27): accept_loop(), AppCommand, dispatch(), dispatch_get_context(), dispatch_get_memory(), dispatch_phantom_command(), dispatch_read_output(), dispatch_run_command() (+19 more)
-
-### Community 92 - "Community 92"
-Cohesion: 0.09
-Nodes (14): decoded_image_from_png_grayscale(), decoded_image_from_png_invalid_bytes(), decoded_image_from_png_rgb(), decoded_image_from_png_valid(), decoded_image_from_rgb(), decoded_image_from_rgb_too_short(), decoded_image_from_rgba(), decoded_image_from_rgba_too_short() (+6 more)
-
-### Community 93 - "Community 93"
-Cohesion: 0.15
-Nodes (23): click_drag_left_to_right_forward(), click_drag_right_to_left_normalizes(), click_drag_same_row_backward(), collapsed_when_same_point(), ctx(), flowing_four_rows_four_rects(), flowing_single_row_one_rect(), flowing_three_rows_three_rects() (+15 more)
-
-### Community 94 - "Community 94"
-Cohesion: 0.15
-Nodes (14): by_task_filters_by_task_id(), HandoffEntry, HandoffError, HandoffLog, jsonl_round_trip_survives_reopen(), mk_log(), multi_agent_chain_all_under_same_task_id(), new_entry() (+6 more)
-
-### Community 95 - "Community 95"
-Cohesion: 0.16
-Nodes (12): agent_event_carries_task_and_success(), app_topology_three_topics(), BusMessage, DataType, drain_clears_queue_for_subscriber(), emit_caps_queue_at_max_size(), error_event_isolated_from_output_subscriber(), EventBus (+4 more)
-
-### Community 96 - "Community 96"
-Cohesion: 0.17
-Nodes (18): decode_png_with_meta(), decode_rejects_non_png(), dhash_collision_similar_frames_within_hamming_4(), dhash_very_different_frames_exceed_hamming_4(), encode_rgba_to_png(), gradient_rgba(), new_rejects_size_mismatch(), new_rejects_zero_dimensions() (+10 more)
-
-### Community 97 - "Community 97"
-Cohesion: 0.13
-Nodes (9): builder_defaults(), builder_setters(), corrupt_line_returns_err(), HistoryEntry, HistoryEntryBuilder, jsonl_round_trip(), make_entry(), timestamp_iso8601_round_trip() (+1 more)
-
-### Community 98 - "Community 98"
-Cohesion: 0.16
-Nodes (10): append_content_summary(), empty_context_prompt_section_is_none(), git_status_branch_surfaces_in_prompt_section(), git_status_content_type_surfaces_in_prompt_section(), latest_returns_most_recent_entry(), non_empty_context_prompt_section_has_heading(), push_onto_empty_context_length_is_one(), ring_buffer_evicts_oldest_at_max_capacity() (+2 more)
-
-### Community 99 - "Community 99"
-Cohesion: 0.14
-Nodes (22): CommandOutput, execute_sandboxed(), none_policy_reports_nonzero_exit(), none_policy_runs_echo(), none_policy_timeout_fires(), permissive_policy_captures_stderr(), permissive_policy_runs_echo(), resource_exhaustion_100_rapid_calls_no_leak() (+14 more)
-
-### Community 100 - "Community 100"
-Cohesion: 0.11
-Nodes (14): audio(), audio_ref_json_round_trip(), frame(), frame_ref_json_round_trip(), importance_clamped_above_one_survives_round_trip(), importance_clamped_below_zero_survives_round_trip(), json_round_trip_all_modalities_bundle(), json_round_trip_audio_only_bundle() (+6 more)
-
-### Community 101 - "Community 101"
-Cohesion: 0.21
-Nodes (19): active_pane_outranks_idle_pane(), activity_never_active_pane_scores_zero_activity(), agent_distress_adds_to_score(), Attention, deterministic_tie_breaking_by_adapter_id(), error_pane_outranks_idle_pane(), error_signal_saturates_at_three_tokens(), make_active() (+11 more)
-
-### Community 102 - "Community 102"
-Cohesion: 0.14
-Nodes (15): dim_mismatch_is_rejected(), empty_modality_search_returns_empty(), InMemoryVectorIndex, ModalityTable, remove_is_idempotent(), search_truncates_to_limit(), upsert_then_search_orders_by_similarity(), VectorHit (+7 more)
-
-### Community 103 - "Community 103"
-Cohesion: 0.24
-Nodes (15): compute_layout_on_empty_dag_is_noop(), compute_layout_places_all_nodes(), DagViewerState, edge(), handle_click_miss_clears_selection(), handle_click_selects_node(), handle_pan_shifts_offset(), handle_zoom_scales_and_clamps() (+7 more)
-
-### Community 104 - "Community 104"
-Cohesion: 0.23
-Nodes (11): add_and_retrieve_skill(), format_for_prompt_shows_skills(), list_skill_names(), load_from_memory_round_trips(), now_epoch(), record_use_increments_count(), retrieve_caps_at_top_k(), retrieve_returns_empty_for_no_match() (+3 more)
-
-### Community 105 - "Community 105"
-Cohesion: 0.2
-Nodes (14): dim_mismatch_is_rejected(), DimCache, embedding_dim_from_schema(), empty_batch(), empty_modality_search_returns_empty(), ids_for_modality_tracks_inserts_and_removes(), LanceDbIndex, modalities_lists_all_tables() (+6 more)
-
-### Community 106 - "Community 106"
+### Community 40 - "InMemoryStore (phantom-embeddings)"
 Cohesion: 0.18
-Nodes (10): channel_filtering(), channel_for_target(), chrono_free_timestamp(), file_mirror_to_tempdir(), install(), install_panic_hook(), level_to_verbosity(), PhantomLogger (+2 more)
+Nodes (25): EmbeddingRecord, EmbeddingStore, InMemoryStore, QueryFilter, QueryHit, record_matches(), StoreError, uuid() (+17 more)
 
-### Community 107 - "Community 107"
-Cohesion: 0.22
-Nodes (12): ChildHandle, JoinHandle<T>, noop_waker(), NowOrNeverResult, one_for_one_rate_limit_escalates(), permanent_policy_respawns_after_clean_exit(), RestartPolicy, shutdown_cancels_all_children() (+4 more)
+### Community 41 - "QuarantineRegistry (phantom-agents)"
+Cohesion: 0.13
+Nodes (20): AgentRuntime, AgentSlot, AutoQuarantinePolicy, QuarantineRegistry, QuarantineState, n_minus_one_taints_do_not_quarantine(), n_taints_quarantine_agent(), clean_taint_resets_consecutive_counter() (+12 more)
 
-### Community 108 - "Community 108"
-Cohesion: 0.17
-Nodes (14): all_grants_every_permission(), all_tools_allowed_with_all_permissions(), check_tool_git_status_and_diff(), check_tool_list_files_uses_read_permission(), check_tool_read_file_allowed(), check_tool_run_command_denied(), check_tool_search_files_uses_read_permission(), check_tool_write_file_denied() (+6 more)
+### Community 42 - "BlockHandle (phantom-memory)"
+Cohesion: 0.14
+Nodes (19): Block, BlockError, BlockHandle, BlockKey, MemoryStore, Permission, key(), attach_same_key_returns_shared_block() (+11 more)
 
-### Community 109 - "Community 109"
-Cohesion: 0.2
-Nodes (12): b64_round_trip_32_bytes(), BlobEnvelope, DataEncryptionKey, decode_b64_32(), dek_derivation_is_deterministic_per_bundle_id(), encode_b64_32(), envelope_bytes_round_trip(), MasterKey (+4 more)
+### Community 43 - "VectorQuery (phantom-recall)"
+Cohesion: 0.18
+Nodes (28): CorpusEntry, cosine(), InMemoryRecallEngine, mock_embed(), normalise(), normalise_dims(), RecallEngine, RecallResult (+20 more)
 
-### Community 110 - "Community 110"
+### Community 44 - "AppRegistry (phantom-adapter)"
+Cohesion: 0.14
+Nodes (2): AppRegistry, RegisteredApp
+
+### Community 45 - "SelfTestRunner (phantom-app)"
+Cohesion: 0.15
+Nodes (12): build_test_suite(), check_result_detailed(), cleanup_after_test(), describe_check(), execute_action(), Failure, HealStage, Phase (+4 more)
+
+### Community 46 - "ResourceManager (phantom-app)"
+Cohesion: 0.13
+Nodes (17): LoadStatus, Resource, ResourceEntry, ResourceHandle, ResourceId, ResourceManager, TestResource, make_test_resource() (+9 more)
+
+### Community 47 - "SettingsPanel (phantom-app)"
 Cohesion: 0.12
 Nodes (6): CurrentValues, SettingsItem, SettingsKind, SettingsPanel, SettingsSection, SettingsSnapshot
 
-### Community 111 - "Community 111"
-Cohesion: 0.19
-Nodes (11): after_ping_waits_for_pong(), backoff_caps_at_max(), backoff_delay(), backoff_grows_exponentially(), first_poll_requests_ping(), Heartbeat, HeartbeatAction, HeartbeatState (+3 more)
+### Community 48 - "DecompositionStep (phantom-brain)"
+Cohesion: 0.14
+Nodes (14): DecompositionResult, DecompositionStep, GoalDecomposer, Orchestrator, steps_are_in_priority_order(), cost_estimation_is_sum_of_step_costs(), errors_detected_bumps_fix_priority(), unknown_goal_falls_back_to_investigate() (+6 more)
 
-### Community 112 - "Community 112"
+### Community 49 - "McpClient (phantom-mcp)"
+Cohesion: 0.14
+Nodes (29): build_call_tool_request(), build_initialize_request(), build_list_tools_request(), McpClient, next_builder_id(), build_initialize_produces_valid_request(), build_list_tools_request_correct_method(), build_call_tool_request_correct_shape() (+21 more)
+
+### Community 50 - "CaptureSession (phantom-bundles)"
+Cohesion: 0.15
+Nodes (17): CaptureFrame, CaptureSession, TranscriptSegment, frame(), segment(), fresh_id(), finalize_on_empty_session_returns_no_frames_error(), finalize_transcript_only_session_returns_no_frames_error() (+9 more)
+
+### Community 51 - "Console (phantom-app)"
+Cohesion: 0.14
+Nodes (16): Console, ConsoleLine, console_with_3_commands(), history_up_once_returns_last_command(), history_up_twice_returns_second_command(), history_up_three_times_returns_first_command(), history_up_past_oldest_stays_at_first_no_panic(), history_up_then_down_restores_input() (+8 more)
+
+### Community 52 - "AgentAdapter (phantom-app)"
+Cohesion: 0.1
+Nodes (14): AgentAdapter, test_render_produces_text_segments(), test_handle_input_accepts_printable_chars(), test_accept_command_unknown_returns_error(), test_is_alive_false_after_dismiss(), agent_adapter_render_stays_within_rect(), scroll_command_up_increments_offset(), scroll_command_down_clamps_at_zero() (+6 more)
+
+### Community 53 - "FailureStore (phantom-agents)"
+Cohesion: 0.16
+Nodes (16): FailureRecord, FailureStore, free_form_task(), make_record(), make_record_with_tool(), push_and_retrieve_single_record(), store_caps_at_100_records_evicting_oldest(), by_agent_returns_only_matching_records() (+8 more)
+
+### Community 54 - "JobPool (phantom-app)"
+Cohesion: 0.13
+Nodes (18): JobContext, JobEnvelope, JobHandle, JobId, JobPayload, JobPool, JobPriority, JobResult (+10 more)
+
+### Community 55 - "PhantomMcpServer (phantom-mcp)"
+Cohesion: 0.14
+Nodes (19): builtin_resources(), builtin_tools(), PhantomMcpServer, ResourceReadParams, ServerInfo, ToolCallParams, server(), initialize_returns_server_info() (+11 more)
+
+### Community 56 - "PhantomModifiers (phantom-terminal)"
+Cohesion: 0.05
+Nodes (57): encode_arrow(), encode_char(), encode_function_key(), encode_key(), encode_mouse_motion_sgr(), encode_mouse_sgr(), encode_paste(), encode_tilde() (+49 more)
+
+### Community 57 - "App (phantom-app)"
 Cohesion: 0.25
-Nodes (14): feed(), headless_term(), no_panic_all_byte_values(), no_panic_arabic_marhaba(), no_panic_combined_edge_cases(), no_panic_e_combining_acute(), no_panic_fire_skull_emoji(), no_panic_null_byte() (+6 more)
+Nodes (1): App
 
-### Community 113 - "Community 113"
+### Community 58 - "AgentPane (phantom-app)"
+Cohesion: 0.1
+Nodes (1): AgentPane
+
+### Community 59 - "Theme (phantom-ui)"
+Cohesion: 0.17
+Nodes (28): amber(), blood(), builtin_by_name(), hex(), hexa(), ice(), phosphor(), pipboy() (+20 more)
+
+### Community 60 - "Framework (phantom-context)"
+Cohesion: 0.12
+Nodes (44): detect_commands(), detect_elixir_framework(), detect_framework(), detect_java_framework(), detect_node_framework(), detect_package_manager(), detect_project(), detect_python_framework() (+36 more)
+
+### Community 61 - "PhantomLogger (phantom-app)"
 Cohesion: 0.18
-Nodes (6): BootOrder, shutdown_guard_default_matches_new(), shutdown_guard_is_idempotent(), shutdown_order_is_reversed(), ShutdownGuard, SubsystemTier
+Nodes (12): channel_for_target(), chrono_free_timestamp(), install(), install_panic_hook(), level_to_verbosity(), PhantomLogger, channel_for_known_targets(), channel_for_unknown_target_passes() (+4 more)
 
-### Community 114 - "Community 114"
+### Community 62 - "Router (phantom-relay)"
+Cohesion: 0.22
+Nodes (18): main(), Config, parse_config_flag(), Router, spawn_relay(), handshake(), recv_json(), make_send() (+10 more)
+
+### Community 63 - "MacOsSckCapture (phantom-audio)"
 Cohesion: 0.21
-Nodes (12): as_uuid_round_trips(), clone_produces_equal_id(), copy_produces_equal_id(), CorrelationId, debug_includes_correlation_id_wrapper_name(), display_emits_hyphenated_uuid_format(), distinct_ids_can_coexist_in_hash_set(), eq_is_reflexive() (+4 more)
+Nodes (10): build_and_start_stream(), MacOsSckCapture, map_sc_error(), map_sc_error_with_context(), sample_buffer_to_audio_frame(), SckAudioStream, SckStreamGuard, enumerate_succeeds_or_permission_denied() (+2 more)
 
-### Community 115 - "Community 115"
-Cohesion: 0.25
+### Community 64 - "MonitorAdapter (phantom-app)"
+Cohesion: 0.15
+Nodes (1): MonitorAdapter
+
+### Community 65 - "AgentPaneStyle (phantom-agents)"
+Cohesion: 0.09
+Nodes (34): agent_header(), agent_output_lines(), AgentPaneStyle, animated_border_color(), truncate(), style_working_has_nonzero_pulse(), style_waiting_for_tool_uses_working_style(), style_queued_has_no_pulse() (+26 more)
+
+### Community 66 - "SandboxError (phantom-agents)"
+Cohesion: 0.14
+Nodes (25): CommandOutput, execute_sandboxed(), run_bare(), run_permissive(), run_strict(), run_strict_linux(), run_strict_macos(), SandboxError (+17 more)
+
+### Community 67 - "OpenAiEmbeddingBackend (phantom-embeddings)"
+Cohesion: 0.16
+Nodes (12): EmbeddingData, EmbeddingsRequest, EmbeddingsResponse, OpenAiEmbeddingBackend, with_env_var(), from_env_returns_not_configured_when_missing(), from_env_succeeds_with_key(), with_small_uses_small_model_and_1536_dim() (+4 more)
+
+### Community 68 - "ReconcilerState (phantom-brain)"
+Cohesion: 0.15
+Nodes (20): connection_state_for_reason(), ReconcilerState, stall_detection_emits_flatline_on_exhausted_retries(), heartbeat_flatline_carries_reason_and_matching_id(), heartbeat_stall_requeues_before_final_flatline(), reset_clears_active_dispatches(), on_agent_complete_routes_by_spawn_tag_not_by_manager_id(), on_agent_complete_ignores_events_without_spawn_tag() (+12 more)
+
+### Community 69 - "Panel (phantom-ui)"
+Cohesion: 0.23
+Nodes (4): Panel, set_title_changes_render_output(), removing_title_collapses_to_untitled_output(), degenerate_rect_body_clamped_to_zero()
+
+### Community 70 - "McpToolRegistry (phantom-mcp)"
+Cohesion: 0.15
+Nodes (18): McpToolRegistry, McpToolRoute, ToolProvenance, register_test_server(), register_two_servers_non_overlapping_tools(), resolve_routes_to_correct_server(), resolve_tool_unknown_returns_none(), invoke_known_tool_returns_ok() (+10 more)
+
+### Community 71 - "PhantomSettings (phantom-app)"
+Cohesion: 0.22
+Nodes (7): CrtSettings, PhantomSettings, ScrollSettings, default_settings_round_trip(), load_from_nonexistent_returns_default(), save_and_reload(), partial_toml_fills_defaults()
+
+### Community 72 - "Heartbeat (phantom-net)"
+Cohesion: 0.19
+Nodes (11): backoff_delay(), Heartbeat, HeartbeatAction, HeartbeatState, first_poll_requests_ping(), after_ping_waits_for_pong(), pong_resets_to_idle(), timeout_triggers_reconnect() (+3 more)
+
+### Community 73 - "SceneNode (phantom-scene)"
+Cohesion: 0.18
+Nodes (5): NodeKind, RenderLayer, SceneNode, Transform, WorldTransform
+
+### Community 74 - "TabStrip (phantom-ui)"
+Cohesion: 0.22
+Nodes (5): TabStrip, click_on_empty_strip_is_no_op(), click_does_not_change_other_tab_badges(), multiple_badges_independently_reported(), on_select_callback_receives_correct_index_on_click()
+
+### Community 75 - "App (phantom-app)"
+Cohesion: 0.33
 Nodes (1): App
 
-### Community 116 - "Community 116"
-Cohesion: 0.22
-Nodes (6): CrtSettings, default_settings_round_trip(), load_from_nonexistent_returns_default(), PhantomSettings, save_and_reload(), ScrollSettings
-
-### Community 117 - "Community 117"
+### Community 76 - "NotificationCenter (phantom-app)"
 Cohesion: 0.2
-Nodes (8): cell_w_and_h_return_components(), default_equals_fallback(), fallback_matches_legacy_assumptions(), measure_mono_empty_string_zero(), measure_mono_handles_unicode_by_char_count(), measure_mono_scales_with_cell_width(), RenderCtx, space_n_is_4n()
+Nodes (6): Banner, NotificationCenter, Severity, triggers_banner_at_threshold(), does_not_trigger_below_threshold(), prunes_old_timestamps_outside_window()
 
-### Community 118 - "Community 118"
-Cohesion: 0.24
-Nodes (13): agent_node(), build_overlay(), build_overlay_in_progress_label_uses_higher_weight(), build_overlay_invalid_json_returns_empty(), build_overlay_maps_issue_to_matching_dag_node(), extract_crate_names(), extract_crate_names_finds_multiple_crates_in_one_body(), GhIssue (+5 more)
+### Community 77 - "LayoutBox (phantom-ui)"
+Cohesion: 0.15
+Nodes (25): LayoutBox, approx_eq(), parent(), layout_box_is_copy_clone_debug(), reserve_top_carves_strip_and_remainder(), reserve_top_clamps_when_exceeds_parent(), reserve_top_zero_height_is_noop(), reserve_bottom_carves_strip_and_remainder() (+17 more)
 
-### Community 119 - "Community 119"
-Cohesion: 0.29
-Nodes (11): agent_capture_is_clone(), agent_capture_records_run(), history_append_increments_count(), history_command_and_exit_code_round_trip(), history_empty_store_is_safe(), history_recent_chronological_order(), history_recent_limit_exceeds_total(), history_survives_reopen() (+3 more)
-
-### Community 120 - "Community 120"
-Cohesion: 0.17
-Nodes (1): TaintLevel
-
-### Community 121 - "Community 121"
-Cohesion: 0.22
-Nodes (5): create_bind_group(), create_offscreen_texture(), crt_wgsl_source(), PostFxParams, PostFxPipeline
-
-### Community 122 - "Community 122"
-Cohesion: 0.41
-Nodes (7): apply_modifies_grid_cell(), apply_out_of_bounds_is_safe(), apply_skips_spaces(), GlitchCell, KeystrokeFx, noise_hash(), trigger_and_tick_lifecycle()
-
-### Community 123 - "Community 123"
-Cohesion: 0.17
-Nodes (0): 
-
-### Community 124 - "Community 124"
-Cohesion: 0.21
-Nodes (9): build_error_analysis_prompt(), build_error_analysis_prompt_caps_at_5_errors(), build_error_analysis_prompt_formats_correctly(), ContentBlock, is_available(), is_available_does_not_panic(), Message, MessagesRequest (+1 more)
-
-### Community 125 - "Community 125"
-Cohesion: 0.24
-Nodes (5): default_is_safe(), poll_returns_none_when_env_var_not_set(), repeated_poll_returns_none(), ShaderEvent, ShaderReloader
-
-### Community 126 - "Community 126"
-Cohesion: 0.29
-Nodes (9): custom_namespace_rejected(), registry_stable_after_rejection(), valid_plugin_loads_correctly(), wasi_fd_write_rejected(), wasi_sock_open_rejected(), wasm_valid_no_wasi(), wasm_with_custom_namespace(), wasm_with_fd_write() (+1 more)
-
-### Community 127 - "Community 127"
-Cohesion: 0.29
-Nodes (7): crt_global_bindings(), crt_wgsl_all_bindings_in_group0(), crt_wgsl_binding_slots_are_contiguous_0_1_2(), crt_wgsl_exactly_three_bindings(), crt_wgsl_params_uniform_at_group0_binding2(), crt_wgsl_scene_sampler_at_group0_binding1(), crt_wgsl_scene_texture_at_group0_binding0()
-
-### Community 128 - "Community 128"
-Cohesion: 0.25
-Nodes (6): encode_png(), encode_png_1x1(), encode_png_produces_valid_png(), save_screenshot(), save_screenshot_writes_files(), ScreenshotMetadata
-
-### Community 129 - "Community 129"
-Cohesion: 0.33
-Nodes (7): rust_ctx(), translate_clarify_for_ambiguous_input(), translate_empty_input_is_clarify_without_backend_call(), translate_malformed_backend_reply_maps_to_clarify(), translate_run_command_with_mock(), translate_search_history_with_mock(), translate_spawn_agent_with_mock()
-
-### Community 130 - "Community 130"
-Cohesion: 0.33
-Nodes (1): App
-
-### Community 131 - "Community 131"
+### Community 78 - "NotificationBanner (phantom-ui)"
 Cohesion: 0.27
-Nodes (8): build_error_triage_prompt(), build_error_triage_prompt_caps_at_3_errors(), build_error_triage_prompt_formats_correctly(), GenerateOptions, GenerateRequest, GenerateResponse, is_available(), is_available_returns_false_when_no_server()
+Nodes (5): NotificationBanner, visible_emits_background_and_stripe(), severity_drives_accent_color(), text_color_matches_severity_token(), clear_hides_banner()
 
-### Community 132 - "Community 132"
-Cohesion: 0.39
-Nodes (6): dedup_identical_frames_detected(), embedding(), end_to_end_capture_pipeline(), open_tmp(), solid_rgba(), store_insert_and_retrieve_by_id()
+### Community 79 - "ShutdownGuard (phantom-app)"
+Cohesion: 0.18
+Nodes (11): BootOrder, ShutdownGuard, SubsystemTier, tiers_are_ordered(), shutdown_order_is_reversed(), foundation_tier_is_first(), all_tiers_have_subsystems(), shutdown_guard_is_idempotent() (+3 more)
 
-### Community 133 - "Community 133"
-Cohesion: 0.53
-Nodes (4): disconnected_sets_have_different_roots(), singleton_is_own_root(), union_merges_components(), UnionFind
+### Community 80 - "SelectionRect (phantom-ui)"
+Cohesion: 0.15
+Nodes (25): normalize(), PixelRect, SelectionMode, SelectionRect, ctx(), sel(), forward_order_unchanged(), reversed_rows_flips_start_and_end() (+17 more)
 
-### Community 134 - "Community 134"
-Cohesion: 0.5
-Nodes (8): fs(), measure_text(), measure_text_doubles_with_font_size(), measure_text_empty_string_is_zero(), measure_text_max_width_forces_wrap(), measure_text_single_m_matches_renderer_cell_width(), measure_text_width_monotonic_with_length(), TextMeasurement
+### Community 81 - "JsonRpcError (phantom-mcp)"
+Cohesion: 0.16
+Nodes (17): create_error(), create_request(), create_response(), JsonRpcError, JsonRpcRequest, JsonRpcResponse, McpResource, McpTool (+9 more)
 
-### Community 135 - "Community 135"
-Cohesion: 0.28
-Nodes (3): probe_shell_path(), resolve_desktop_path(), resolve_desktop_path_unix()
-
-### Community 136 - "Community 136"
+### Community 82 - "SupervisorClient (phantom-app)"
 Cohesion: 0.32
 Nodes (1): SupervisorClient
 
-### Community 137 - "Community 137"
-Cohesion: 0.29
-Nodes (3): frame_mark(), frame_mark_is_callable(), ProfileScope
-
-### Community 138 - "Community 138"
-Cohesion: 0.43
-Nodes (4): boot_smoke_full_invariants(), make_runtime(), runtime_new_succeeds_with_test_config(), runtime_tick_with_no_events_does_not_panic()
-
-### Community 139 - "Community 139"
+### Community 83 - "App (phantom-app)"
 Cohesion: 0.57
 Nodes (1): App
 
-### Community 140 - "Community 140"
+### Community 84 - "WsTransport (phantom-net)"
 Cohesion: 0.29
 Nodes (1): WsTransport
 
-### Community 141 - "Community 141"
-Cohesion: 0.52
-Nodes (3): allows_up_to_rate(), refills_over_time(), TokenBucket
+### Community 85 - "GenerateOptions (phantom-brain)"
+Cohesion: 0.27
+Nodes (9): build_error_triage_prompt(), generate(), GenerateOptions, GenerateRequest, GenerateResponse, is_available(), build_error_triage_prompt_formats_correctly(), build_error_triage_prompt_caps_at_3_errors() (+1 more)
 
-### Community 142 - "Community 142"
+### Community 86 - "AppState (phantom-adapter)"
+Cohesion: 0.33
+Nodes (1): AppState
+
+### Community 87 - "Session (phantom-relay)"
+Cohesion: 0.33
+Nodes (2): Session, SessionHandle
+
+### Community 88 - "HandshakeAck (phantom-relay)"
+Cohesion: 0.47
+Nodes (5): handle_connection(), HandshakeAck, IdentityProof, run(), run_with_listener()
+
+### Community 89 - "PeerId (phantom-relay)"
+Cohesion: 0.33
+Nodes (4): Envelope, ClientMessage, PeerId, RelayMessage
+
+### Community 90 - "SequenceClock (phantom-memory)"
+Cohesion: 0.42
+Nodes (4): SequenceClock, clock_starts_at_zero(), clock_next_increments_monotonically(), clock_is_thread_safe()
+
+### Community 91 - "UnionFind (phantom-dag)"
 Cohesion: 0.53
-Nodes (4): AgentPolicy, default_policy_matches_former_global_values(), policy_clone_is_independent(), policy_fields_are_independently_mutable()
+Nodes (4): UnionFind, singleton_is_own_root(), union_merges_components(), disconnected_sets_have_different_roots()
 
-### Community 143 - "Community 143"
+### Community 92 - "GlyphClipRect (phantom-renderer)"
 Cohesion: 0.33
 Nodes (1): GlyphClipRect
 
-### Community 144 - "Community 144"
+### Community 93 - "ScreenshotMetadata (phantom-renderer)"
+Cohesion: 0.25
+Nodes (10): capture_frame(), capture_frame_sub(), encode_png(), save_screenshot(), ScreenshotMetadata, encode_png_produces_valid_png(), encode_png_1x1(), metadata_serialization_round_trip() (+2 more)
+
+### Community 94 - "ClipRect (phantom-renderer)"
 Cohesion: 0.33
 Nodes (1): ClipRect
 
-### Community 145 - "Community 145"
-Cohesion: 0.4
-Nodes (1): GpuContext
+### Community 95 - "ProfileScope (phantom-app)"
+Cohesion: 0.29
+Nodes (5): frame_mark(), ProfileScope, profile_scope_compiles_without_feature(), profile_frame_compiles_without_feature(), frame_mark_is_callable()
 
-### Community 146 - "Community 146"
-Cohesion: 0.83
-Nodes (1): App
+### Community 96 - "CorrelationId (phantom-agents)"
+Cohesion: 0.21
+Nodes (13): CorrelationId, new_returns_distinct_ids(), copy_produces_equal_id(), clone_produces_equal_id(), eq_is_reflexive(), hash_is_stable_for_equal_ids(), distinct_ids_can_coexist_in_hash_set(), display_emits_hyphenated_uuid_format() (+5 more)
 
-### Community 147 - "Community 147"
+### Community 97 - "spawn_mock_relay() (phantom-net)"
+Cohesion: 0.7
+Nodes (4): handle_connection(), mock_relay_handshake_completes(), spawn_mock_relay(), two_clients_exchange_one_message()
+
+### Community 98 - "TokenBucket (phantom-relay)"
+Cohesion: 0.52
+Nodes (3): TokenBucket, allows_up_to_rate(), refills_over_time()
+
+### Community 99 - "build_codebase_context() (phantom-app)"
 Cohesion: 0.5
-Nodes (0): 
+Nodes (3): build_codebase_context(), class_label(), now_unix_ms()
 
-### Community 148 - "Community 148"
+### Community 100 - "App (phantom-app)"
 Cohesion: 0.67
 Nodes (1): App
 
-### Community 149 - "Community 149"
+### Community 101 - "AgentPane (phantom-app)"
 Cohesion: 0.5
 Nodes (1): AgentPane
 
-### Community 150 - "Community 150"
+### Community 102 - "RuntimeMode (phantom-agents)"
 Cohesion: 0.5
 Nodes (1): RuntimeMode
 
-### Community 151 - "Community 151"
+### Community 103 - "DagFile (phantom-dag)"
 Cohesion: 0.5
-Nodes (1): DirtyFlags
+Nodes (3): DagFile, from_json(), to_json()
 
-### Community 152 - "Community 152"
-Cohesion: 0.5
-Nodes (1): DagFile
+### Community 104 - "resolve_desktop_path_unix() (phantom)"
+Cohesion: 0.28
+Nodes (8): probe_shell_path(), resolve_desktop_path(), resolve_desktop_path_unix(), parses_shell_path_from_output(), merges_shell_path_before_current(), timeout_kills_hung_process(), corrupt_output_without_slash_is_rejected(), empty_shell_path_is_handled()
 
-### Community 153 - "Community 153"
+### Community 105 - "AgentPane (phantom-app)"
 Cohesion: 1.0
 Nodes (1): AgentPane
 
-### Community 154 - "Community 154"
+### Community 106 - "is_alt_screen() (phantom-terminal)"
 Cohesion: 0.67
-Nodes (0): 
-
-### Community 155 - "Community 155"
-Cohesion: 0.67
-Nodes (0): 
-
-### Community 156 - "Community 156"
-Cohesion: 1.0
-Nodes (1): App
-
-### Community 157 - "Community 157"
-Cohesion: 1.0
-Nodes (1): AgentPane
-
-### Community 158 - "Community 158"
-Cohesion: 1.0
-Nodes (1): String
-
-### Community 159 - "Community 159"
-Cohesion: 1.0
-Nodes (1): AiAction
-
-### Community 160 - "Community 160"
-Cohesion: 1.0
-Nodes (1): MockStream<F>
-
-### Community 161 - "Community 161"
-Cohesion: 1.0
-Nodes (1): T
+Nodes (2): is_alt_screen(), is_vi_mode()
 
 ## Knowledge Gaps
-- **377 isolated node(s):** `CommandType`, `GitCommand`, `CargoCommand`, `DockerCommand`, `NpmCommand` (+372 more)
+- **13 isolated node(s):** `T`, `Extract the line number from a source_location like 'L42'.`, `Return a set of line numbers that fall inside #[cfg(test)] modules or     are #[`, `Annotate extraction nodes with ``is_test: true`` when they originate     from ```, `Parse workspace Cargo.toml for members and each crate's Cargo.toml for     inter` (+8 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 156`** (2 nodes): `App`, `.collect_metrics()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 157`** (2 nodes): `AgentPane`, `.build_dispatch_context()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 158`** (2 nodes): `String`, `.from()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 159`** (2 nodes): `AiAction`, `.execute()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 160`** (2 nodes): `MockStream<F>`, `.poll_next()`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 161`** (1 nodes): `T`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **What connects `CommandType`, `GitCommand`, `CargoCommand` to the rest of the system?**
-  _377 weakly-connected nodes found - possible documentation gaps or missing edges._
-- **Should `Community 0` be split into smaller, more focused modules?**
+- **Why does `crate:phantom-agents` connect `EventLog (phantom-agents)` to `AgentTask (phantom-agents, phantom-session)`, `AgentSnapshot (phantom-session)`, `InspectorAdapter (phantom-ui)`, `AgentPaneStyle (phantom-agents)`, `CorrelationId (phantom-agents)`, `SandboxError (phantom-agents)`, `RuntimeMode (phantom-agents)`, `AgentJournal (phantom-memory)`, `HeadlessActionHandler (phantom-nlp, phantom-agents)`, `AgentManager (phantom-agents)`, `QuarantineRegistry (phantom-agents)`, `SemanticParser (phantom-semantic, phantom-agents)`, `PersistentSkillRegistry (phantom-brain, phantom-agents)`, `AgentRuntime (phantom-agents, phantom-app)`, `FailureStore (phantom-agents)`, `Agent (phantom-agents)`, `GhTicketDispatcher (phantom-agents)`?**
+  _High betweenness centrality (0.000) - this node is a cross-community bridge._
+- **Why does `crate:phantom-app` connect `TerminalAdapter (phantom-app, phantom-scene)` to `AgentTask (phantom-agents, phantom-session)`, `InspectorAdapter (phantom-ui)`, `MemoryStore (phantom-brain)`, `PluginRegistry (phantom-renderer)`, `EventLog (phantom-agents)`, `Bundle (phantom-bundle-store, phantom-bundles)`, `PhantomTerminal (phantom-terminal, phantom-app)`, `AgentJournal (phantom-memory)`, `HeadlessActionHandler (phantom-nlp, phantom-agents)`, `AgentManager (phantom-agents)`, `OpenAiBackend (phantom-stt)`, `MockRuntime (phantom-plugins)`, `SemanticParser (phantom-semantic, phantom-agents)`, `PersistentSkillRegistry (phantom-brain, phantom-agents)`, `AgentRuntime (phantom-agents, phantom-app)`, `KeybindRegistry (phantom-ui, phantom-app)`, `Screenshot (phantom-vision)`, `Supervisor (phantom-supervisor, phantom-app)`, `TextRenderer (phantom-renderer)`, `AppCoordinator (phantom-app)`, `BootSequence (phantom-app)`, `CodeDag (phantom-dag, phantom-app)`, `PhantomConfig (phantom, phantom-app)`, `AgentSnapshot (phantom-session)`, `SysmonHandle (phantom-app)`, `HistoryStore (phantom-history)`, `InMemoryStore (phantom-embeddings)`, `SelfTestRunner (phantom-app)`, `ResourceManager (phantom-app)`, `SettingsPanel (phantom-app)`, `McpClient (phantom-mcp)`, `Console (phantom-app)`, `AgentAdapter (phantom-app)`, `JobPool (phantom-app)`, `App (phantom-app)`, `AgentPane (phantom-app)`, `Framework (phantom-context)`, `PhantomLogger (phantom-app)`, `MonitorAdapter (phantom-app)`, `PhantomSettings (phantom-app)`, `App (phantom-app)`, `NotificationCenter (phantom-app)`, `ShutdownGuard (phantom-app)`, `SupervisorClient (phantom-app)`, `App (phantom-app)`, `ProfileScope (phantom-app)`, `build_codebase_context() (phantom-app)`, `App (phantom-app)`, `AgentPane (phantom-app)`, `AgentPane (phantom-app)`?**
+  _High betweenness centrality (0.000) - this node is a cross-community bridge._
+- **Why does `crate:phantom-brain` connect `MemoryStore (phantom-brain)` to `AgentTask (phantom-agents, phantom-session)`, `TerminalAdapter (phantom-app, phantom-scene)`, `PluginRegistry (phantom-renderer)`, `EventLog (phantom-agents)`, `AgentJournal (phantom-memory)`, `SemanticParser (phantom-semantic, phantom-agents)`, `PersistentSkillRegistry (phantom-brain, phantom-agents)`, `AgentRuntime (phantom-agents, phantom-app)`, `InterventionEngine (phantom-brain)`, `ClaudeBackend (phantom-brain)`, `TaskLedger (phantom-brain)`, `GoalPursuit (phantom-brain)`, `Attention (phantom-adapter, phantom-brain)`, `HistoryStore (phantom-history)`, `ProviderCatalog (phantom-brain)`, `DecompositionStep (phantom-brain)`, `Framework (phantom-context)`, `ReconcilerState (phantom-brain)`, `GenerateOptions (phantom-brain)`?**
+  _High betweenness centrality (0.000) - this node is a cross-community bridge._
+- **What connects `T`, `Extract the line number from a source_location like 'L42'.`, `Return a set of line numbers that fall inside #[cfg(test)] modules or     are #[` to the rest of the system?**
+  _13 weakly-connected nodes found - possible documentation gaps or missing edges._
+- **Should `AgentTask (phantom-agents, phantom-session)` be split into smaller, more focused modules?**
   _Cohesion score 0.01 - nodes in this community are weakly interconnected._
-- **Should `Community 1` be split into smaller, more focused modules?**
-  _Cohesion score 0.02 - nodes in this community are weakly interconnected._
-- **Should `Community 2` be split into smaller, more focused modules?**
-  _Cohesion score 0.02 - nodes in this community are weakly interconnected._
-- **Should `Community 3` be split into smaller, more focused modules?**
-  _Cohesion score 0.04 - nodes in this community are weakly interconnected._
-- **Should `Community 4` be split into smaller, more focused modules?**
-  _Cohesion score 0.02 - nodes in this community are weakly interconnected._
-- **Should `Community 5` be split into smaller, more focused modules?**
-  _Cohesion score 0.03 - nodes in this community are weakly interconnected._
+- **Should `TerminalAdapter (phantom-app, phantom-scene)` be split into smaller, more focused modules?**
+  _Cohesion score 0.01 - nodes in this community are weakly interconnected._
+- **Should `InspectorAdapter (phantom-ui)` be split into smaller, more focused modules?**
+  _Cohesion score 0.01 - nodes in this community are weakly interconnected._

--- a/graphify-out/graphify-metadata.json
+++ b/graphify-out/graphify-metadata.json
@@ -1,0 +1,312 @@
+{
+  "root": "/Users/jeremymiranda/Documents/GitHub/phantom",
+  "total_files": 312,
+  "total_words": 506305,
+  "code_files": 283,
+  "nodes": 7477,
+  "edges": 23048,
+  "communities": 107,
+  "test_nodes": 3536,
+  "cross_crate_edges": 398,
+  "crate_dependencies": {
+    "phantom": [
+      "phantom-app",
+      "phantom-protocol",
+      "phantom-renderer",
+      "phantom-terminal",
+      "phantom-ui",
+      "phantom-brain",
+      "phantom-context",
+      "phantom-memory",
+      "phantom-history",
+      "phantom-agents",
+      "phantom-semantic",
+      "phantom-nlp"
+    ],
+    "phantom-ui": [
+      "phantom-renderer",
+      "phantom-adapter"
+    ],
+    "phantom-app": [
+      "phantom-renderer",
+      "phantom-terminal",
+      "phantom-ui",
+      "phantom-protocol",
+      "phantom-brain",
+      "phantom-semantic",
+      "phantom-context",
+      "phantom-memory",
+      "phantom-nlp",
+      "phantom-session",
+      "phantom-agents",
+      "phantom-history",
+      "phantom-scene",
+      "phantom-mcp",
+      "phantom-adapter",
+      "phantom-plugins",
+      "phantom-vision",
+      "phantom-bundles",
+      "phantom-bundle-store",
+      "phantom-embeddings",
+      "phantom-stt",
+      "phantom-dag",
+      "phantom-ui",
+      "phantom-bundle-store",
+      "phantom-stt",
+      "phantom-nlp",
+      "phantom-context"
+    ],
+    "phantom-supervisor": [
+      "phantom-protocol"
+    ],
+    "phantom-history": [
+      "phantom-semantic"
+    ],
+    "phantom-agents": [
+      "phantom-semantic",
+      "phantom-protocol",
+      "phantom-memory"
+    ],
+    "phantom-session": [
+      "phantom-agents",
+      "phantom-context"
+    ],
+    "phantom-nlp": [
+      "phantom-context"
+    ],
+    "phantom-brain": [
+      "phantom-semantic",
+      "phantom-agents",
+      "phantom-adapter",
+      "phantom-context",
+      "phantom-memory",
+      "phantom-history"
+    ],
+    "phantom-adapter": [
+      "phantom-protocol"
+    ],
+    "phantom-recall": [
+      "phantom-bundles"
+    ],
+    "phantom-bundle-store": [
+      "phantom-bundles",
+      "phantom-embeddings",
+      "phantom-bundle-store",
+      "phantom-vision"
+    ]
+  },
+  "scoped_duplicate_ids_fixed": {
+    "lib": [
+      "crates/phantom-semantic/src/lib.rs",
+      "crates/phantom-audio/src/lib.rs",
+      "crates/phantom-voice/src/lib.rs",
+      "crates/phantom-adapter/src/lib.rs",
+      "crates/phantom-vision/src/lib.rs",
+      "crates/phantom-app/src/lib.rs",
+      "crates/phantom-agents/src/lib.rs",
+      "crates/phantom-net/src/lib.rs",
+      "crates/phantom-brain/src/lib.rs",
+      "crates/phantom-plugins/src/lib.rs",
+      "crates/phantom-relay/src/lib.rs",
+      "crates/phantom-scene/src/lib.rs",
+      "crates/phantom-ui/src/lib.rs",
+      "crates/phantom-bundle-store/src/lib.rs",
+      "crates/phantom-mcp/src/lib.rs",
+      "crates/phantom-memory/src/lib.rs",
+      "crates/phantom-context/src/lib.rs",
+      "crates/phantom-dag/src/lib.rs",
+      "crates/phantom-bundles/src/lib.rs",
+      "crates/phantom-session/src/lib.rs",
+      "crates/phantom-nlp/src/lib.rs",
+      "crates/phantom-renderer/src/lib.rs",
+      "crates/phantom-protocol/src/lib.rs",
+      "crates/phantom-stt/src/lib.rs",
+      "crates/phantom-terminal/src/lib.rs",
+      "crates/phantom-history/src/lib.rs",
+      "crates/phantom-embeddings/src/lib.rs",
+      "crates/phantom-recall/src/lib.rs"
+    ],
+    "lib_stream": [
+      "crates/phantom-audio/src/lib.rs",
+      "crates/phantom-stt/src/lib.rs"
+    ],
+    "lib_mockstream": [
+      "crates/phantom-audio/src/lib.rs",
+      "crates/phantom-stt/src/lib.rs"
+    ],
+    "lib_assert_stream_is_send": [
+      "crates/phantom-audio/src/lib.rs",
+      "crates/phantom-voice/src/lib.rs",
+      "crates/phantom-stt/src/lib.rs"
+    ],
+    "lib_assert_backend_is_send_sync": [
+      "crates/phantom-audio/src/lib.rs",
+      "crates/phantom-stt/src/lib.rs"
+    ],
+    "openai": [
+      "crates/phantom-voice/src/openai.rs",
+      "crates/phantom-stt/src/openai.rs",
+      "crates/phantom-embeddings/src/openai.rs"
+    ],
+    "openai_from_env_returns_not_configured_when_missing": [
+      "crates/phantom-voice/src/openai.rs",
+      "crates/phantom-stt/src/openai.rs",
+      "crates/phantom-embeddings/src/openai.rs"
+    ],
+    "openai_from_env_succeeds_with_key": [
+      "crates/phantom-voice/src/openai.rs",
+      "crates/phantom-stt/src/openai.rs",
+      "crates/phantom-embeddings/src/openai.rs"
+    ],
+    "registry": [
+      "crates/phantom-adapter/src/registry.rs",
+      "crates/phantom-plugins/src/registry.rs",
+      "crates/phantom-mcp/src/registry.rs"
+    ],
+    "protocol": [
+      "crates/phantom-adapter/src/protocol.rs",
+      "crates/phantom-mcp/src/protocol.rs"
+    ],
+    "lifecycle": [
+      "crates/phantom-adapter/src/lifecycle.rs",
+      "crates/phantom-agents/src/lifecycle.rs"
+    ],
+    "main": [
+      "crates/phantom-supervisor/src/main.rs",
+      "crates/phantom-relay/src/main.rs",
+      "crates/phantom/src/main.rs"
+    ],
+    "main_install_signal_handlers": [
+      "crates/phantom-supervisor/src/main.rs",
+      "crates/phantom/src/main.rs"
+    ],
+    "main_main": [
+      "crates/phantom-supervisor/src/main.rs",
+      "crates/phantom-relay/src/main.rs",
+      "crates/phantom/src/main.rs"
+    ],
+    "inspector": [
+      "crates/phantom-app/src/inspector.rs",
+      "crates/phantom-app/src/adapters/inspector.rs",
+      "crates/phantom-agents/src/inspector.rs"
+    ],
+    "session": [
+      "crates/phantom-app/src/session.rs",
+      "crates/phantom-relay/src/session.rs",
+      "crates/phantom-bundles/src/session.rs",
+      "crates/phantom-session/src/session.rs"
+    ],
+    "render": [
+      "crates/phantom-app/src/render.rs",
+      "crates/phantom-agents/src/render.rs"
+    ],
+    "video": [
+      "crates/phantom-app/src/video.rs",
+      "crates/phantom-app/src/adapters/video.rs",
+      "crates/phantom-renderer/src/video.rs"
+    ],
+    "input": [
+      "crates/phantom-app/src/input.rs",
+      "crates/phantom-terminal/src/input.rs"
+    ],
+    "notifications": [
+      "crates/phantom-app/src/notifications.rs",
+      "crates/phantom-memory/src/notifications.rs"
+    ],
+    "capture": [
+      "crates/phantom-app/src/capture.rs",
+      "crates/phantom-app/src/agent_pane/capture.rs"
+    ],
+    "events": [
+      "crates/phantom-app/src/agent_pane/events.rs",
+      "crates/phantom-brain/src/events.rs",
+      "crates/phantom-bundles/src/events.rs",
+      "crates/phantom-protocol/src/events.rs"
+    ],
+    "journal": [
+      "crates/phantom-app/src/agent_pane/journal.rs",
+      "crates/phantom-memory/src/journal.rs"
+    ],
+    "mod": [
+      "crates/phantom-app/src/agent_pane/mod.rs",
+      "crates/phantom-app/src/adapters/mod.rs",
+      "crates/phantom-agents/src/dispatch/mod.rs",
+      "crates/phantom-ui/src/widgets/mod.rs"
+    ],
+    "tests": [
+      "crates/phantom-app/src/agent_pane/tests.rs",
+      "crates/phantom-agents/src/dispatch/tests.rs",
+      "crates/phantom-net/src/tests.rs"
+    ],
+    "inspector_agent_ref": [
+      "crates/phantom-app/src/adapters/inspector.rs",
+      "crates/phantom-agents/src/inspector.rs"
+    ],
+    "terminal": [
+      "crates/phantom-app/src/adapters/terminal.rs",
+      "crates/phantom-terminal/src/terminal.rs"
+    ],
+    "agent": [
+      "crates/phantom-app/src/adapters/agent.rs",
+      "crates/phantom-agents/src/agent.rs"
+    ],
+    "router": [
+      "crates/phantom-agents/src/router.rs",
+      "crates/phantom-brain/src/router.rs",
+      "crates/phantom-relay/src/router.rs"
+    ],
+    "context": [
+      "crates/phantom-agents/src/dispatch/context.rs",
+      "crates/phantom-context/src/context.rs"
+    ],
+    "client": [
+      "crates/phantom-net/src/client.rs",
+      "crates/phantom-mcp/src/client.rs"
+    ],
+    "envelope": [
+      "crates/phantom-net/src/envelope.rs",
+      "crates/phantom-relay/src/envelope.rs"
+    ],
+    "envelope_envelope": [
+      "crates/phantom-net/src/envelope.rs",
+      "crates/phantom-relay/src/envelope.rs"
+    ],
+    "server": [
+      "crates/phantom-relay/src/server.rs",
+      "crates/phantom-mcp/src/server.rs"
+    ],
+    "clock": [
+      "crates/phantom-scene/src/clock.rs",
+      "crates/phantom-memory/src/clock.rs"
+    ],
+    "node": [
+      "crates/phantom-scene/src/node.rs",
+      "crates/phantom-dag/src/node.rs"
+    ],
+    "node_nodekind": [
+      "crates/phantom-scene/src/node.rs",
+      "crates/phantom-dag/src/node.rs"
+    ],
+    "recovery": [
+      "crates/phantom-bundle-store/tests/recovery.rs",
+      "crates/phantom-bundle-store/src/recovery.rs"
+    ],
+    "recovery_embedding": [
+      "crates/phantom-bundle-store/tests/recovery.rs",
+      "crates/phantom-bundle-store/src/recovery.rs"
+    ],
+    "lib_embedding": [
+      "crates/phantom-bundle-store/src/lib.rs",
+      "crates/phantom-embeddings/src/lib.rs"
+    ],
+    "store": [
+      "crates/phantom-memory/src/store.rs",
+      "crates/phantom-history/src/store.rs",
+      "crates/phantom-embeddings/src/store.rs"
+    ],
+    "lib_modality": [
+      "crates/phantom-embeddings/src/lib.rs",
+      "crates/phantom-recall/src/lib.rs"
+    ]
+  }
+}

--- a/scripts/graphify_rebuild.py
+++ b/scripts/graphify_rebuild.py
@@ -1,0 +1,1042 @@
+#!/usr/bin/env python3
+"""Rebuild graphify output with scoped IDs, cross-crate edges, test filtering,
+auto-labeled communities, and an agent-optimized report."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import sys
+import tempfile
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import networkx as nx
+from networkx.readwrite import json_graph
+
+from graphify.analyze import god_nodes, suggest_questions, surprising_connections
+from graphify.cluster import cluster, score_all
+from graphify.detect import detect
+from graphify.extract import extract
+from graphify.report import generate
+
+
+LOCAL_RELATIONS = {
+    "calls",
+    "contains",
+    "inherits",
+    "implements",
+    "defines",
+    "declares",
+    "rationale_for",
+    "tests",
+}
+
+# Relations injected by the cross-crate edge pipeline.  These are explicitly
+# non-local and must NOT trigger the same-file validation check.
+CROSS_CRATE_RELATIONS = {
+    "uses",
+    "depends_on",
+    "contains_entity",
+    "crate_depends_on",
+}
+
+
+@dataclass(frozen=True)
+class BuildArtifacts:
+    graph_json: Path
+    report_md: Path
+    metadata_json: Path
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_scoped_id(source_file: str, old_id: str) -> str:
+    path_part = source_file.replace("\\", "/").replace("/", "__").replace(".", "_").replace("-", "_")
+    return f"{path_part}__{old_id}".lower()
+
+
+def _parse_line_number(source_location: str | None) -> int | None:
+    """Extract the line number from a source_location like 'L42'."""
+    if not source_location:
+        return None
+    m = re.match(r"L(\d+)", source_location)
+    return int(m.group(1)) if m else None
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: Tag Test Nodes
+# ---------------------------------------------------------------------------
+
+def _build_test_line_ranges(rs_path: Path) -> set[int]:
+    """Return a set of line numbers that fall inside #[cfg(test)] modules or
+    are #[test] functions.  Uses simple brace-depth tracking."""
+    try:
+        lines = rs_path.read_text(errors="replace").splitlines()
+    except (OSError, UnicodeDecodeError):
+        return set()
+
+    test_lines: set[int] = set()
+    in_test_mod = False
+    brace_depth = 0
+    test_mod_start_depth = 0
+
+    for i, line in enumerate(lines, start=1):
+        stripped = line.strip()
+
+        # Track brace depth
+        brace_depth += stripped.count("{") - stripped.count("}")
+
+        if not in_test_mod:
+            if "#[cfg(test)]" in stripped:
+                in_test_mod = True
+                test_mod_start_depth = brace_depth
+                test_lines.add(i)
+        else:
+            test_lines.add(i)
+            if brace_depth <= test_mod_start_depth and "}" in stripped:
+                in_test_mod = False
+
+        # Individual #[test] functions (outside cfg(test) blocks)
+        if not in_test_mod and stripped == "#[test]":
+            test_lines.add(i)
+            # Tag the next few lines as test (the fn signature + body start)
+            for j in range(i + 1, min(i + 4, len(lines) + 1)):
+                test_lines.add(j)
+
+    return test_lines
+
+
+def tag_test_nodes(extraction: dict, root: Path) -> dict:
+    """Annotate extraction nodes with ``is_test: true`` when they originate
+    from ``#[cfg(test)]`` blocks, ``#[test]`` functions, or ``tests/`` dirs."""
+
+    # Build per-file test line sets (lazily, only for files that appear)
+    file_test_cache: dict[str, set[int]] = {}
+
+    def is_test_location(source_file: str | None, source_location: str | None) -> bool:
+        if not source_file:
+            return False
+        # Anything under a tests/ directory is a test
+        if "/tests/" in source_file or source_file.startswith("tests/"):
+            return True
+        if source_file not in file_test_cache:
+            full_path = root / source_file
+            if full_path.suffix == ".rs" and full_path.exists():
+                file_test_cache[source_file] = _build_test_line_ranges(full_path)
+            else:
+                file_test_cache[source_file] = set()
+        line = _parse_line_number(source_location)
+        if line is None:
+            return False
+        return line in file_test_cache[source_file]
+
+    tagged = dict(extraction)
+
+    # Tag nodes
+    test_node_ids: set[str] = set()
+    new_nodes = []
+    for node in extraction.get("nodes", []):
+        node = dict(node)
+        if is_test_location(node.get("source_file"), node.get("source_location")):
+            node["is_test"] = True
+            test_node_ids.add(node["id"])
+        new_nodes.append(node)
+    tagged["nodes"] = new_nodes
+
+    # Tag edges where both endpoints are test nodes
+    new_edges = []
+    for edge in extraction.get("edges", []):
+        edge = dict(edge)
+        if edge.get("source") in test_node_ids and edge.get("target") in test_node_ids:
+            edge["is_test"] = True
+        new_edges.append(edge)
+    tagged["edges"] = new_edges
+
+    return tagged
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Inject Cross-Crate Edges
+# ---------------------------------------------------------------------------
+
+def _parse_workspace_crate_deps(root: Path) -> tuple[list[str], dict[str, list[str]]]:
+    """Parse workspace Cargo.toml for members and each crate's Cargo.toml for
+    inter-crate dependencies.  Returns (crate_names, crate_deps)."""
+    workspace_toml = root / "Cargo.toml"
+    if not workspace_toml.exists():
+        return [], {}
+
+    text = workspace_toml.read_text()
+    # Extract members list
+    members: list[str] = re.findall(r'"(crates/[^"]+)"', text)
+    crate_names = [m.split("/")[-1] for m in members]
+
+    crate_deps: dict[str, list[str]] = {}
+    for member_path in members:
+        crate_name = member_path.split("/")[-1]
+        crate_toml = root / member_path / "Cargo.toml"
+        if not crate_toml.exists():
+            continue
+        crate_text = crate_toml.read_text()
+        # Find path dependencies pointing to sibling phantom crates
+        dep_names = re.findall(r'(phantom-[\w-]+)\s*=\s*\{[^}]*path\s*=', crate_text)
+        # Filter to workspace members only
+        deps = [d for d in dep_names if d in crate_names]
+        if deps:
+            crate_deps[crate_name] = deps
+
+    return crate_names, crate_deps
+
+
+def _scan_use_imports(root: Path) -> list[dict]:
+    """Scan all .rs files for ``use phantom_*::`` imports.  Returns a list of
+    dicts with source_file, target_crate, imported_items."""
+    imports: list[dict] = []
+    crates_dir = root / "crates"
+    if not crates_dir.exists():
+        return imports
+
+    # Match: use phantom_foo::bar::Baz;  or  use phantom_foo::{A, B};
+    use_re = re.compile(r"use\s+(phantom_\w+)::(.+?);")
+
+    for rs_file in crates_dir.rglob("*.rs"):
+        try:
+            text = rs_file.read_text(errors="replace")
+        except OSError:
+            continue
+        rel_path = str(rs_file.relative_to(root))
+        for m in use_re.finditer(text):
+            crate_mod = m.group(1)  # e.g. phantom_agents
+            import_path = m.group(2).strip()  # e.g. agent::PauseReason or {A, B}
+            target_crate = crate_mod.replace("_", "-")
+
+            # Extract individual items from the import path
+            if import_path.startswith("{"):
+                items = [i.strip().split("::")[-1] for i in import_path.strip("{}").split(",")]
+            else:
+                items = [import_path.split("::")[-1].strip()]
+            # Clean up items (remove aliases, wildcards)
+            items = [i.split(" as ")[0].strip() for i in items if i.strip() and i.strip() != "*"]
+
+            for item in items:
+                imports.append({
+                    "source_file": rel_path,
+                    "target_crate": target_crate,
+                    "item": item,
+                })
+
+    return imports
+
+
+def inject_cross_crate_edges(
+    extraction: dict, root: Path
+) -> tuple[dict, dict[str, list[str]]]:
+    """Add cross-crate ``uses`` edges from ``use phantom_*`` import analysis."""
+    crate_names, crate_deps = _parse_workspace_crate_deps(root)
+    imports = _scan_use_imports(root)
+
+    if not imports:
+        return extraction, crate_deps
+
+    # Build a lookup: (crate_name, label) -> node_id for resolution
+    label_to_nid: dict[tuple[str, str], str] = {}
+    for node in extraction.get("nodes", []):
+        sf = node.get("source_file", "")
+        label = node.get("label", "")
+        if not sf or not label:
+            continue
+        # Determine which crate this node belongs to
+        parts = sf.split("/")
+        if len(parts) >= 2 and parts[0] == "crates":
+            crate = parts[1]
+            key = (crate, label)
+            if key not in label_to_nid:
+                label_to_nid[key] = node["id"]
+
+    # Build file-node lookup: source_file -> node_id (for file-level nodes)
+    file_to_nid: dict[str, str] = {}
+    for node in extraction.get("nodes", []):
+        sf = node.get("source_file", "")
+        if sf and node.get("file_type") == "code":
+            # File-level nodes typically have label == filename
+            if node.get("label", "").endswith(".rs"):
+                file_to_nid[sf] = node["id"]
+
+    # Source file -> its node ID (the file-level node of the importing file)
+    import_source_nids: dict[str, str] = {}
+    for node in extraction.get("nodes", []):
+        sf = node.get("source_file", "")
+        if sf and node.get("label", "").endswith(".rs"):
+            import_source_nids[sf] = node["id"]
+
+    new_edges = list(extraction.get("edges", []))
+    edges_added = 0
+
+    for imp in imports:
+        source_file = imp["source_file"]
+        target_crate = imp["target_crate"]
+        item = imp["item"]
+
+        # Find source node (file-level node of the importing file)
+        source_nid = import_source_nids.get(source_file)
+        if not source_nid:
+            continue
+
+        # Try to resolve target to a specific entity node
+        target_nid = label_to_nid.get((target_crate, item))
+
+        if target_nid:
+            new_edges.append({
+                "source": source_nid,
+                "target": target_nid,
+                "relation": "uses",
+                "confidence": "INFERRED",
+                "weight": 2.0,
+                "cross_crate": True,
+                "source_file": source_file,
+                "source_location": "L0",
+            })
+            edges_added += 1
+        else:
+            # Fall back to lib.rs node of the target crate
+            lib_file = f"crates/{target_crate}/src/lib.rs"
+            fallback_nid = file_to_nid.get(lib_file)
+            if fallback_nid:
+                new_edges.append({
+                    "source": source_nid,
+                    "target": fallback_nid,
+                    "relation": "depends_on",
+                    "confidence": "INFERRED",
+                    "weight": 1.5,
+                    "cross_crate": True,
+                    "source_file": source_file,
+                    "source_location": "L0",
+                })
+                edges_added += 1
+
+    result = dict(extraction)
+    result["edges"] = new_edges
+    print(f"  Cross-crate edges injected: {edges_added}")
+    return result, crate_deps
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: Crate Summary Nodes
+# ---------------------------------------------------------------------------
+
+def add_crate_summary_nodes(
+    graph: nx.DiGraph, root: Path, crate_deps: dict[str, list[str]]
+) -> None:
+    """Add synthetic ``crate:NAME`` hub nodes and crate-to-crate dependency edges."""
+    crates_dir = root / "crates"
+    if not crates_dir.exists():
+        return
+
+    crate_dirs = sorted(
+        d.name for d in crates_dir.iterdir()
+        if d.is_dir() and (d / "Cargo.toml").exists()
+    )
+
+    # Map existing nodes to their crate
+    crate_members: dict[str, list[str]] = defaultdict(list)
+    for nid, attrs in graph.nodes(data=True):
+        sf = attrs.get("source_file", "")
+        parts = sf.split("/") if sf else []
+        if len(parts) >= 2 and parts[0] == "crates":
+            crate_members[parts[1]].append(nid)
+
+    for crate_name in crate_dirs:
+        crate_nid = f"crate:{crate_name}"
+        graph.add_node(
+            crate_nid,
+            label=crate_nid,
+            file_type="crate",
+            source_file=f"crates/{crate_name}/Cargo.toml",
+            source_location="L1",
+            is_synthetic=True,
+        )
+        # Connect to member entities (low weight so it doesn't dominate clustering)
+        for member_nid in crate_members.get(crate_name, []):
+            graph.add_edge(
+                crate_nid, member_nid,
+                relation="contains_entity",
+                weight=0.5,
+                _src=crate_nid,
+                _tgt=member_nid,
+            )
+
+    # Crate-to-crate dependency edges (high weight = architectural backbone)
+    for crate_name, deps in crate_deps.items():
+        src = f"crate:{crate_name}"
+        if src not in graph:
+            continue
+        for dep in deps:
+            tgt = f"crate:{dep}"
+            if tgt not in graph:
+                continue
+            graph.add_edge(
+                src, tgt,
+                relation="crate_depends_on",
+                weight=3.0,
+                _src=src,
+                _tgt=tgt,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: Filter Test Nodes for Clustering
+# ---------------------------------------------------------------------------
+
+def build_clustering_subgraph(graph: nx.DiGraph) -> nx.DiGraph:
+    """Return a subgraph excluding test and synthetic nodes for cleaner
+    community detection."""
+    keep = [
+        nid for nid, attrs in graph.nodes(data=True)
+        if not attrs.get("is_test") and not attrs.get("is_synthetic")
+    ]
+    return graph.subgraph(keep).copy()
+
+
+def assign_excluded_nodes(
+    full_graph: nx.DiGraph,
+    clustering_graph: nx.DiGraph,
+    communities: dict[int, list[str]],
+) -> dict[int, list[str]]:
+    """Assign test and synthetic nodes to the nearest community."""
+    community_by_node = node_community_map(communities)
+    clustered = set(clustering_graph.nodes)
+
+    for nid in full_graph.nodes:
+        if nid in clustered:
+            continue
+
+        # Find the community of the most-connected non-excluded neighbor
+        neighbor_communities: Counter[int] = Counter()
+        for neighbor in full_graph.predecessors(nid):
+            if neighbor in community_by_node:
+                neighbor_communities[community_by_node[neighbor]] += 1
+        for neighbor in full_graph.successors(nid):
+            if neighbor in community_by_node:
+                neighbor_communities[community_by_node[neighbor]] += 1
+
+        if neighbor_communities:
+            best = neighbor_communities.most_common(1)[0][0]
+        else:
+            best = 0  # default community
+
+        community_by_node[nid] = best
+        communities.setdefault(best, []).append(nid)
+
+    return communities
+
+
+# ---------------------------------------------------------------------------
+# Phase 5: Auto-Label Communities
+# ---------------------------------------------------------------------------
+
+def label_communities(
+    graph: nx.DiGraph, communities: dict[int, list[str]]
+) -> dict[int, str]:
+    """Generate semantic labels for communities based on dominant crate and
+    highest-degree non-test entity."""
+    labels: dict[int, str] = {}
+
+    for cid, members in communities.items():
+        # Count crate membership
+        crate_counts: Counter[str] = Counter()
+        for nid in members:
+            attrs = graph.nodes.get(nid, {})
+            if attrs.get("is_test") or attrs.get("is_synthetic"):
+                continue
+            sf = attrs.get("source_file", "")
+            parts = sf.split("/") if sf else []
+            if len(parts) >= 2 and parts[0] == "crates":
+                crate_counts[parts[1]] += 1
+
+        if not crate_counts:
+            labels[cid] = f"Community {cid}"
+            continue
+
+        # Find dominant crate(s)
+        total = sum(crate_counts.values())
+        top_crates = crate_counts.most_common(3)
+        dominant = top_crates[0][0]
+        dominant_pct = top_crates[0][1] / total if total else 0
+
+        # Find keyword: highest-degree non-test struct/trait (no parens in label)
+        keyword = ""
+        best_degree = -1
+        for nid in members:
+            attrs = graph.nodes.get(nid, {})
+            if attrs.get("is_test") or attrs.get("is_synthetic"):
+                continue
+            lbl = attrs.get("label", "")
+            # Prefer structs/enums/traits (no parentheses = not a function)
+            if "(" in lbl or ")" in lbl or lbl.endswith(".rs"):
+                continue
+            deg = graph.degree(nid)
+            if deg > best_degree:
+                best_degree = deg
+                keyword = lbl
+
+        if not keyword:
+            # Fall back to highest-degree function
+            for nid in members:
+                attrs = graph.nodes.get(nid, {})
+                if attrs.get("is_test") or attrs.get("is_synthetic"):
+                    continue
+                lbl = attrs.get("label", "")
+                if lbl.endswith(".rs"):
+                    continue
+                deg = graph.degree(nid)
+                if deg > best_degree:
+                    best_degree = deg
+                    keyword = lbl
+
+        # Build label
+        if dominant_pct >= 0.8 or len(top_crates) == 1:
+            crate_part = dominant
+        elif len(top_crates) >= 2 and top_crates[1][1] / total >= 0.2:
+            crate_part = f"{top_crates[0][0]}, {top_crates[1][0]}"
+        else:
+            crate_part = dominant
+
+        if keyword:
+            labels[cid] = f"{keyword} ({crate_part})"
+        else:
+            labels[cid] = f"{crate_part}"
+
+    return labels
+
+
+# ---------------------------------------------------------------------------
+# Phase 6: Prune Noise
+# ---------------------------------------------------------------------------
+
+def prune_noise(
+    graph: nx.DiGraph, communities: dict[int, list[str]]
+) -> tuple[nx.DiGraph, dict[int, list[str]]]:
+    """Remove isolated nodes and merge thin communities."""
+    community_by_node = node_community_map(communities)
+
+    # Remove degree-0 nodes (truly isolated)
+    isolates = [nid for nid in graph.nodes if graph.degree(nid) == 0]
+    for nid in isolates:
+        cid = community_by_node.get(nid)
+        if cid is not None and nid in communities.get(cid, []):
+            communities[cid].remove(nid)
+        graph.remove_node(nid)
+    if isolates:
+        print(f"  Pruned {len(isolates)} isolated nodes")
+
+    # Deduplicate: if both imports_from and uses exist between same pair, drop imports_from
+    edges_to_remove = []
+    for u, v, data in graph.edges(data=True):
+        if data.get("relation") == "imports_from":
+            # Check if a 'uses' edge exists for the same pair
+            if graph.has_edge(u, v):
+                for _, edata in graph[u][v].items() if graph.is_multigraph() else [(0, graph[u][v])]:
+                    if isinstance(edata, dict) and edata.get("relation") == "uses":
+                        edges_to_remove.append((u, v, "imports_from"))
+                        break
+    for u, v, _rel in edges_to_remove:
+        # Only remove if the edge is still imports_from
+        if graph.has_edge(u, v) and graph[u][v].get("relation") == "imports_from":
+            graph.remove_edge(u, v)
+    if edges_to_remove:
+        print(f"  Deduplicated {len(edges_to_remove)} redundant imports_from edges")
+
+    # Merge thin communities (<3 non-test nodes) into nearest neighbor
+    community_by_node = node_community_map(communities)  # refresh
+    thin_cids = []
+    for cid, members in communities.items():
+        non_test = [m for m in members if not graph.nodes.get(m, {}).get("is_test")]
+        if len(non_test) < 3:
+            thin_cids.append(cid)
+
+    merged_count = 0
+    for cid in thin_cids:
+        members = communities.get(cid, [])
+        if not members:
+            continue
+        # Find the most-connected neighbor community
+        neighbor_cids: Counter[int] = Counter()
+        for nid in members:
+            for neighbor in list(graph.predecessors(nid)) + list(graph.successors(nid)):
+                ncid = community_by_node.get(neighbor)
+                if ncid is not None and ncid != cid and ncid not in thin_cids:
+                    neighbor_cids[ncid] += 1
+
+        if not neighbor_cids:
+            continue  # leave it as-is if no connections to other communities
+
+        target_cid = neighbor_cids.most_common(1)[0][0]
+        for nid in members:
+            community_by_node[nid] = target_cid
+            communities.setdefault(target_cid, []).append(nid)
+        del communities[cid]
+        merged_count += 1
+
+    if merged_count:
+        print(f"  Merged {merged_count} thin communities")
+
+    # Remove empty communities
+    communities = {cid: members for cid, members in communities.items() if members}
+
+    return graph, communities
+
+
+# ---------------------------------------------------------------------------
+# Phase 7: Enhanced Report
+# ---------------------------------------------------------------------------
+
+def enhance_report(
+    report: str,
+    graph: nx.DiGraph,
+    crate_deps: dict[str, list[str]],
+    communities: dict[int, list[str]],
+    labels: dict[int, str],
+) -> str:
+    """Post-process the generated report to add agent-useful sections."""
+    sections: list[str] = []
+
+    # --- Crate Dependency Map ---
+    dep_section = "\n## Crate Dependency Map\n\n"
+    # Build tier assignments
+    all_crates = set()
+    for c in crate_deps:
+        all_crates.add(c)
+        for d in crate_deps[c]:
+            all_crates.add(d)
+    # Also include crates with no deps
+    for nid in graph.nodes:
+        if nid.startswith("crate:"):
+            all_crates.add(nid.removeprefix("crate:"))
+
+    # Compute tiers: tier 0 = no phantom deps, tier N = max(dep tiers) + 1
+    tiers: dict[str, int] = {}
+
+    def get_tier(crate: str, visited: set[str] | None = None) -> int:
+        if crate in tiers:
+            return tiers[crate]
+        if visited is None:
+            visited = set()
+        if crate in visited:
+            return 0
+        visited.add(crate)
+        deps = crate_deps.get(crate, [])
+        if not deps:
+            tiers[crate] = 0
+            return 0
+        t = max(get_tier(d, visited) for d in deps) + 1
+        tiers[crate] = t
+        return t
+
+    for c in sorted(all_crates):
+        get_tier(c)
+
+    max_tier = max(tiers.values()) if tiers else 0
+    dep_section += "| Tier | Crates | Dependencies |\n|------|--------|-------------|\n"
+    for t in range(max_tier + 1):
+        tier_crates = sorted(c for c, tier in tiers.items() if tier == t)
+        for c in tier_crates:
+            deps = ", ".join(sorted(crate_deps.get(c, []))) or "(none)"
+            dep_section += f"| {t} | `{c}` | {deps} |\n"
+    sections.append(dep_section)
+
+    # --- Cross-Crate Coupling ---
+    coupling_section = "\n## Cross-Crate Coupling (most imported types)\n\n"
+    # Count how many distinct source crates import each target entity
+    import_counts: Counter[str] = Counter()
+    for u, v, data in graph.edges(data=True):
+        if data.get("relation") == "uses" and data.get("cross_crate"):
+            target_label = graph.nodes[v].get("label", v)
+            import_counts[target_label] += 1
+
+    if import_counts:
+        coupling_section += "| Entity | Imported by N files |\n|--------|--------------------|\n"
+        for label, count in import_counts.most_common(15):
+            coupling_section += f"| `{label}` | {count} |\n"
+    else:
+        coupling_section += "No cross-crate imports detected.\n"
+    sections.append(coupling_section)
+
+    # --- Test Coverage Summary ---
+    test_section = "\n## Test Coverage Summary\n\n"
+    test_nodes = sum(1 for _, d in graph.nodes(data=True) if d.get("is_test"))
+    prod_nodes = sum(1 for _, d in graph.nodes(data=True) if not d.get("is_test") and not d.get("is_synthetic"))
+    test_section += f"- {prod_nodes} production entities, {test_nodes} test entities\n"
+    test_section += f"- Test nodes are tagged `is_test: true` in graph.json but excluded from community detection\n"
+    sections.append(test_section)
+
+    # Inject after ## Summary
+    injection = "\n".join(sections)
+    marker = "## God Nodes"
+    if marker in report:
+        report = report.replace(marker, injection + "\n" + marker)
+    else:
+        report += injection
+
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Existing: Relativize, Normalize, Build, Export, Validate
+# ---------------------------------------------------------------------------
+
+def relativize_extraction(extraction: dict, root: Path) -> dict:
+    def relativize(path_str: str | None) -> str | None:
+        if not path_str:
+            return path_str
+        try:
+            return str(Path(path_str).resolve().relative_to(root))
+        except Exception:
+            return path_str
+
+    normalized = dict(extraction)
+    normalized["nodes"] = []
+    normalized["edges"] = []
+
+    for node in extraction.get("nodes", []):
+        rewritten = dict(node)
+        rewritten["source_file"] = relativize(node.get("source_file"))
+        normalized["nodes"].append(rewritten)
+
+    for edge in extraction.get("edges", []):
+        rewritten = dict(edge)
+        rewritten["source_file"] = relativize(edge.get("source_file"))
+        normalized["edges"].append(rewritten)
+
+    return normalized
+
+
+def normalize_extraction(extraction: dict) -> tuple[dict, dict[str, list[str]]]:
+    nodes = extraction.get("nodes", [])
+    edges = extraction.get("edges", [])
+
+    id_to_nodes: dict[str, list[dict]] = defaultdict(list)
+    for node in nodes:
+        id_to_nodes[node["id"]].append(node)
+
+    duplicated_ids = {node_id for node_id, items in id_to_nodes.items() if len(items) > 1}
+    renamed_nodes: dict[tuple[str, str], str] = {}
+    new_nodes: list[dict] = []
+
+    for node in nodes:
+        source_file = node.get("source_file")
+        old_id = node["id"]
+        if old_id in duplicated_ids and source_file:
+            new_id = make_scoped_id(source_file, old_id)
+            renamed_nodes[(old_id, source_file)] = new_id
+        else:
+            new_id = old_id
+        new_node = dict(node)
+        new_node["id"] = new_id
+        new_nodes.append(new_node)
+
+    node_ids = {node["id"] for node in new_nodes}
+
+    def resolve(edge_endpoint: str, edge_source_file: str | None, relation: str, role: str) -> str:
+        if edge_endpoint not in duplicated_ids:
+            return edge_endpoint
+
+        if edge_source_file and (edge_endpoint, edge_source_file) in renamed_nodes:
+            return renamed_nodes[(edge_endpoint, edge_source_file)]
+
+        if role == "target" and relation in LOCAL_RELATIONS and edge_source_file:
+            scoped = renamed_nodes.get((edge_endpoint, edge_source_file))
+            if scoped:
+                return scoped
+
+        candidates = [node for node in id_to_nodes[edge_endpoint] if node.get("source_file")]
+        if len(candidates) == 1:
+            scoped = renamed_nodes.get((edge_endpoint, candidates[0]["source_file"]))
+            if scoped:
+                return scoped
+
+        return edge_endpoint
+
+    new_edges: list[dict] = []
+    unresolved_duplicates: dict[str, list[str]] = defaultdict(list)
+    for edge in edges:
+        source_file = edge.get("source_file")
+        new_edge = dict(edge)
+        new_edge["source"] = resolve(edge["source"], source_file, edge.get("relation", ""), "source")
+        new_edge["target"] = resolve(edge["target"], source_file, edge.get("relation", ""), "target")
+        if new_edge["source"] not in node_ids or new_edge["target"] not in node_ids:
+            unresolved_duplicates[edge.get("relation", "unknown")].append(
+                f"{edge['source']}->{edge['target']} @ {source_file or 'unknown'}"
+            )
+            continue
+        new_edges.append(new_edge)
+
+    normalized = dict(extraction)
+    normalized["nodes"] = new_nodes
+    normalized["edges"] = new_edges
+    duplicate_map = {
+        node_id: [item.get("source_file", "<unknown>") for item in items]
+        for node_id, items in id_to_nodes.items()
+        if node_id in duplicated_ids
+    }
+    if unresolved_duplicates:
+        normalized["repair_warnings"] = {
+            "dropped_edges": unresolved_duplicates,
+        }
+    return normalized, duplicate_map
+
+
+def build_directed_graph(extraction: dict) -> nx.DiGraph:
+    graph = nx.DiGraph()
+    for node in extraction.get("nodes", []):
+        graph.add_node(node["id"], **{k: v for k, v in node.items() if k != "id"})
+    node_ids = set(graph.nodes)
+    for edge in extraction.get("edges", []):
+        source = edge["source"]
+        target = edge["target"]
+        if source not in node_ids or target not in node_ids:
+            continue
+        attrs = {k: v for k, v in edge.items() if k not in ("source", "target")}
+        attrs["_src"] = source
+        attrs["_tgt"] = target
+        graph.add_edge(source, target, **attrs)
+    graph.graph["hyperedges"] = extraction.get("hyperedges", [])
+    return graph
+
+
+def node_community_map(communities: dict[int, list[str]]) -> dict[str, int]:
+    result: dict[str, int] = {}
+    for community_id, members in communities.items():
+        for member in members:
+            result[member] = community_id
+    return result
+
+
+def export_graph(graph: nx.DiGraph, communities: dict[int, list[str]], output_path: Path) -> None:
+    community_by_node = node_community_map(communities)
+    data = json_graph.node_link_data(graph, edges="links")
+    for node in data["nodes"]:
+        node["community"] = community_by_node.get(node["id"])
+    for link in data["links"]:
+        if "confidence_score" not in link:
+            confidence = link.get("confidence", "EXTRACTED")
+            link["confidence_score"] = {"EXTRACTED": 1.0, "INFERRED": 0.7, "AMBIGUOUS": 0.4}.get(confidence, 1.0)
+    data["hyperedges"] = graph.graph.get("hyperedges", [])
+    output_path.write_text(json.dumps(data, indent=2))
+
+
+def validate_graph_json(graph_json_path: Path) -> list[str]:
+    data = json.loads(graph_json_path.read_text())
+    errors: list[str] = []
+
+    if not data.get("directed", False):
+        errors.append("graph.json is not directed")
+
+    node_ids = [node["id"] for node in data.get("nodes", [])]
+    duplicate_ids = [node_id for node_id, count in Counter(node_ids).items() if count > 1]
+    if duplicate_ids:
+        errors.append(f"duplicate node ids detected: {duplicate_ids[:10]}")
+
+    node_sources = {node["id"]: node.get("source_file") for node in data.get("nodes", [])}
+    for index, link in enumerate(data.get("links", []), start=1):
+        source = link.get("source")
+        target = link.get("target")
+        if source != link.get("_src") or target != link.get("_tgt"):
+            errors.append(f"link {index} has mismatched source/_src or target/_tgt")
+            break
+        if source not in node_sources or target not in node_sources:
+            errors.append(f"link {index} references missing node ids")
+            break
+        relation = link.get("relation", "")
+        # Skip cross-crate relation checks — they are expected to cross files
+        if relation in CROSS_CRATE_RELATIONS:
+            continue
+        if relation == "contains" and node_sources[source] != node_sources[target]:
+            errors.append(
+                f"contains edge crosses files: {source} ({node_sources[source]}) -> {target} ({node_sources[target]})"
+            )
+            break
+        if relation in LOCAL_RELATIONS and "__" not in source and "__" not in target:
+            if source == target:
+                errors.append(f"self-loop on local relation at link {index}")
+                break
+
+    return errors
+
+
+def write_metadata(
+    output_path: Path,
+    *,
+    root: Path,
+    detection: dict,
+    duplicate_map: dict[str, list[str]],
+    graph: nx.DiGraph,
+    communities: dict[int, list[str]],
+    crate_deps: dict[str, list[str]],
+) -> None:
+    test_nodes = sum(1 for _, d in graph.nodes(data=True) if d.get("is_test"))
+    cross_crate_edges = sum(1 for _, _, d in graph.edges(data=True) if d.get("cross_crate"))
+    payload = {
+        "root": str(root),
+        "total_files": detection.get("total_files", 0),
+        "total_words": detection.get("total_words", 0),
+        "code_files": len(detection.get("files", {}).get("code", [])),
+        "nodes": graph.number_of_nodes(),
+        "edges": graph.number_of_edges(),
+        "communities": len(communities),
+        "test_nodes": test_nodes,
+        "cross_crate_edges": cross_crate_edges,
+        "crate_dependencies": crate_deps,
+        "scoped_duplicate_ids_fixed": duplicate_map,
+    }
+    output_path.write_text(json.dumps(payload, indent=2))
+
+
+# ---------------------------------------------------------------------------
+# Pipeline
+# ---------------------------------------------------------------------------
+
+def stage_build(root: Path, staging_dir: Path) -> BuildArtifacts:
+    print("Step 1: Detecting files...")
+    detection = detect(root)
+    code_files = [Path(path) for path in detection["files"]["code"]]
+    if not code_files:
+        raise SystemExit("No code files detected")
+    print(f"  Found {len(code_files)} code files")
+
+    print("Step 2: Extracting entities and relationships...")
+    extraction = relativize_extraction(extract(code_files), root)
+    print(f"  Extracted {len(extraction.get('nodes', []))} nodes, {len(extraction.get('edges', []))} edges")
+
+    print("Step 3: Tagging test nodes...")
+    extraction = tag_test_nodes(extraction, root)
+    test_count = sum(1 for n in extraction["nodes"] if n.get("is_test"))
+    print(f"  Tagged {test_count} test nodes")
+
+    print("Step 4: Normalizing duplicate IDs...")
+    normalized, duplicate_map = normalize_extraction(extraction)
+
+    print("Step 5: Injecting cross-crate edges...")
+    normalized, crate_deps = inject_cross_crate_edges(normalized, root)
+
+    print("Step 6: Building directed graph...")
+    graph = build_directed_graph(normalized)
+    print(f"  Graph: {graph.number_of_nodes()} nodes, {graph.number_of_edges()} edges")
+
+    print("Step 7: Adding crate summary nodes...")
+    add_crate_summary_nodes(graph, root, crate_deps)
+    crate_count = sum(1 for n in graph.nodes if n.startswith("crate:"))
+    print(f"  Added {crate_count} crate nodes")
+
+    print("Step 8: Clustering (test-filtered)...")
+    clustering_graph = build_clustering_subgraph(graph)
+    print(f"  Clustering on {clustering_graph.number_of_nodes()} non-test nodes")
+    communities = cluster(clustering_graph)
+    communities = assign_excluded_nodes(graph, clustering_graph, communities)
+    print(f"  Detected {len(communities)} communities")
+
+    print("Step 9: Pruning noise...")
+    graph, communities = prune_noise(graph, communities)
+    print(f"  After pruning: {graph.number_of_nodes()} nodes, {len(communities)} communities")
+
+    print("Step 10: Labeling communities...")
+    labels = label_communities(graph, communities)
+
+    cohesion = score_all(graph, communities)
+    gods = god_nodes(clustering_graph)
+    surprises = surprising_connections(graph, communities)
+    questions = suggest_questions(graph, communities, labels)
+
+    staging_dir.mkdir(parents=True, exist_ok=True)
+    graph_json = staging_dir / "graph.json"
+    report_md = staging_dir / "GRAPH_REPORT.md"
+    metadata_json = staging_dir / "graphify-metadata.json"
+
+    print("Step 11: Exporting graph and report...")
+    export_graph(graph, communities, graph_json)
+
+    report_text = generate(
+        graph,
+        communities,
+        cohesion,
+        labels,
+        gods,
+        surprises,
+        detection,
+        {
+            "input": extraction.get("input_tokens", 0),
+            "output": extraction.get("output_tokens", 0),
+        },
+        root.name,
+        suggested_questions=questions,
+    )
+    report_text = enhance_report(report_text, graph, crate_deps, communities, labels)
+    report_md.write_text(report_text)
+
+    write_metadata(
+        metadata_json,
+        root=root,
+        detection=detection,
+        duplicate_map=duplicate_map,
+        graph=graph,
+        communities=communities,
+        crate_deps=crate_deps,
+    )
+    return BuildArtifacts(graph_json=graph_json, report_md=report_md, metadata_json=metadata_json)
+
+
+def publish(staged: BuildArtifacts, destination: Path) -> None:
+    destination.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(staged.graph_json, destination / "graph.json")
+    shutil.copy2(staged.report_md, destination / "GRAPH_REPORT.md")
+    shutil.copy2(staged.metadata_json, destination / "graphify-metadata.json")
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Rebuild graphify output safely with scoped ids and validation.")
+    parser.add_argument("--root", default=".", help="Repository root to scan.")
+    parser.add_argument("--output", default="graphify-out", help="Canonical output directory.")
+    parser.add_argument(
+        "--staging-dir",
+        default=None,
+        help="Optional staging directory. Defaults to a temporary directory under .graphify-tmp/.",
+    )
+    parser.add_argument("--keep-staging", action="store_true", help="Keep the staged build directory on success.")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    root = Path(args.root).resolve()
+    output = (root / args.output).resolve()
+
+    if args.staging_dir:
+        staging_dir = Path(args.staging_dir).resolve()
+        cleanup = False
+    else:
+        tmp_root = root / ".graphify-tmp"
+        tmp_root.mkdir(exist_ok=True)
+        staging_dir = Path(tempfile.mkdtemp(prefix="build-", dir=tmp_root))
+        cleanup = not args.keep_staging
+
+    try:
+        artifacts = stage_build(root, staging_dir)
+        errors = validate_graph_json(artifacts.graph_json)
+        if errors:
+            print("Graph validation failed:", file=sys.stderr)
+            for error in errors:
+                print(f"  - {error}", file=sys.stderr)
+            return 1
+        publish(artifacts, output)
+        print(f"Published graph to {output}")
+        print(f"Staged build at {staging_dir}")
+        return 0
+    finally:
+        if cleanup and staging_dir.exists():
+            shutil.rmtree(staging_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add `scripts/graphify_rebuild.py` to drive a reproducible graphify rebuild
- Add `.graphifyignore` and gitignore entries for graphify staging/cache output
- Refresh `graphify-out/` (GRAPH_REPORT, graph.json, metadata) against current main

## Test plan
- [ ] `python3 scripts/graphify_rebuild.py` runs cleanly
- [ ] `graphify-out/GRAPH_REPORT.md` opens and matches current crate inventory
- [ ] No tracked files under `graphify-out/cache/` or `.graphify-tmp/`