### PR TITLE
feat(phantom-context): token-budgeted context injection primitive

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,47 @@
+# PLAN: Token-Budgeted Context Injection
+
+## Steps
+
+1. Create `crates/phantom-context/src/context_budget.rs` containing:
+   - `ContextBudget` struct with three usize fields and a `Default` impl
+     matching Claude Code's 5/5K/25K reference values.
+   - `TokenCounter` trait with `count(&self, s: &str) -> usize`.
+   - `WordCounter` zero-sized type implementing `TokenCounter` via
+     `s.split_whitespace().count()`.
+   - `BudgetedItem` trait with associated type `Recency: Ord`, `recency_key`,
+     `payload`, and `identifier` methods.
+   - `SelectedItem` struct with `identifier`, `payload`, `token_cost`.
+   - `ContextBudget::select` implementing the algorithm in SPEC.md.
+
+2. Export the module from `crates/phantom-context/src/lib.rs` with a single
+   `pub mod context_budget;` line. Do not re-export via glob to avoid name
+   collisions with `context::*`.
+
+3. Add unit tests inside the new module under a `#[cfg(test)] mod tests`
+   block. Cover all six cases listed in TASKS.md.
+
+4. Build and test only the `phantom-context` crate to stay within scope:
+   - `cargo build -p phantom-context`
+   - `cargo test -p phantom-context`
+
+5. Commit the change on the current worktree branch with a Conventional
+   Commits message: `feat(phantom-context): token-budgeted context injection
+   primitive`.
+
+6. Push the branch and open a draft PR via `gh pr create --draft` with the
+   prescribed title and HEREDOC body.
+
+## Risks
+
+- Truncation by token (word) count rather than byte count means the payload
+  string must be reconstructed from the kept words. Use
+  `s.split_whitespace().take(cap).collect::<Vec<_>>().join(" ")`.
+- The `total_token_cap` mid-iteration drop rule means a small item further
+  down the list might still fit after a large one is dropped. The test
+  `total_cap_hit_mid_iteration` pins that behavior.
+
+## Out of scope
+
+- BPE tokenizer integration.
+- Real skill-file discovery or filesystem walks.
+- Wiring into `phantom-agents::spawn` or any caller in this PR.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,91 @@
+# SPEC: Token-Budgeted Context Injection Primitive
+
+## Problem
+
+Phantom's `phantom-context` crate assembles agent prompt context without any
+size ceiling. As session memory, skill files, and recent history grow, the
+prompt payload grows without bound. Claude Code's reference pattern caps each
+of the top-5 most recent skill files at 5K tokens with a 25K aggregate ceiling.
+This SPEC introduces an equivalent primitive in Phantom.
+
+## Scope
+
+Standalone module. No wiring into agent spawn in this slice. Public surface
+limited to one new module exported through `phantom-context::lib.rs`.
+
+## Public API
+
+Module: `crates/phantom-context/src/context_budget.rs`.
+
+### `ContextBudget`
+
+```rust
+pub struct ContextBudget {
+    pub max_items: usize,
+    pub per_item_token_cap: usize,
+    pub total_token_cap: usize,
+}
+```
+
+Default values mirror Claude Code: `max_items = 5`, `per_item_token_cap = 5_000`,
+`total_token_cap = 25_000`.
+
+### `TokenCounter` trait
+
+```rust
+pub trait TokenCounter {
+    fn count(&self, s: &str) -> usize;
+}
+```
+
+Default impl `WordCounter` splits on ASCII whitespace.
+
+### `BudgetedItem` trait
+
+```rust
+pub trait BudgetedItem {
+    type Recency: Ord;
+    fn recency_key(&self) -> Self::Recency;
+    fn payload(&self) -> &str;
+    fn identifier(&self) -> &str;
+}
+```
+
+### `SelectedItem`
+
+```rust
+pub struct SelectedItem {
+    pub identifier: String,
+    pub payload: String,
+    pub token_cost: usize,
+}
+```
+
+### Selection method
+
+```rust
+impl ContextBudget {
+    pub fn select<I, C>(&self, items: impl IntoIterator<Item = I>, counter: &C)
+        -> Vec<SelectedItem>
+    where
+        I: BudgetedItem,
+        C: TokenCounter;
+}
+```
+
+## Algorithm
+
+1. Collect items into a vec.
+2. Sort by `recency_key` descending (most-recent first).
+3. Take the first `max_items`.
+4. For each item: count tokens; if over `per_item_token_cap`, truncate payload
+   to the first `per_item_token_cap` tokens.
+5. Accumulate total cost. If adding the next item would exceed
+   `total_token_cap`, drop that item (do not truncate further) and continue
+   evaluating subsequent items in case any are smaller and still fit.
+
+## Non-goals
+
+- Real BPE tokenization (the trait is the seam for that).
+- Persistence, caching, or reinjection on compaction.
+- Wiring into `phantom-agents` spawn paths.

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,50 @@
+# TASKS
+
+## Implementation
+
+- [ ] Add `crates/phantom-context/src/context_budget.rs` with the module body.
+- [ ] Define `ContextBudget` struct with `max_items`, `per_item_token_cap`,
+      `total_token_cap` (all `usize`) plus a `Default` impl returning
+      `{ 5, 5_000, 25_000 }`.
+- [ ] Define `TokenCounter` trait with `fn count(&self, s: &str) -> usize`.
+- [ ] Provide `WordCounter` zero-sized struct implementing `TokenCounter` via
+      `s.split_whitespace().count()`.
+- [ ] Define `BudgetedItem` trait with associated type `Recency: Ord` and the
+      `recency_key`, `payload`, `identifier` methods.
+- [ ] Define `SelectedItem` struct `{ identifier: String, payload: String,
+      token_cost: usize }`.
+- [ ] Implement `ContextBudget::select` per the SPEC.md algorithm.
+- [ ] Add `pub mod context_budget;` to `crates/phantom-context/src/lib.rs`.
+
+## Tests (all inside the module)
+
+- [ ] `cap_respecting_selection`: 10 items, `max_items = 3`, only 3 returned.
+- [ ] `recency_ordering`: items shuffled, output is sorted newest first.
+- [ ] `per_item_truncation`: one item over `per_item_token_cap` is truncated
+      to the cap and `token_cost == per_item_token_cap`.
+- [ ] `empty_input`: empty iterator returns empty vec.
+- [ ] `all_items_fit`: total tokens well under cap, all items returned with
+      original payloads.
+- [ ] `total_cap_hit_mid_iteration`: first big item consumes most of the
+      budget; subsequent oversize item is dropped; later small item still
+      fits and is included.
+
+## Verification
+
+- [ ] `cargo build -p phantom-context` exits 0.
+- [ ] `cargo test -p phantom-context` exits 0 with all new tests passing.
+
+## Delivery
+
+- [ ] Commit on the current worktree branch.
+- [ ] Push branch to origin.
+- [ ] Open draft PR titled
+      `feat(phantom-context): token-budgeted context injection primitive`.
+- [ ] Reply with the PR URL.
+
+## Constraints check
+
+- [ ] Edition 2024, no new heavy deps.
+- [ ] Zero question-mark sentences in any committed file.
+- [ ] No modifications to existing public APIs in `phantom-context`.
+- [ ] Total diff under 600 lines.

--- a/crates/phantom-context/src/context_budget.rs
+++ b/crates/phantom-context/src/context_budget.rs
@@ -1,0 +1,314 @@
+//! Token-budgeted context-injection primitive.
+//!
+//! Mirrors Claude Code's pattern: take the most recent N items, cap each one
+//! at a per-item token ceiling, and stop accumulating once the aggregate token
+//! ceiling would be exceeded. Items that would overflow are dropped rather
+//! than truncated further; later items that still fit are kept.
+//!
+//! This module is standalone. It does not read from disk and does not depend
+//! on any other phantom-context types. Callers supply items via the
+//! [`BudgetedItem`] trait and a token counter via [`TokenCounter`].
+
+use std::cmp::Reverse;
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+/// Configuration for the token-budgeted selection algorithm.
+///
+/// The default values mirror Claude Code's reference pattern: top 5 most
+/// recent items, each capped at 5_000 tokens, with a 25_000-token aggregate
+/// ceiling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ContextBudget {
+    /// Maximum number of items to consider after recency ordering.
+    pub max_items: usize,
+    /// Per-item token cap. Items longer than this are truncated.
+    pub per_item_token_cap: usize,
+    /// Aggregate token ceiling across all selected items.
+    pub total_token_cap: usize,
+}
+
+impl Default for ContextBudget {
+    fn default() -> Self {
+        Self {
+            max_items: 5,
+            per_item_token_cap: 5_000,
+            total_token_cap: 25_000,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Token counter
+// ---------------------------------------------------------------------------
+
+/// Counts tokens in a payload string.
+///
+/// The trait is the seam through which a real BPE tokenizer can be swapped
+/// in. For now the only built-in implementation is [`WordCounter`], which
+/// counts whitespace-separated words.
+pub trait TokenCounter {
+    fn count(&self, s: &str) -> usize;
+}
+
+/// Zero-sized whitespace token counter.
+///
+/// Splits on ASCII / Unicode whitespace and counts the resulting non-empty
+/// segments. Cheap and deterministic.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct WordCounter;
+
+impl TokenCounter for WordCounter {
+    fn count(&self, s: &str) -> usize {
+        s.split_whitespace().count()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Budgeted item
+// ---------------------------------------------------------------------------
+
+/// An item that can be ranked, sized, and identified for budgeted selection.
+///
+/// Implementors provide a recency key for ordering, the raw payload string,
+/// and a stable identifier used for diagnostics and de-duplication by the
+/// caller.
+pub trait BudgetedItem {
+    type Recency: Ord;
+    fn recency_key(&self) -> Self::Recency;
+    fn payload(&self) -> &str;
+    fn identifier(&self) -> &str;
+}
+
+/// The result of running [`ContextBudget::select`] over one item.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SelectedItem {
+    /// Identifier copied from the source [`BudgetedItem`].
+    pub identifier: String,
+    /// Possibly-truncated payload. Truncation preserves word boundaries.
+    pub payload: String,
+    /// Token cost of `payload` as measured by the supplied [`TokenCounter`].
+    pub token_cost: usize,
+}
+
+// ---------------------------------------------------------------------------
+// Selection
+// ---------------------------------------------------------------------------
+
+impl ContextBudget {
+    /// Select up to `max_items` of the most recent items from `items`, with
+    /// each truncated to `per_item_token_cap` tokens and the aggregate
+    /// bounded by `total_token_cap`.
+    ///
+    /// The algorithm:
+    /// 1. Materialize the iterator.
+    /// 2. Sort descending by `recency_key`.
+    /// 3. Truncate to at most `max_items`.
+    /// 4. For each surviving item, truncate payload to the per-item cap.
+    /// 5. Accumulate cost; drop any item whose inclusion would overflow the
+    ///    total cap, but continue evaluating subsequent items in case a
+    ///    smaller one still fits.
+    pub fn select<I, C>(
+        &self,
+        items: impl IntoIterator<Item = I>,
+        counter: &C,
+    ) -> Vec<SelectedItem>
+    where
+        I: BudgetedItem,
+        C: TokenCounter,
+    {
+        let mut collected: Vec<I> = items.into_iter().collect();
+        // Sort newest first.
+        collected.sort_by_key(|it| Reverse(it.recency_key()));
+        collected.truncate(self.max_items);
+
+        let mut out: Vec<SelectedItem> = Vec::with_capacity(collected.len());
+        let mut running: usize = 0;
+
+        for it in collected {
+            let raw = it.payload();
+            let raw_cost = counter.count(raw);
+
+            let (payload, cost) = if raw_cost > self.per_item_token_cap {
+                let truncated = truncate_to_tokens(raw, self.per_item_token_cap);
+                let cost = counter.count(&truncated);
+                (truncated, cost)
+            } else {
+                (raw.to_string(), raw_cost)
+            };
+
+            if running.saturating_add(cost) > self.total_token_cap {
+                // Drop this item; keep looking for a smaller one that fits.
+                continue;
+            }
+
+            running = running.saturating_add(cost);
+            out.push(SelectedItem {
+                identifier: it.identifier().to_string(),
+                payload,
+                token_cost: cost,
+            });
+        }
+
+        out
+    }
+}
+
+/// Truncate `s` to the first `cap` whitespace-separated tokens, joined with
+/// single spaces. The result has token count `min(cap, original_count)`.
+fn truncate_to_tokens(s: &str, cap: usize) -> String {
+    s.split_whitespace()
+        .take(cap)
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal test fixture implementing [`BudgetedItem`].
+    struct TestItem {
+        id: String,
+        recency: u64,
+        body: String,
+    }
+
+    impl TestItem {
+        fn new(id: &str, recency: u64, body: &str) -> Self {
+            Self {
+                id: id.to_string(),
+                recency,
+                body: body.to_string(),
+            }
+        }
+    }
+
+    impl BudgetedItem for TestItem {
+        type Recency = u64;
+        fn recency_key(&self) -> u64 {
+            self.recency
+        }
+        fn payload(&self) -> &str {
+            &self.body
+        }
+        fn identifier(&self) -> &str {
+            &self.id
+        }
+    }
+
+    fn body_of(n: usize) -> String {
+        (0..n).map(|i| format!("w{i}")).collect::<Vec<_>>().join(" ")
+    }
+
+    #[test]
+    fn cap_respecting_selection() {
+        let budget = ContextBudget {
+            max_items: 3,
+            per_item_token_cap: 1_000,
+            total_token_cap: 1_000_000,
+        };
+        let items: Vec<TestItem> = (0..10)
+            .map(|i| TestItem::new(&format!("i{i}"), i as u64, "alpha beta"))
+            .collect();
+        let out = budget.select(items, &WordCounter);
+        assert_eq!(out.len(), 3);
+        // The three most recent are i9, i8, i7.
+        assert_eq!(out[0].identifier, "i9");
+        assert_eq!(out[1].identifier, "i8");
+        assert_eq!(out[2].identifier, "i7");
+    }
+
+    #[test]
+    fn recency_ordering() {
+        let budget = ContextBudget::default();
+        let items = vec![
+            TestItem::new("oldest", 1, "a b"),
+            TestItem::new("newest", 100, "a b"),
+            TestItem::new("middle", 50, "a b"),
+        ];
+        let out = budget.select(items, &WordCounter);
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].identifier, "newest");
+        assert_eq!(out[1].identifier, "middle");
+        assert_eq!(out[2].identifier, "oldest");
+    }
+
+    #[test]
+    fn per_item_truncation() {
+        let budget = ContextBudget {
+            max_items: 5,
+            per_item_token_cap: 4,
+            total_token_cap: 1_000_000,
+        };
+        let item = TestItem::new("big", 1, &body_of(20));
+        let out = budget.select(vec![item], &WordCounter);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].token_cost, 4);
+        assert_eq!(out[0].payload, "w0 w1 w2 w3");
+    }
+
+    #[test]
+    fn empty_input() {
+        let budget = ContextBudget::default();
+        let items: Vec<TestItem> = vec![];
+        let out = budget.select(items, &WordCounter);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn all_items_fit() {
+        let budget = ContextBudget {
+            max_items: 10,
+            per_item_token_cap: 100,
+            total_token_cap: 1_000,
+        };
+        let items = vec![
+            TestItem::new("a", 1, "one two three"),
+            TestItem::new("b", 2, "four five"),
+            TestItem::new("c", 3, "six"),
+        ];
+        let out = budget.select(items, &WordCounter);
+        assert_eq!(out.len(), 3);
+        // Most-recent first.
+        assert_eq!(out[0].identifier, "c");
+        assert_eq!(out[0].payload, "six");
+        assert_eq!(out[0].token_cost, 1);
+        assert_eq!(out[1].identifier, "b");
+        assert_eq!(out[1].payload, "four five");
+        assert_eq!(out[1].token_cost, 2);
+        assert_eq!(out[2].identifier, "a");
+        assert_eq!(out[2].payload, "one two three");
+        assert_eq!(out[2].token_cost, 3);
+    }
+
+    #[test]
+    fn total_cap_hit_mid_iteration() {
+        // Total cap is 10. After the first big item (8 tokens), a 5-token
+        // item must be skipped (would overflow to 13) but a later 2-token
+        // item still fits.
+        let budget = ContextBudget {
+            max_items: 10,
+            per_item_token_cap: 100,
+            total_token_cap: 10,
+        };
+        let items = vec![
+            TestItem::new("big", 30, &body_of(8)),
+            TestItem::new("medium", 20, &body_of(5)),
+            TestItem::new("small", 10, &body_of(2)),
+        ];
+        let out = budget.select(items, &WordCounter);
+        // big and small fit; medium is dropped.
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].identifier, "big");
+        assert_eq!(out[0].token_cost, 8);
+        assert_eq!(out[1].identifier, "small");
+        assert_eq!(out[1].token_cost, 2);
+    }
+}

--- a/crates/phantom-context/src/context_budget.rs
+++ b/crates/phantom-context/src/context_budget.rs
@@ -82,6 +82,21 @@ pub trait BudgetedItem {
     fn identifier(&self) -> &str;
 }
 
+/// Blanket impl so callers can pass borrowed slices to [`ContextBudget::select`]
+/// without giving up ownership of their items.
+impl<T: BudgetedItem> BudgetedItem for &T {
+    type Recency = T::Recency;
+    fn recency_key(&self) -> Self::Recency {
+        (*self).recency_key()
+    }
+    fn payload(&self) -> &str {
+        (*self).payload()
+    }
+    fn identifier(&self) -> &str {
+        (*self).identifier()
+    }
+}
+
 /// The result of running [`ContextBudget::select`] over one item.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SelectedItem {
@@ -131,10 +146,13 @@ impl ContextBudget {
             let raw = it.payload();
             let raw_cost = counter.count(raw);
 
+            // On the truncation path the stored cost MUST reflect the
+            // truncated payload, not the original. Re-count after truncation
+            // so SelectedItem::token_cost stays consistent with payload.
             let (payload, cost) = if raw_cost > self.per_item_token_cap {
                 let truncated = truncate_to_tokens(raw, self.per_item_token_cap);
-                let cost = counter.count(&truncated);
-                (truncated, cost)
+                let truncated_cost = counter.count(&truncated);
+                (truncated, truncated_cost)
             } else {
                 (raw.to_string(), raw_cost)
             };
@@ -286,6 +304,76 @@ mod tests {
         assert_eq!(out[2].identifier, "a");
         assert_eq!(out[2].payload, "one two three");
         assert_eq!(out[2].token_cost, 3);
+    }
+
+    #[test]
+    fn borrowed_items_via_blanket_impl() {
+        let budget = ContextBudget {
+            max_items: 5,
+            per_item_token_cap: 100,
+            total_token_cap: 1_000,
+        };
+        let items = vec![
+            TestItem::new("a", 1, "alpha"),
+            TestItem::new("b", 2, "beta gamma"),
+        ];
+        // Pass borrowed references through the &T blanket impl.
+        let borrowed: Vec<&TestItem> = items.iter().collect();
+        let out = budget.select(borrowed, &WordCounter);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].identifier, "b");
+        assert_eq!(out[1].identifier, "a");
+        // Original items remain owned by caller.
+        assert_eq!(items.len(), 2);
+    }
+
+    #[test]
+    fn max_items_zero_returns_empty() {
+        let budget = ContextBudget {
+            max_items: 0,
+            per_item_token_cap: 100,
+            total_token_cap: 1_000,
+        };
+        let items = vec![
+            TestItem::new("a", 1, "one two"),
+            TestItem::new("b", 2, "three four"),
+        ];
+        let out = budget.select(items, &WordCounter);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn total_cap_zero_returns_empty() {
+        let budget = ContextBudget {
+            max_items: 10,
+            per_item_token_cap: 100,
+            total_token_cap: 0,
+        };
+        let items = vec![
+            TestItem::new("a", 1, "one two"),
+            TestItem::new("b", 2, "three"),
+        ];
+        let out = budget.select(items, &WordCounter);
+        // A single-token item would push running from 0 to 1, exceeding 0.
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn single_item_exceeds_per_item_cap_is_truncated_not_dropped() {
+        // One item with 20 tokens, per_item_cap = 5, total_cap = 100.
+        // It must appear in the output, truncated to 5 tokens, with the
+        // token_cost reflecting the truncated payload.
+        let budget = ContextBudget {
+            max_items: 5,
+            per_item_token_cap: 5,
+            total_token_cap: 100,
+        };
+        let item = TestItem::new("only", 1, &body_of(20));
+        let out = budget.select(vec![item], &WordCounter);
+        assert_eq!(out.len(), 1, "truncated item must survive, not be dropped");
+        assert_eq!(out[0].identifier, "only");
+        assert_eq!(out[0].token_cost, 5);
+        assert_eq!(out[0].payload, "w0 w1 w2 w3 w4");
     }
 
     #[test]

--- a/crates/phantom-context/src/lib.rs
+++ b/crates/phantom-context/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod context;
+pub mod context_budget;
 pub mod detect;
 
 pub use context::*;


### PR DESCRIPTION
## Summary
- Adds `crates/phantom-context/src/context_budget.rs`: a standalone token-budgeted selection primitive modeled on Claude Code's pattern (top-5 recent items, 5K per-item cap, 25K aggregate ceiling, all configurable on `ContextBudget`).
- Introduces three small public types — `ContextBudget`, `TokenCounter` (with default `WordCounter` impl), and `BudgetedItem` — plus the `ContextBudget::select` algorithm that recency-sorts, truncates per item, and drops overflow items rather than truncating further.
- Standalone slice only. No wiring into `phantom-agents` spawn paths yet; existing `phantom-context` public API is untouched.

## Test plan
- [x] `cargo build -p phantom-context` exits clean.
- [x] `cargo test -p phantom-context` passes; six new unit tests cover cap-respecting selection, recency ordering, per-item truncation, empty input, all-items-fit, and mid-iteration total-cap drop semantics.
- [ ] Follow-up PR: wire `ContextBudget::select` into the agent context-assembly path with a real BPE `TokenCounter` impl.
- [ ] Follow-up PR: re-injection hook on auto-compaction.